### PR TITLE
fix: restrict resolution reasons for code-change-only evaluations

### DIFF
--- a/internal/review/triage.go
+++ b/internal/review/triage.go
@@ -392,14 +392,7 @@ func EvaluateThreadsParallel(triaged []TriagedThread, env []string, cfg *ReviewC
 			usage.Phase = "triage"
 			tracker.Add(usage)
 			res := parseThreadResolution(result.Text, tt.Index)
-			// For code-change-only classifications (no author reply),
-			// only "code_change" is a valid resolution reason. If Claude
-			// returns anything else, treat it as unresolved.
-			if res.Resolved && res.Reason != "code_change" &&
-				(tt.Class == TriageCodeChanged || tt.Class == TriageCrossFileChange) {
-				res.Resolved = false
-				res.Reason = ""
-			}
+			res = validateResolutionReason(res, tt.Class)
 			results[idx] = res
 		}(i, t)
 	}
@@ -430,6 +423,18 @@ func parseThreadResolution(output string, index int) ThreadResolution {
 
 	// If parsing fails, treat as unresolved (conservative).
 	return ThreadResolution{Index: index, Resolved: false}
+}
+
+// validateResolutionReason enforces that code-change-only classifications
+// (no author reply) can only resolve with reason "code_change". If Claude
+// returns "acknowledged"/"dismissed"/"rebutted", treat it as unresolved.
+func validateResolutionReason(res ThreadResolution, class ThreadClassification) ThreadResolution {
+	if res.Resolved && res.Reason != "code_change" &&
+		(class == TriageCodeChanged || class == TriageCrossFileChange) {
+		res.Resolved = false
+		res.Reason = ""
+	}
+	return res
 }
 
 // LogTriage prints structured triage results to stderr.

--- a/internal/review/triage_test.go
+++ b/internal/review/triage_test.go
@@ -98,26 +98,19 @@ func TestBuildCodeChangeReplyPrompt_AllowsAllReasons(t *testing.T) {
 	}
 }
 
-func TestParseThreadResolution_RejectsInvalidReasonForCodeChangeOnly(t *testing.T) {
+func TestValidateResolutionReason_RejectsInvalidReasonForCodeChangeOnly(t *testing.T) {
 	// Simulate Claude returning "acknowledged" for a code-change-only thread.
 	output := "```json\n{\"resolved\": true, \"reason\": \"acknowledged\"}\n```"
-	res := parseThreadResolution(output, 0)
+	parsed := parseThreadResolution(output, 0)
 
 	// parseThreadResolution itself accepts any reason (it's just a parser).
-	// Verify that it does parse it so we know the validation must happen downstream.
-	if !res.Resolved || res.Reason != "acknowledged" {
+	if !parsed.Resolved || parsed.Reason != "acknowledged" {
 		t.Fatal("parseThreadResolution should parse the raw response as-is")
 	}
 
-	// Now simulate the validation that EvaluateThreadsParallel applies
-	// for TriageCodeChanged and TriageCrossFileChange classifications.
+	// For code-change-only classifications, invalid reasons should be rejected.
 	for _, class := range []ThreadClassification{TriageCodeChanged, TriageCrossFileChange} {
-		res := parseThreadResolution(output, 0)
-		if res.Resolved && res.Reason != "code_change" &&
-			(class == TriageCodeChanged || class == TriageCrossFileChange) {
-			res.Resolved = false
-			res.Reason = ""
-		}
+		res := validateResolutionReason(parsed, class)
 		if res.Resolved {
 			t.Errorf("class %d: resolution with reason 'acknowledged' should be rejected", class)
 		}
@@ -128,12 +121,7 @@ func TestParseThreadResolution_RejectsInvalidReasonForCodeChangeOnly(t *testing.
 
 	// For reply-based classifications, the same reason should be accepted.
 	for _, class := range []ThreadClassification{TriageHasReply, TriageCodeChangedReply} {
-		res := parseThreadResolution(output, 0)
-		if res.Resolved && res.Reason != "code_change" &&
-			(class == TriageCodeChanged || class == TriageCrossFileChange) {
-			res.Resolved = false
-			res.Reason = ""
-		}
+		res := validateResolutionReason(parsed, class)
 		if !res.Resolved {
 			t.Errorf("class %d: resolution with reason 'acknowledged' should be accepted", class)
 		}


### PR DESCRIPTION
## Summary
- When evaluating threads where only code changed (no author reply), Claude could return `"acknowledged"`/`"dismissed"`/`"rebutted"`, causing misleading messages like "Author acknowledged this finding" when the author never replied
- Added `writeCodeChangeResolutionFormat()` that restricts code-change-only prompts (`buildCodeChangePrompt`, `buildCrossFilePrompt`) to only allow `"code_change"` as a resolution reason
- Reply-based prompts (`buildReplyPrompt`, `buildCodeChangeReplyPrompt`) remain unchanged with all four reasons available

## Context
Reported by Anderson on [thetechfx/bedrock#1237](https://github.com/thetechfx/bedrock/pull/1237) — CodeCanary posted "Author acknowledged this finding" on a thread where the author never replied, only pushed a code change.

## Test plan
- [x] Added 4 tests verifying code-change-only prompts exclude `acknowledged`/`dismissed`/`rebutted` and reply-based prompts include all reasons
- [ ] Run against a test PR with code-change-only threads to confirm Claude only returns `code_change` or `not resolved`