### PR TITLE
fix: add reopened event type to pull_request_target trigger

### DIFF
--- a/.github/workflows/codecanary.yml
+++ b/.github/workflows/codecanary.yml
@@ -1,7 +1,7 @@
 name: CodeCanary
 on:
   pull_request_target:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review]
   pull_request_review_comment:
     types: [created]
 

--- a/cmd/setup/main.go
+++ b/cmd/setup/main.go
@@ -115,7 +115,7 @@ func run() error {
 	workflow := fmt.Sprintf(`name: CodeCanary
 on:
   pull_request_target:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review]
   pull_request_review_comment:
     types: [created]
 


### PR DESCRIPTION
## Summary

- Add `reopened` to the `pull_request_target` event types so that closing and reopening a PR triggers the review workflow
- Discovered while testing fork PR support from #32 — closing/reopening PR #30 to re-trigger the workflow had no effect

## Test plan

- [ ] Merge this, then close/reopen PR #30 — workflow should trigger