### PR TITLE
Improve setup: canary support, confirmation prompts, rename workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ This walks you through:
 4. Generating a `.codecanary.yml` config tailored to your project
 5. Opening a PR with everything ready to merge
 
+## Canary
+
+Want the canary version of CodeCanary? Living dangerously has never been this meta.
+
+```sh
+curl -fsSL https://codecanary.sh/setup | sh -s -- --canary
+```
+
+This installs the latest prerelease and pins your workflow to `@canary` instead of `@v1`.
+
 ## Config
 
 CodeCanary uses a `.codecanary.yml` file at your repo root:

--- a/cmd/review/cli/generate.go
+++ b/cmd/review/cli/generate.go
@@ -1,9 +1,10 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
 	"os"
-	"time"
+	"strings"
 
 	"github.com/alansikora/codecanary/internal/review"
 	"github.com/spf13/cobra"
@@ -15,6 +16,21 @@ var generateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dryRun, _ := cmd.InheritedFlags().GetBool("dry-run")
 		force, _ := cmd.Flags().GetBool("force")
+
+		configPath := ".codecanary.yml"
+
+		// If config exists and not --force, ask for confirmation.
+		if !dryRun && !force {
+			if _, err := os.Stat(configPath); err == nil {
+				fmt.Fprintf(os.Stderr, "%s already exists. Re-generate? [y/N] ", configPath)
+				reader := bufio.NewReader(os.Stdin)
+				answer, _ := reader.ReadString('\n')
+				if answer = strings.TrimSpace(strings.ToLower(answer)); answer != "y" && answer != "yes" {
+					fmt.Fprintf(os.Stderr, "Keeping current config.\n")
+					return nil
+				}
+			}
+		}
 
 		fmt.Fprintf(os.Stderr, "Analyzing project...\n")
 
@@ -28,23 +44,6 @@ var generateCmd = &cobra.Command{
 			return nil
 		}
 
-		configPath := ".codecanary.yml"
-
-		// Back up existing file unless --force.
-		if _, err := os.Stat(configPath); err == nil {
-			if !force {
-				bakPath := configPath + "." + time.Now().Format("20060102-150405") + ".bak"
-				data, err := os.ReadFile(configPath)
-				if err != nil {
-					return fmt.Errorf("reading existing config for backup: %w", err)
-				}
-				if err := os.WriteFile(bakPath, data, 0644); err != nil {
-					return fmt.Errorf("writing backup: %w", err)
-				}
-				fmt.Fprintf(os.Stderr, "  Backed up existing config to %s\n", bakPath)
-			}
-		}
-
 		if err := os.WriteFile(configPath, []byte(yamlStr+"\n"), 0644); err != nil {
 			return fmt.Errorf("writing config: %w", err)
 		}
@@ -55,6 +54,6 @@ var generateCmd = &cobra.Command{
 }
 
 func init() {
-	generateCmd.Flags().Bool("force", false, "Overwrite existing config without backup")
+	generateCmd.Flags().Bool("force", false, "Overwrite existing config without prompting")
 	reviewCmd.AddCommand(generateCmd)
 }

--- a/cmd/setup/main.go
+++ b/cmd/setup/main.go
@@ -23,8 +23,22 @@ func main() {
 	}
 }
 
+func hasFlag(name string) bool {
+	for _, arg := range os.Args[1:] {
+		if arg == name {
+			return true
+		}
+	}
+	return false
+}
+
 func run() error {
-	fmt.Fprintf(os.Stderr, "CodeCanary Setup %s\n\n", version)
+	canary := hasFlag("--canary")
+	if canary {
+		fmt.Fprintf(os.Stderr, "CodeCanary Setup %s (canary)\n\n", version)
+	} else {
+		fmt.Fprintf(os.Stderr, "CodeCanary Setup %s\n\n", version)
+	}
 
 	// Ensure stdin is a terminal so interactive prompts work.
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
@@ -74,7 +88,12 @@ func run() error {
 
 	// 6. Create workflow file.
 	workflowDir := filepath.Join(".github", "workflows")
-	workflowPath := filepath.Join(workflowDir, "codecanary-bot.yml")
+	workflowPath := filepath.Join(workflowDir, "codecanary.yml")
+
+	actionRef := "v1"
+	if canary {
+		actionRef = "canary"
+	}
 
 	var authEnv string
 	if secretName == "ANTHROPIC_API_KEY" {
@@ -128,12 +147,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - uses: alansikora/codecanary-action@v1
+      - uses: alansikora/codecanary-action@%s
         with:
 %s
           config_path: .codecanary.yml
           reply_only: ${{ github.event_name == 'pull_request_review_comment' }}
-`, authEnv)
+`, actionRef, authEnv)
 
 	if err := os.MkdirAll(workflowDir, 0755); err != nil {
 		return fmt.Errorf("creating workflow directory: %w", err)
@@ -154,9 +173,16 @@ jobs:
 	// 7. Generate review config.
 	configPath := ".codecanary.yml"
 	configCreated := false
+	generateConfig := true
 	if _, err := os.Stat(configPath); err == nil {
-		fmt.Fprintf(os.Stderr, "  %s already exists, skipping\n", configPath)
-	} else {
+		fmt.Fprintf(os.Stderr, "  %s already exists. Re-generate? [y/N] ", configPath)
+		answer, _ := reader.ReadString('\n')
+		if a := strings.TrimSpace(strings.ToLower(answer)); a != "y" && a != "yes" {
+			fmt.Fprintf(os.Stderr, "  Keeping current config.\n")
+			generateConfig = false
+		}
+	}
+	if generateConfig {
 		configContent := review.StarterConfig
 		fmt.Fprintf(os.Stderr, "Generating review config...\n")
 		if generated, err := review.Generate(); err != nil {
@@ -172,14 +198,8 @@ jobs:
 		configCreated = true
 	}
 
-	// 8. Update .gitignore.
-	gitignoreUpdated, err := updateGitignore()
-	if err != nil {
-		return fmt.Errorf("updating .gitignore: %w", err)
-	}
-
-	// 9. Create PR.
-	if !workflowCreated && !configCreated && !gitignoreUpdated {
+	// 8. Create PR.
+	if !workflowCreated && !configCreated {
 		fmt.Fprintf(os.Stderr, "\nSetup is already complete — nothing to do.\n")
 		return nil
 	}
@@ -187,16 +207,12 @@ jobs:
 	var filesToAdd []string
 	var bullets []string
 	if workflowCreated {
-		filesToAdd = append(filesToAdd, ".github/workflows/codecanary-bot.yml")
+		filesToAdd = append(filesToAdd, ".github/workflows/codecanary.yml")
 		bullets = append(bullets, "- Add CodeCanary automated PR review workflow")
 	}
 	if configCreated {
 		filesToAdd = append(filesToAdd, ".codecanary.yml")
 		bullets = append(bullets, "- Add starter `.codecanary.yml` config")
-	}
-	if gitignoreUpdated {
-		filesToAdd = append(filesToAdd, ".gitignore")
-		bullets = append(bullets, "- Update `.gitignore` with codecanary entries")
 	}
 
 	if len(filesToAdd) == 0 {
@@ -223,7 +239,7 @@ jobs:
 		return fmt.Errorf("pushing: %s\n%s", err, string(out))
 	}
 
-	prBody := "## Summary\n" + strings.Join(bullets, "\n") + "\n\nPRs will be automatically reviewed by Claude on open and update."
+	prBody := "## Summary\n" + strings.Join(bullets, "\n") + "\n\nCodeCanary will automatically review PRs on open and update."
 	prOut, err := exec.Command("gh", "pr", "create",
 		"--title", "Add CodeCanary PR review",
 		"--body", prBody,
@@ -297,42 +313,3 @@ func confirm(reader *bufio.Reader) bool {
 	return answer == "" || answer == "y" || answer == "yes"
 }
 
-func updateGitignore() (bool, error) {
-	entries := []string{
-		".codecanary.yml.bak",
-	}
-
-	gitignorePath := ".gitignore"
-	existing := ""
-	if data, err := os.ReadFile(gitignorePath); err == nil {
-		existing = string(data)
-	}
-
-	var toAdd []string
-	for _, entry := range entries {
-		if !strings.Contains(existing, entry) {
-			toAdd = append(toAdd, entry)
-		}
-	}
-
-	if len(toAdd) == 0 {
-		fmt.Fprintf(os.Stderr, "  .gitignore already up to date\n")
-		return false, nil
-	}
-
-	if existing != "" && !strings.HasSuffix(existing, "\n") {
-		existing += "\n"
-	}
-
-	prefix := "\n"
-	if existing == "" {
-		prefix = ""
-	}
-	section := prefix + "# codecanary\n" + strings.Join(toAdd, "\n") + "\n"
-	if err := os.WriteFile(gitignorePath, []byte(existing+section), 0644); err != nil {
-		return false, err
-	}
-
-	fmt.Fprintf(os.Stderr, "  Updated .gitignore\n")
-	return true, nil
-}

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,13 @@ set -eu
 
 REPO="alansikora/codecanary"
 BINARY="codecanary-setup"
+CANARY=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --canary) CANARY=true ;;
+  esac
+done
 
 cleanup() { rm -rf "$TMPDIR"; }
 trap cleanup EXIT INT TERM
@@ -15,10 +22,15 @@ case "$ARCH" in
   aarch64|arm64) ARCH="arm64" ;;
 esac
 
-TAG=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | head -1 | sed 's/.*"v//' | sed 's/".*//')
+if [ "$CANARY" = true ]; then
+  TAG=$(curl -fsSL "https://api.github.com/repos/$REPO/releases" | grep '"tag_name"' | head -1 | sed 's/.*"v//' | sed 's/".*//')
+  echo "Downloading CodeCanary Setup v${TAG} (canary)..."
+else
+  TAG=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | head -1 | sed 's/.*"v//' | sed 's/".*//')
+  echo "Downloading CodeCanary Setup v${TAG}..."
+fi
 URL="https://github.com/$REPO/releases/download/v${TAG}/codecanary-setup_${TAG}_${OS}_${ARCH}.tar.gz"
 
-echo "Downloading CodeCanary Setup v${TAG}..."
 curl -fsSL "$URL" | tar -xz -C "$TMPDIR" "$BINARY"
 chmod +x "$TMPDIR/$BINARY"
 "$TMPDIR/$BINARY" "$@" < /dev/tty


### PR DESCRIPTION
## Summary
- Add `--canary` flag to `setup.sh` and setup binary — installs prerelease and pins workflow to `@canary`
- Replace config backup (`.bak`) files with interactive confirmation prompt when config already exists
- Rename generated workflow from `codecanary-bot.yml` to `codecanary.yml`
- Remove `.gitignore` manipulation (no more backup files to ignore)
- Update PR body copy to reference CodeCanary instead of Claude
- Add Canary section to README

## Test plan
- [ ] Run `go build ./cmd/setup && go build ./cmd/review`
- [ ] Run setup with `--canary` and verify workflow uses `@canary` ref
- [ ] Run setup without `--canary` and verify workflow uses `@v1` ref
- [ ] Run `codecanary review generate` on repo with existing config — confirm prompt appears
- [ ] Run `codecanary review generate --force` — confirm no prompt