### PR TITLE
fix: setup wizard PR targets itself on new repos

### DIFF
--- a/cmd/setup/main.go
+++ b/cmd/setup/main.go
@@ -67,7 +67,7 @@ func run() error {
 		return fmt.Errorf("could not detect default branch: %w", err)
 	}
 	defaultBranch := strings.TrimSpace(string(defaultBranchOut))
-	if defaultBranch == "" {
+	if defaultBranch == "" || defaultBranch == "null" {
 		return fmt.Errorf("could not detect default branch — is the repository empty?")
 	}
 	if err := exec.Command("git", "show-ref", "--verify", "refs/heads/"+branch).Run(); err == nil {


### PR DESCRIPTION
## Summary
- Explicitly pass `--base <defaultBranch>` to `gh pr create` in the setup wizard
- Detect the repo's default branch via `gh repo view` early in the setup flow

On new/empty repos, `gh pr create` without `--base` inferred `codecanary/review-setup` as both head and base (since it was the only branch), producing:
```
GraphQL: No commits between codecanary/review-setup and codecanary/review-setup
```

## Test plan
- [ ] Run setup wizard against a fresh empty repo and verify PR is created targeting `main`
- [ ] Run setup wizard against an existing repo with commits and verify behavior is unchanged