### PR TITLE
feat: skip draft PRs by default

### DIFF
--- a/.github/workflows/codecanary.yml
+++ b/.github/workflows/codecanary.yml
@@ -1,7 +1,7 @@
 name: CodeCanary
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
   pull_request_review_comment:
     types: [created]
 
@@ -13,7 +13,10 @@ permissions:
 jobs:
   review:
     if: >-
-      github.event_name == 'pull_request' || (
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.draft == false
+      ) || (
         github.event.comment.user.login != 'codecanary-bot[bot]' &&
         github.event.comment.in_reply_to_id
       )

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ On subsequent pushes, CodeCanary is smarter:
 - **Author rebuts** — evaluated for technical merit, kept open
 - **No changes** — skipped entirely (zero Claude cost)
 
+### Draft PRs
+
+Draft PRs are skipped by default — the workflow won't run until the PR is marked as ready for review. When you convert a draft to ready, CodeCanary triggers automatically.
+
+To review draft PRs, remove the `github.event.pull_request.draft == false` condition from the workflow `if` in `.github/workflows/codecanary.yml`.
+
 ### Safety
 
 - **Anti-hallucination**: explicit file allowlist, line number validation against diff

--- a/cmd/setup/main.go
+++ b/cmd/setup/main.go
@@ -115,7 +115,7 @@ func run() error {
 	workflow := fmt.Sprintf(`name: CodeCanary
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
   pull_request_review_comment:
     types: [created]
 
@@ -127,7 +127,10 @@ permissions:
 jobs:
   review:
     if: >-
-      github.event_name == 'pull_request' || (
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.draft == false
+      ) || (
         github.event.comment.user.login != 'codecanary-bot[bot]' &&
         github.event.comment.in_reply_to_id
       )


### PR DESCRIPTION
## Summary
- Skip draft PRs at the workflow level — the job won't run until the PR is marked ready for review
- Add `ready_for_review` to event types so draft→ready conversion triggers a review
- Keep setup template in sync with the workflow change
- Document the behavior and opt-out in README

## Test plan
- [ ] Open a draft PR → workflow job should be skipped
- [ ] Convert draft to ready → review should trigger
- [ ] Open a non-draft PR → review runs as before
- [ ] `go build ./cmd/setup` compiles