### PR TITLE
Allow replacing existing OAuth token during setup

### DIFF
--- a/cmd/setup/main.go
+++ b/cmd/setup/main.go
@@ -261,6 +261,7 @@ func authenticateClaude(repo string, reader *bufio.Reader) (string, string, erro
 	// Check if either secret already exists.
 	secretsOut, err := exec.Command("gh", "secret", "list", "--repo", repo).Output()
 	if err == nil {
+		// OAuth token takes priority — only one auth secret is expected at a time.
 		existing := ""
 		if strings.Contains(string(secretsOut), "CLAUDE_CODE_OAUTH_TOKEN") {
 			existing = "CLAUDE_CODE_OAUTH_TOKEN"


### PR DESCRIPTION
## Summary
- When an auth secret already exists, prompt the user with "Replace it? [y/N]" instead of silently skipping
- Defaults to keeping the existing secret (safe default)
- Allows users to re-authenticate or switch auth methods without manual secret deletion

## Test plan
- [ ] Run `codecanary-setup` on a repo with an existing `CLAUDE_CODE_OAUTH_TOKEN` — verify it prompts to replace
- [ ] Decline replacement — verify it keeps the existing secret and continues
- [ ] Accept replacement — verify it runs the full auth flow and overwrites the secret
- [ ] Run on a repo with no existing secret — verify behavior is unchanged