### PR TITLE
Fix setup prompts skipped when run via curl | sh

### DIFF
--- a/cmd/setup/main.go
+++ b/cmd/setup/main.go
@@ -26,6 +26,13 @@ func main() {
 func run() error {
 	fmt.Fprintf(os.Stderr, "CodeCanary Setup %s\n\n", version)
 
+	// Ensure stdin is a terminal so interactive prompts work.
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return fmt.Errorf("stdin is not a terminal — run with: curl -fsSL https://codecanary.sh/setup | sh")
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+
 	// 1. Check for gh CLI.
 	if _, err := exec.LookPath("gh"); err != nil {
 		return fmt.Errorf("gh CLI not found. Install it: https://cli.github.com")
@@ -40,12 +47,12 @@ func run() error {
 	fmt.Fprintf(os.Stderr, "Repository: %s\n\n", repo)
 
 	// 3. Install the CodeCanary Review App.
-	if err := auth.InstallCodeCanaryApp(repo); err != nil {
+	if err := auth.InstallCodeCanaryApp(repo, reader); err != nil {
 		return fmt.Errorf("installing CodeCanary app: %w", err)
 	}
 
 	// 4. Auth: prompt for method.
-	secretName, token, err := authenticateClaude(repo)
+	secretName, token, err := authenticateClaude(repo, reader)
 	if err != nil {
 		return err
 	}
@@ -53,7 +60,7 @@ func run() error {
 	// 5. Confirm and set secret.
 	if token != "" {
 		fmt.Fprintf(os.Stderr, "Set %s as a secret on %s? [Y/n] ", secretName, repo)
-		if confirm() {
+		if confirm(reader) {
 			fmt.Fprintf(os.Stderr, "Setting %s secret on %s...\n", secretName, repo)
 			if err := auth.SetGitHubSecret(repo, secretName, token); err != nil {
 				return fmt.Errorf("setting secret: %w", err)
@@ -233,7 +240,7 @@ jobs:
 
 // authenticateClaude prompts the user for auth method and returns (secretName, token, error).
 // If the secret already exists, returns ("", "", nil).
-func authenticateClaude(repo string) (string, string, error) {
+func authenticateClaude(repo string, reader *bufio.Reader) (string, string, error) {
 	// Check if either secret already exists.
 	secretsOut, err := exec.Command("gh", "secret", "list", "--repo", repo).Output()
 	if err == nil {
@@ -252,7 +259,6 @@ func authenticateClaude(repo string) (string, string, error) {
 	fmt.Fprintf(os.Stderr, "  [2] API key\n")
 	fmt.Fprintf(os.Stderr, "Choice [1]: ")
 
-	reader := bufio.NewReader(os.Stdin)
 	choice, _ := reader.ReadString('\n')
 	choice = strings.TrimSpace(choice)
 
@@ -273,7 +279,7 @@ func authenticateClaude(repo string) (string, string, error) {
 	}
 
 	// OAuth flow (default).
-	if err := auth.InstallGitHubApp(repo); err != nil {
+	if err := auth.InstallGitHubApp(repo, reader); err != nil {
 		return "", "", fmt.Errorf("installing Claude GitHub App: %w", err)
 	}
 
@@ -285,8 +291,7 @@ func authenticateClaude(repo string) (string, string, error) {
 	return "CLAUDE_CODE_OAUTH_TOKEN", token, nil
 }
 
-func confirm() bool {
-	reader := bufio.NewReader(os.Stdin)
+func confirm(reader *bufio.Reader) bool {
 	answer, _ := reader.ReadString('\n')
 	answer = strings.TrimSpace(strings.ToLower(answer))
 	return answer == "" || answer == "y" || answer == "yes"

--- a/internal/auth/github_app.go
+++ b/internal/auth/github_app.go
@@ -1,11 +1,14 @@
 package auth
 
-import "fmt"
+import (
+	"bufio"
+	"fmt"
+)
 
 const codeCanaryAppInstallURL = "https://github.com/apps/codecanary-bot/installations/new"
 
 // InstallCodeCanaryApp opens the browser to install the CodeCanary Review app on a repo.
-func InstallCodeCanaryApp(repo string) error {
+func InstallCodeCanaryApp(repo string, reader *bufio.Reader) error {
 	fmt.Printf("Opening browser to install the CodeCanary Review app...\n")
 	fmt.Printf("  → Select the repository: %s\n\n", repo)
 
@@ -14,7 +17,7 @@ func InstallCodeCanaryApp(repo string) error {
 	}
 
 	fmt.Printf("Press Enter after installing the app...")
-	fmt.Scanln()
+	reader.ReadString('\n')
 	fmt.Println()
 	return nil
 }

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"bufio"
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
@@ -30,7 +31,7 @@ type SetupResult struct {
 }
 
 // InstallGitHubApp opens the browser to install the Claude GitHub App on a repo.
-func InstallGitHubApp(repo string) error {
+func InstallGitHubApp(repo string, reader *bufio.Reader) error {
 	installURL := githubAppURL
 	fmt.Printf("Opening browser to install the Claude GitHub App...\n")
 	fmt.Printf("  → Select the repository: %s\n\n", repo)
@@ -40,7 +41,7 @@ func InstallGitHubApp(repo string) error {
 	}
 
 	fmt.Printf("Press Enter after installing the app...")
-	fmt.Scanln()
+	reader.ReadString('\n')
 	fmt.Println()
 	return nil
 }

--- a/setup.sh
+++ b/setup.sh
@@ -21,4 +21,4 @@ URL="https://github.com/$REPO/releases/download/v${TAG}/codecanary-setup_${TAG}_
 echo "Downloading CodeCanary Setup v${TAG}..."
 curl -fsSL "$URL" | tar -xz -C "$TMPDIR" "$BINARY"
 chmod +x "$TMPDIR/$BINARY"
-"$TMPDIR/$BINARY" "$@"
+"$TMPDIR/$BINARY" "$@" < /dev/tty


### PR DESCRIPTION
## Summary
- Redirect stdin from `/dev/tty` in `setup.sh` so the binary reads from the terminal instead of the exhausted curl pipe
- Add early `term.IsTerminal` check in the Go binary as defense-in-depth
- Use a single shared `bufio.Reader` across all prompts instead of mixing `fmt.Scanln()` with `bufio.NewReader`

## Test plan
- [ ] `curl -fsSL https://codecanary.sh/setup | sh` — browser tabs should open one at a time, waiting for Enter between each
- [ ] `echo "" | ./codecanary-setup` — should error with "stdin is not a terminal"
- [ ] `./codecanary-setup` run directly — should behave interactively as before