### PR TITLE
Fix install.sh matching both codecanary and codecanary-setup assets

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,6 +43,7 @@ echo "Fetching release ${TAG}..."
 URL="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/tags/${TAG}" \
   | grep '"browser_download_url"' \
   | grep "_${OS}_${ARCH}\.tar\.gz" \
+  | grep -v 'codecanary-setup' \
   | cut -d'"' -f4)"
 
 if [ -z "$URL" ]; then


### PR DESCRIPTION
## Summary
- Adds `grep -v 'codecanary-setup'` to exclude the setup binary from asset matching
- Fixes `curl: (3) URL rejected: Malformed input to a URL function` caused by two URLs in the variable

## Context
The `install.sh` merged in #5 matches both `codecanary_*` and `codecanary-setup_*` assets, resulting in a multi-line URL that curl rejects.

## Test plan
- [ ] Merge and verify the action passes on a PR