### PR TITLE
Rename workflow to "CodeCanary"

### DIFF
--- a/cmd/setup/main.go
+++ b/cmd/setup/main.go
@@ -76,7 +76,7 @@ func run() error {
 		authEnv = "          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
 	}
 
-	workflow := fmt.Sprintf(`name: CodeCanary Review
+	workflow := fmt.Sprintf(`name: CodeCanary
 on:
   pull_request:
     types: [opened, synchronize]


### PR DESCRIPTION
## Summary
- Renames the generated workflow from "CodeCanary Review" to "CodeCanary"
- GitHub checks will now display as **CodeCanary / review** and **CodeCanary / filter**

## Test plan
- [ ] Run `codecanary-setup` and verify the generated workflow file has `name: CodeCanary`