### PR TITLE
fix: support fork PRs by using pull_request_target trigger

### DIFF
--- a/.github/workflows/codecanary.yml
+++ b/.github/workflows/codecanary.yml
@@ -1,6 +1,6 @@
 name: CodeCanary
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review]
   pull_request_review_comment:
     types: [created]
@@ -14,7 +14,7 @@ jobs:
   review:
     if: >-
       (
-        github.event_name == 'pull_request' &&
+        github.event_name == 'pull_request_target' &&
         github.event.pull_request.draft == false
       ) || (
         github.event.comment.user.login != 'codecanary-bot[bot]' &&

--- a/cmd/setup/main.go
+++ b/cmd/setup/main.go
@@ -114,7 +114,7 @@ func run() error {
 
 	workflow := fmt.Sprintf(`name: CodeCanary
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review]
   pull_request_review_comment:
     types: [created]
@@ -128,7 +128,7 @@ jobs:
   review:
     if: >-
       (
-        github.event_name == 'pull_request' &&
+        github.event_name == 'pull_request_target' &&
         github.event.pull_request.draft == false
       ) || (
         github.event.comment.user.login != 'codecanary-bot[bot]' &&


### PR DESCRIPTION
## Summary

- Switch workflow trigger from `pull_request` to `pull_request_target` so fork PRs get OIDC tokens and can complete the review flow
- Update the setup wizard's embedded workflow template to match

## Problem

GitHub Actions does not provide OIDC tokens (`ACTIONS_ID_TOKEN_REQUEST_URL`) for `pull_request` events from forks — a security restriction. This causes the "Generate review token" step to fail immediately with: `OIDC not available`.

Observed on: https://github.com/alansikora/codecanary/actions/runs/23680973678/job/69177310313?pr=30

## Why `pull_request_target` is safe here

- The workflow file is always read from the **base branch**, not the fork
- The CodeCanary binary is downloaded from a GitHub release, not from fork code
- Claude CLI is installed from official sources
- CodeCanary only **reads** checked-out files for context — it never executes PR code

## Test plan

- [ ] Re-run the CodeCanary workflow on PR #30 (fork PR) — should now complete
- [ ] Verify a same-repo PR still triggers and reviews correctly