### PR TITLE
feat: skip app install prompts when already installed

### DIFF
--- a/cmd/setup/main.go
+++ b/cmd/setup/main.go
@@ -75,7 +75,12 @@ func run() error {
 	}
 
 	// 4. Install the CodeCanary Review App (skip if already installed).
-	if auth.CheckAppInstalled(repo, "codecanary-bot") {
+	if installed, err := auth.CheckAppInstalled(repo, "codecanary-bot"); err != nil {
+		fmt.Fprintf(os.Stderr, "  Warning: could not check CodeCanary app installation: %v\n\n", err)
+		if err := auth.InstallCodeCanaryApp(repo, reader); err != nil {
+			return fmt.Errorf("installing CodeCanary app: %w", err)
+		}
+	} else if installed {
 		fmt.Fprintf(os.Stderr, "CodeCanary Review app already installed on %s\n\n", repo)
 	} else {
 		if err := auth.InstallCodeCanaryApp(repo, reader); err != nil {
@@ -344,7 +349,12 @@ func authenticateClaude(repo string, reader *bufio.Reader) (string, string, erro
 	}
 
 	// OAuth flow (default).
-	if auth.CheckAppInstalled(repo, "claude") {
+	if installed, err := auth.CheckAppInstalled(repo, "claude"); err != nil {
+		fmt.Fprintf(os.Stderr, "  Warning: could not check Claude app installation: %v\n\n", err)
+		if err := auth.InstallGitHubApp(repo, reader); err != nil {
+			return "", "", fmt.Errorf("installing Claude GitHub App: %w", err)
+		}
+	} else if installed {
 		fmt.Fprintf(os.Stderr, "Claude GitHub App already installed on %s\n\n", repo)
 	} else {
 		if err := auth.InstallGitHubApp(repo, reader); err != nil {

--- a/internal/auth/github_app.go
+++ b/internal/auth/github_app.go
@@ -34,8 +34,8 @@ type reposResponse struct {
 
 // CheckAppInstalled checks whether a GitHub App (by slug) is installed on the
 // given repo. It uses the gh CLI's user-level installation listing so it works
-// with regular OAuth tokens. Returns false on any error (best-effort check).
-func CheckAppInstalled(repo, appSlug string) bool {
+// with regular OAuth tokens.
+func CheckAppInstalled(repo, appSlug string) (bool, error) {
 	owner := strings.SplitN(repo, "/", 2)[0]
 
 	// List installations that the current user can see.
@@ -43,7 +43,7 @@ func CheckAppInstalled(repo, appSlug string) bool {
 	// so we decode each page separately.
 	out, err := exec.Command("gh", "api", "/user/installations", "--paginate").Output()
 	if err != nil {
-		return false
+		return false, fmt.Errorf("listing installations: %w", err)
 	}
 
 	var allInstallations []installation
@@ -53,7 +53,7 @@ func CheckAppInstalled(repo, appSlug string) bool {
 		if err := dec.Decode(&page); err == io.EOF {
 			break
 		} else if err != nil {
-			return false
+			return false, fmt.Errorf("parsing installations response: %w", err)
 		}
 		allInstallations = append(allInstallations, page.Installations...)
 	}
@@ -65,14 +65,14 @@ func CheckAppInstalled(repo, appSlug string) bool {
 
 		// "all" means every repo in this account is covered.
 		if inst.RepositorySelection == "all" {
-			return true
+			return true, nil
 		}
 
 		// Otherwise verify the specific repo is in the selected set.
 		endpoint := "/user/installations/" + strconv.Itoa(inst.ID) + "/repositories"
 		repoOut, err := exec.Command("gh", "api", endpoint, "--paginate").Output()
 		if err != nil {
-			continue
+			return false, fmt.Errorf("listing repos for installation %d: %w", inst.ID, err)
 		}
 		repoDec := json.NewDecoder(bytes.NewReader(repoOut))
 		for {
@@ -80,17 +80,17 @@ func CheckAppInstalled(repo, appSlug string) bool {
 			if err := repoDec.Decode(&page); err == io.EOF {
 				break
 			} else if err != nil {
-				break
+				return false, fmt.Errorf("parsing repos response: %w", err)
 			}
 			for _, r := range page.Repositories {
 				if r.FullName == repo {
-					return true
+					return true, nil
 				}
 			}
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 // InstallCodeCanaryApp opens the browser to install the CodeCanary Review app on a repo.


### PR DESCRIPTION
## Summary
- Add `CheckAppInstalled(repo, appSlug)` to detect existing GitHub App installations via `gh api /user/installations`
- Skip browser-open prompts in the setup wizard when CodeCanary or Claude apps are already installed on the target repo
- Handles both org-wide (`repository_selection: "all"`) and per-repo installations

## Test plan
- [ ] Run setup on a repo where both apps are already installed — verify both steps are skipped with confirmation messages
- [ ] Run setup on a repo with neither app installed — verify normal browser install flow
- [ ] Run setup on a repo with only one app installed — verify mixed behavior (one skipped, one prompted)