### PR TITLE
fix: show finding title instead of HTML marker in triage logs

### DIFF
--- a/internal/review/triage.go
+++ b/internal/review/triage.go
@@ -38,9 +38,18 @@ type ThreadResolution struct {
 
 // threadLabel returns a short label for logging: "path:line — title".
 func threadLabel(t ReviewThread) string {
-	firstLine := t.Body
-	if idx := strings.Index(t.Body, "\n"); idx >= 0 {
-		firstLine = t.Body[:idx]
+	body := t.Body
+	// Skip leading HTML marker lines (e.g. "<!-- codecanary:finding -->").
+	for strings.HasPrefix(body, "<!--") {
+		if idx := strings.Index(body, "\n"); idx >= 0 {
+			body = strings.TrimLeft(body[idx+1:], "\n")
+		} else {
+			break
+		}
+	}
+	firstLine := body
+	if idx := strings.Index(body, "\n"); idx >= 0 {
+		firstLine = body[:idx]
 	}
 	// Truncate long titles for readability.
 	if len(firstLine) > 80 {


### PR DESCRIPTION
## Summary
- `threadLabel` was displaying `<!-- codecanary:finding -->` (the hidden HTML marker) as the finding title in triage log output
- Now skips leading HTML comment lines so the log shows the actual severity + ID line (e.g. `🔴 **critical** — \`some-id\``)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/review/` passes
- [ ] Trigger a re-review on a PR with existing threads and verify the triage log shows the finding title