### PR TITLE
Detect and tag possibly non-actionable findings

### DIFF
--- a/internal/review/findings.go
+++ b/internal/review/findings.go
@@ -3,8 +3,8 @@ package review
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"regexp"
-	"strings"
 )
 
 // Finding represents a single review issue found in the code.
@@ -56,65 +56,16 @@ func ParseFindings(output string) ([]Finding, error) {
 	return nil, fmt.Errorf("parsing findings JSON: %w\nClaude output:\n%s", lastErr, output)
 }
 
-// dismissivePhrases are patterns that suggest a finding concludes the code is correct.
-var dismissivePhrases = []string{
-	"no action needed",
-	"no action required",
-	"no change needed",
-	"no change required",
-	"this is fine",
-	"this is safe",
-	"this is correct",
-	"no bug here",
-	"no issue here",
-	"no real issue",
-	"actually fine",
-	"not a concern",
-	"everything looks good",
-	"the pattern is appropriate",
-	"this is intentional",
-	"correctly handled",
-	"properly handled",
-}
-
-// actionableWords indicate the finding contains a real suggestion despite dismissive language.
-var actionableWords = []string{
-	"should", "consider", "must", "fix", "change", "remove", "replace",
-	"update", "avoid", "instead", "recommend", "migrate", "refactor",
-	"extract", "rename",
-}
-
-// IsPossiblyNonActionable returns true when the finding appears to conclude
-// that the code is correct and no change is needed. It checks both the
-// explicit Actionable field (set by Claude) and pattern-matches the description.
-func (f *Finding) IsPossiblyNonActionable() bool {
-	// If Claude explicitly marked it as not actionable, trust that.
-	if f.Actionable != nil && !*f.Actionable {
-		return true
-	}
-
-	desc := strings.ToLower(f.Description)
-
-	// Check for dismissive phrases.
-	hasDismissive := false
-	for _, phrase := range dismissivePhrases {
-		if strings.Contains(desc, phrase) {
-			hasDismissive = true
-			break
+// FilterNonActionable removes findings that Claude explicitly marked as not
+// actionable (actionable: false). Findings without the field are kept.
+func FilterNonActionable(findings []Finding) []Finding {
+	var kept []Finding
+	for _, f := range findings {
+		if f.Actionable != nil && !*f.Actionable {
+			fmt.Fprintf(os.Stderr, "Dropped non-actionable finding: %s (%s:%d)\n", f.ID, f.File, f.Line)
+			continue
 		}
+		kept = append(kept, f)
 	}
-	if !hasDismissive {
-		return false
-	}
-
-	// If dismissive language is present, check whether there's also actionable
-	// language — if so, the finding likely has a real suggestion mixed in.
-	text := desc + " " + strings.ToLower(f.Suggestion)
-	for _, word := range actionableWords {
-		if strings.Contains(text, word) {
-			return false
-		}
-	}
-
-	return true
+	return kept
 }

--- a/internal/review/findings_test.go
+++ b/internal/review/findings_test.go
@@ -4,95 +4,54 @@ import "testing"
 
 func boolPtr(v bool) *bool { return &v }
 
-func TestIsPossiblyNonActionable(t *testing.T) {
+func TestFilterNonActionable(t *testing.T) {
 	tests := []struct {
-		name     string
-		finding  Finding
-		expected bool
+		name      string
+		findings  []Finding
+		wantCount int
 	}{
 		{
-			name: "clearly actionable finding",
-			finding: Finding{
-				Description: "This function does not handle the error returned by Close(). This can silently swallow I/O errors.",
-				Suggestion:  "Consider wrapping the Close() call in an error check.",
+			name: "actionable false is dropped",
+			findings: []Finding{
+				{ID: "a", Actionable: boolPtr(false)},
 			},
-			expected: false,
+			wantCount: 0,
 		},
 		{
-			name: "non-actionable - concludes code is fine",
-			finding: Finding{
-				Description: "The allowlist permits dots, which is necessary for semver tags. The real concern is that TAG is interpolated into a curl URL but it is double-quoted, so this is safe. No action needed on that front.",
+			name: "actionable true is kept",
+			findings: []Finding{
+				{ID: "a", Actionable: boolPtr(true)},
 			},
-			expected: true,
+			wantCount: 1,
 		},
 		{
-			name: "non-actionable - this is fine",
-			finding: Finding{
-				Description: "Looked at the error handling here. The fallback catches all edge cases. This is fine.",
+			name: "actionable nil is kept",
+			findings: []Finding{
+				{ID: "a", Actionable: nil},
 			},
-			expected: true,
+			wantCount: 1,
 		},
 		{
-			name: "non-actionable - correctly handled",
-			finding: Finding{
-				Description: "The race condition concern is correctly handled by the mutex acquired on line 45.",
+			name: "mixed findings",
+			findings: []Finding{
+				{ID: "keep-1", Actionable: boolPtr(true)},
+				{ID: "drop", Actionable: boolPtr(false)},
+				{ID: "keep-2", Actionable: nil},
 			},
-			expected: true,
+			wantCount: 2,
 		},
 		{
-			name: "mixed - dismissive phrase but also actionable suggestion",
-			finding: Finding{
-				Description: "The current validation is fine for now, but this is safe only because the input is trusted. You should add input sanitization if this is ever exposed to user input.",
-				Suggestion:  "Consider adding bounds checking.",
-			},
-			expected: false,
-		},
-		{
-			name: "actionable field explicitly false",
-			finding: Finding{
-				Description: "The code looks reasonable.",
-				Actionable:  boolPtr(false),
-			},
-			expected: true,
-		},
-		{
-			name: "actionable field explicitly true",
-			finding: Finding{
-				Description: "No action needed.",
-				Actionable:  boolPtr(true),
-			},
-			// Actionable=true does not override pattern detection
-			expected: true,
-		},
-		{
-			name: "actionable field nil with no dismissive language",
-			finding: Finding{
-				Description: "Buffer overflow when input exceeds 256 bytes.",
-			},
-			expected: false,
-		},
-		{
-			name: "non-actionable - no real issue",
-			finding: Finding{
-				Description: "Investigated the potential null pointer dereference. The guard clause on line 12 prevents this. No real issue here.",
-			},
-			expected: true,
-		},
-		{
-			name: "dismissive phrase in suggestion does not count alone",
-			finding: Finding{
-				Description: "The retry logic has no backoff, which can cause thundering herd.",
-				Suggestion:  "The current approach is fine for low-traffic services, but consider exponential backoff.",
-			},
-			expected: false,
+			name:      "empty input",
+			findings:  []Finding{},
+			wantCount: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.finding.IsPossiblyNonActionable()
-			if got != tt.expected {
-				t.Errorf("IsPossiblyNonActionable() = %v, want %v\n  description: %s", got, tt.expected, tt.finding.Description)
+			got := FilterNonActionable(tt.findings)
+			if len(got) != tt.wantCount {
+				t.Errorf("FilterNonActionable() returned %d findings, want %d", len(got), tt.wantCount)
 			}
 		})
 	}

--- a/internal/review/formatter.go
+++ b/internal/review/formatter.go
@@ -91,9 +91,6 @@ func FormatMarkdown(result *ReviewResult) string {
 		icon := severityIcon(f.Severity)
 		fmt.Fprintf(&b, "### %s `%s` in `%s:%d`\n", icon, f.ID, f.File, f.Line)
 		fmt.Fprintf(&b, "**%s**\n\n", f.Title)
-		if f.IsPossiblyNonActionable() {
-			b.WriteString("\u26A0\uFE0F *This finding may not be actionable \u2014 dismiss if not relevant.*\n\n")
-		}
 		fmt.Fprintf(&b, "%s\n", f.Description)
 
 		if f.Suggestion != "" {
@@ -165,9 +162,6 @@ func FormatReviewBody(result *ReviewResult, canInline func(Finding) bool) string
 			icon := severityIcon(f.Severity)
 			fmt.Fprintf(&b, "### %s **%s** \u2014 `%s`\n\n", icon, f.Severity, f.ID)
 			fmt.Fprintf(&b, "**%s**\n\n", f.Title)
-			if f.IsPossiblyNonActionable() {
-				b.WriteString("\u26A0\uFE0F *This finding may not be actionable \u2014 dismiss if not relevant.*\n\n")
-			}
 			fmt.Fprintf(&b, "%s\n", f.Description)
 			if f.Suggestion != "" {
 				fmt.Fprintf(&b, "\n> **Suggestion**: %s\n", f.Suggestion)
@@ -192,9 +186,6 @@ func FormatFindingComment(f *Finding) string {
 	b.WriteString("<!-- codecanary:finding -->\n")
 	icon := severityIcon(f.Severity)
 	fmt.Fprintf(&b, "%s **%s** \u2014 `%s`\n\n", icon, f.Severity, f.ID)
-	if f.IsPossiblyNonActionable() {
-		b.WriteString("\u26A0\uFE0F *This finding may not be actionable \u2014 dismiss if not relevant.*\n\n")
-	}
 	fmt.Fprintf(&b, "%s\n", f.Description)
 
 	if f.Suggestion != "" {

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -410,6 +410,7 @@ func Run(opts RunOptions) error {
 			}
 		}
 		findings = filteredFindings
+		findings = FilterNonActionable(findings)
 	}
 
 	if len(findings) == 0 {


### PR DESCRIPTION
## Summary
- Adds an `actionable` boolean field to findings, prompting Claude to self-tag whether a finding requires action
- Findings with `actionable: false` are dropped before posting; `true` or absent are posted normally
- No pattern-matching heuristics — simple, predictable behavior based on Claude's explicit signal

## Test plan
- [x] `go build ./cmd/review` passes
- [x] `go test ./internal/review/...` passes
- [ ] Run a review on a PR and verify non-actionable findings are dropped
- [ ] Verify actionable findings are unaffected