### PR TITLE
Update actions/checkout v4 → v6 (Node.js 20 deprecation)

### DIFF
--- a/.github/workflows/codecanary.yml
+++ b/.github/workflows/codecanary.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           echo "skip=true" >> "$GITHUB_ENV"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: env.skip != 'true'
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,4 +55,5 @@ Version is set via ldflags: `-X main.version=v{version}`
 ## Rules
 
 - **Minimize shell code.** `setup.sh` and the GitHub Action (`alansikora/codecanary-action`) should be kept as thin as possible. All logic must live in Go.
+- **Keep the setup generator in sync.** `cmd/setup/main.go` contains an embedded workflow template. Any change to `.github/workflows/codecanary.yml` (actions, steps, permissions, etc.) must also be applied to that template, and vice versa.
 - No automated tests exist yet (only config unit tests). Be careful with refactors.

--- a/cmd/setup/main.go
+++ b/cmd/setup/main.go
@@ -152,7 +152,7 @@ jobs:
         run: |
           echo "skip=true" >> "$GITHUB_ENV"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: env.skip != 'true'
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v4 to v6 in the CodeCanary workflow and setup generator template
- Add CLAUDE.md rule to keep the setup generator template in sync with the workflow file

Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 2, 2026.

## Test plan
- [ ] Verify CodeCanary workflow runs successfully on a PR