### PR TITLE
Add fix-all-with-AI prompt to review comments

### DIFF
--- a/internal/review/formatter.go
+++ b/internal/review/formatter.go
@@ -173,9 +173,11 @@ func FormatReviewBody(result *ReviewResult, canInline func(Finding) bool) string
 	if len(result.Findings) > 0 {
 		b.WriteString("\n<details>\n<summary>\U0001F527 Fix all with AI</summary>\n\n")
 		b.WriteString("Copy the prompt below and paste it into your AI coding tool:\n\n")
-		b.WriteString("````\n")
-		b.WriteString(buildFixAllPrompt(result.Findings))
-		b.WriteString("````\n\n")
+		prompt := buildFixAllPrompt(result.Findings)
+		fence := codeFence(prompt)
+		fmt.Fprintf(&b, "%s\n", fence)
+		b.WriteString(prompt)
+		fmt.Fprintf(&b, "%s\n\n", fence)
 		b.WriteString("</details>\n")
 	}
 
@@ -205,6 +207,29 @@ func buildFixAllPrompt(findings []Finding) string {
 	}
 
 	return b.String()
+}
+
+// codeFence returns a backtick fence long enough to safely wrap content.
+// It scans for the longest consecutive backtick run and returns one longer,
+// with a minimum of 3.
+func codeFence(content string) string {
+	max := 0
+	cur := 0
+	for _, ch := range content {
+		if ch == '`' {
+			cur++
+			if cur > max {
+				max = cur
+			}
+		} else {
+			cur = 0
+		}
+	}
+	n := max + 1
+	if n < 3 {
+		n = 3
+	}
+	return strings.Repeat("`", n)
 }
 
 // FormatFindingComment renders a single finding as markdown for an inline PR

--- a/internal/review/formatter_test.go
+++ b/internal/review/formatter_test.go
@@ -96,3 +96,24 @@ func TestFormatReviewBody_NoFindings_NoFixAll(t *testing.T) {
 		t.Error("should not contain <details> when there are no findings")
 	}
 }
+
+func TestCodeFence(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"no backticks", "hello world", "```"},
+		{"triple backticks", "some ```code``` here", "````"},
+		{"quad backticks", "some ````code```` here", "`````"},
+		{"mixed runs", "` `` ``` ```` ``", "`````"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := codeFence(tt.content)
+			if got != tt.want {
+				t.Errorf("codeFence(%q) = %q, want %q", tt.content, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a collapsible "🔧 Fix all with AI" section to the main review comment body
- Contains a copy-pasteable prompt listing all findings (file, line, severity, title, description, suggestion)
- Users can paste the prompt into an AI coding tool to fix all review findings at once
- Wrapped in `<details>` to keep the review comment clean

## Test plan
- [x] `go build ./cmd/review` passes
- [x] `go test ./internal/review/...` passes (new formatter tests)
- [ ] Post a review on a test PR and verify the collapsible section renders correctly on GitHub