### PR TITLE
fix: auto-resolve triage threads when finding's file is deleted

### DIFF
--- a/internal/review/triage.go
+++ b/internal/review/triage.go
@@ -150,8 +150,11 @@ func fileDeletedInDiff(diff, path string) bool {
 	if idx < 0 {
 		return false
 	}
-	// Find the next line after the "--- a/<path>" marker.
+	// Ensure full path match (not a prefix of a longer filename).
 	rest := diff[idx+len(marker):]
+	if len(rest) > 0 && rest[0] != '\n' && rest[0] != '\r' {
+		return false
+	}
 	nl := strings.Index(rest, "\n")
 	if nl < 0 {
 		return false


### PR DESCRIPTION
## Summary
- When a finding's file is deleted in a PR, triage now auto-resolves the thread as `code_change` instead of sending it to Claude with an empty diff
- Adds `TriageFileDeleted` classification with `fileDeletedInDiff()` detection (`--- a/<path>` followed by `+++ /dev/null`)
- Skips Claude evaluation for deleted-file threads, saving API calls

## Context
Bug: when `provider_api.go` was deleted and code moved to `provider_openai.go`, `ExtractFileDiff` returned empty (it looks for `+++ b/<path>`, but deleted files have `+++ /dev/null`). Claude saw no diff and reported "not resolved".

The finding's target no longer exists — the code was either removed or moved, and either way the original finding is moot. If the issue persists in the replacement file, it will be caught as a new finding.

## Test plan
- [ ] Verify build: `go build ./cmd/review`
- [ ] Verify existing tests pass: `go test ./internal/review/`
- [ ] Manual: run incremental review on a PR where a file with findings was deleted — threads should auto-resolve with `[resolved] ... — file deleted` in triage log