### PR TITLE
Fix reply-only review never triggering on comment events

### DIFF
--- a/.github/workflows/codecanary.yml
+++ b/.github/workflows/codecanary.yml
@@ -28,7 +28,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           BODY=$(gh api repos/${{ github.repository }}/pulls/comments/${{ github.event.comment.in_reply_to_id }} --jq '.body')
-          if echo "$BODY" | grep -q "codecanary fix\|clanopy fix"; then
+          if echo "$BODY" | grep -qF "codecanary:finding" || echo "$BODY" | grep -qF "codecanary fix" || echo "$BODY" | grep -qF "clanopy fix"; then
             echo "is_codecanary_thread=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_codecanary_thread=false" >> "$GITHUB_OUTPUT"

--- a/cmd/setup/main.go
+++ b/cmd/setup/main.go
@@ -142,7 +142,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           BODY=$(gh api repos/${{ github.repository }}/pulls/comments/${{ github.event.comment.in_reply_to_id }} --jq '.body')
-          if echo "$BODY" | grep -q "codecanary fix\|clanopy fix"; then
+          if echo "$BODY" | grep -qF "codecanary:finding" || echo "$BODY" | grep -qF "codecanary fix" || echo "$BODY" | grep -qF "clanopy fix"; then
             echo "is_codecanary_thread=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_codecanary_thread=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- The workflow filter for comment-triggered reviews checked for legacy markers (`codecanary fix` / `clanopy fix`) that are never written by the current code
- The actual marker written by `FormatFindingComment()` is `<!-- codecanary:finding -->`, so the filter never matched and reply-only reviews were silently skipped
- Added `codecanary:finding` as the primary check in both `.github/workflows/codecanary.yml` and the embedded template in `cmd/setup/main.go`, keeping legacy markers for backward compatibility

## Test plan
- [ ] Reply to an existing CodeCanary finding on a PR and verify the workflow triggers
- [ ] Verify the filter job correctly sets `is_codecanary_thread=true` for replies to CodeCanary findings
- [ ] Verify non-CodeCanary comments are still filtered out