### PR TITLE
fix: always print usage table to stderr

### DIFF
--- a/internal/review/platform_github.go
+++ b/internal/review/platform_github.go
@@ -174,18 +174,14 @@ func (g *GithubPlatform) SaveState(result *ReviewResult, stillOpen []Finding, is
 }
 
 func (g *GithubPlatform) ReportUsage(tracker *UsageTracker) {
+	// Always print usage table to stderr (visible in GHA logs and local-detect).
+	fmt.Fprint(os.Stderr, FormatUsageTable(tracker.Calls(), colorsEnabled()))
+
+	// Also write to GITHUB_ENV so the workflow Usage step can display it.
 	report := tracker.Report(g.Repo, g.PRNumber)
 	if len(report.Calls) > 0 {
 		if err := WriteUsageEnv(report); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: could not write usage env: %v\n", err)
-		}
-	}
-
-	// Also print usage table when output goes to terminal (local-detect mode).
-	if !g.Post {
-		outputFormat := resolveOutputFormat(g.OutputFormat)
-		if outputFormat == "terminal" {
-			fmt.Fprint(os.Stderr, FormatUsageTable(tracker.Calls(), colorsEnabled()))
 		}
 	}
 }

--- a/internal/review/platform_local.go
+++ b/internal/review/platform_local.go
@@ -64,8 +64,5 @@ func (l *LocalPlatform) SaveState(result *ReviewResult, stillOpen []Finding, _ b
 }
 
 func (l *LocalPlatform) ReportUsage(tracker *UsageTracker) {
-	outputFormat := resolveOutputFormat(l.OutputFormat)
-	if outputFormat == "terminal" {
-		fmt.Fprint(os.Stderr, FormatUsageTable(tracker.Calls(), colorsEnabled()))
-	}
+	fmt.Fprint(os.Stderr, FormatUsageTable(tracker.Calls(), colorsEnabled()))
 }


### PR DESCRIPTION
## Summary

- On GHA (`Post=true`), usage was only written to `GITHUB_ENV` for the workflow Usage step — never printed to stderr, so it was invisible in job logs
- `GithubPlatform.ReportUsage()` now always prints the usage table to stderr before writing to `GITHUB_ENV`
- `LocalPlatform.ReportUsage()` simplified — removed unnecessary TTY gate (usage goes to stderr, not stdout)

## Test plan

- [ ] Run GHA review → usage table appears in job log AND Usage step still works via `CODECANARY_USAGE` env
- [ ] Run local review with LLM calls → usage table still appears in stderr