### PR TITLE
Reduce GitHub Actions billing waste

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: stable
+          cache: true
 
       - uses: goreleaser/goreleaser-action@v7
         with:

--- a/.github/workflows/codecanary.yml
+++ b/.github/workflows/codecanary.yml
@@ -11,15 +11,13 @@ permissions:
   pull-requests: write
 
 jobs:
-  filter:
+  review:
     if: >-
       github.event_name == 'pull_request' || (
         github.event.comment.user.login != 'codecanary-bot[bot]' &&
         github.event.comment.in_reply_to_id
       )
     runs-on: ubuntu-latest
-    outputs:
-      should_review: ${{ github.event_name == 'pull_request' || steps.check.outputs.is_codecanary_thread == 'true' }}
     steps:
       - name: Check if codecanary thread
         id: check
@@ -31,19 +29,22 @@ jobs:
           if echo "$BODY" | grep -q "codecanary fix\|clanopy fix"; then
             echo "is_codecanary_thread=true" >> "$GITHUB_OUTPUT"
           else
-            echo "is_codecanary_thread=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping: not a codecanary thread"
+            exit 0
           fi
 
-  review:
-    needs: filter
-    if: needs.filter.outputs.should_review == 'true'
-    runs-on: ubuntu-latest
-    steps:
+      - name: Skip if not codecanary thread
+        if: github.event_name == 'pull_request_review_comment' && steps.check.outputs.is_codecanary_thread != 'true'
+        run: |
+          echo "skip=true" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v4
+        if: env.skip != 'true'
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: alansikora/codecanary-action@canary
+        if: env.skip != 'true'
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           config_path: .codecanary.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: stable
+          cache: true
 
       - uses: goreleaser/goreleaser-action@v7
         with:

--- a/cmd/setup/main.go
+++ b/cmd/setup/main.go
@@ -125,15 +125,13 @@ permissions:
   pull-requests: write
 
 jobs:
-  filter:
+  review:
     if: >-
       github.event_name == 'pull_request' || (
         github.event.comment.user.login != 'codecanary-bot[bot]' &&
         github.event.comment.in_reply_to_id
       )
     runs-on: ubuntu-latest
-    outputs:
-      should_review: ${{ github.event_name == 'pull_request' || steps.check.outputs.is_codecanary_thread == 'true' }}
     steps:
       - name: Check if codecanary thread
         id: check
@@ -145,19 +143,22 @@ jobs:
           if echo "$BODY" | grep -q "codecanary fix\|clanopy fix"; then
             echo "is_codecanary_thread=true" >> "$GITHUB_OUTPUT"
           else
-            echo "is_codecanary_thread=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping: not a codecanary thread"
+            exit 0
           fi
 
-  review:
-    needs: filter
-    if: needs.filter.outputs.should_review == 'true'
-    runs-on: ubuntu-latest
-    steps:
+      - name: Skip if not codecanary thread
+        if: github.event_name == 'pull_request_review_comment' && steps.check.outputs.is_codecanary_thread != 'true'
+        run: |
+          echo "skip=true" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v4
+        if: env.skip != 'true'
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: alansikora/codecanary-action@%s
+        if: env.skip != 'true'
         with:
 %s
           config_path: .codecanary.yml


### PR DESCRIPTION
## Summary
- Merge the two-job review workflow (`filter` + `review`) into a single `review` job, eliminating the extra runner spin-up. Every run was billing at least 2 minutes (1 min minimum per job); now it bills 1 min.
- Add Go module caching (`cache: true`) to canary and release workflows.
- Update the setup wizard template (`cmd/setup/main.go`) to generate the optimized single-job workflow.

## How it works
- The top-level `if` still skips bot comments and non-replies (free — GitHub doesn't bill skipped jobs)
- For comment events: the thread check runs inline and sets a `skip` env var if it's not a codecanary thread, gating checkout and action steps
- For PR events: proceeds directly to checkout and action

## Test plan
- [ ] Open a test PR → verify single-job review workflow runs correctly
- [ ] Reply to a non-codecanary comment thread → verify early exit (no checkout/action)
- [ ] Reply to a codecanary comment thread → verify reply review works
- [ ] Check canary build uses cached Go modules on second run