### PR TITLE
feat: cross-provider model validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ evaluation:
 | `openrouter` | `anthropic/claude-sonnet-4-6` | `anthropic/claude-haiku-4-5-20251001` |
 | `claude` | `claude-sonnet-4-6` | `haiku` |
 
+Both `review_model` and `triage_model` must be models supported by your configured provider — you can't use an OpenAI model with `provider: anthropic` or vice versa. Config validation catches obvious mismatches. To mix models from different providers, use `provider: openrouter`, which proxies all of them. The `openai` provider skips this check when `api_base` is set, since custom endpoints (Ollama, vLLM, Azure) can serve any model.
+
 ### Budget Enforcement
 
 `max_budget_usd` caps total spending per review run. Set to `0` (default) for unlimited.

--- a/internal/review/config_test.go
+++ b/internal/review/config_test.go
@@ -130,6 +130,50 @@ func TestValidate_ValidCLIModels(t *testing.T) {
 	}
 }
 
+func TestValidate_CrossProviderModel_Anthropic(t *testing.T) {
+	// OpenAI model on anthropic provider.
+	cfg := &ReviewConfig{Provider: "anthropic", TriageModel: "gpt-5.4-mini"}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for OpenAI model on anthropic provider")
+	}
+	// OpenRouter-style model on anthropic provider.
+	cfg = &ReviewConfig{Provider: "anthropic", TriageModel: "openai/gpt-5.4"}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for OpenRouter model on anthropic provider")
+	}
+	// Review model too.
+	cfg = &ReviewConfig{Provider: "anthropic", ReviewModel: "o4-mini", TriageModel: "claude-haiku-4-5-20251001"}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for OpenAI review_model on anthropic provider")
+	}
+}
+
+func TestValidate_CrossProviderModel_OpenAI(t *testing.T) {
+	// Anthropic model on openai provider.
+	cfg := &ReviewConfig{Provider: "openai", TriageModel: "claude-haiku-4-5-20251001"}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for Anthropic model on openai provider")
+	}
+	// Claude alias on openai provider.
+	cfg = &ReviewConfig{Provider: "openai", TriageModel: "haiku"}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for Claude alias on openai provider")
+	}
+	// OpenRouter-style model on openai provider.
+	cfg = &ReviewConfig{Provider: "openai", ReviewModel: "anthropic/claude-sonnet-4-6", TriageModel: "gpt-5.4-mini"}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for OpenRouter model on openai provider")
+	}
+}
+
+func TestValidate_CrossProviderModel_OpenAI_CustomBase(t *testing.T) {
+	// With api_base set, any model name is allowed (custom endpoint).
+	cfg := &ReviewConfig{Provider: "openai", APIBase: "http://localhost:11434/v1", TriageModel: "claude-haiku-4-5-20251001"}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("unexpected error with custom api_base: %v", err)
+	}
+}
+
 func TestValidate_ValidProviders(t *testing.T) {
 	triageModels := map[string]string{
 		"anthropic":  "claude-haiku-4-5-20251001",

--- a/internal/review/provider_anthropic.go
+++ b/internal/review/provider_anthropic.go
@@ -40,6 +40,17 @@ func validateAnthropic(cfg *ReviewConfig) error {
 	if cfg.APIBase != "" {
 		return fmt.Errorf("api_base is not supported by the anthropic provider")
 	}
+	for _, model := range []string{cfg.ReviewModel, cfg.TriageModel} {
+		if model == "" {
+			continue
+		}
+		if strings.Contains(model, "/") {
+			return fmt.Errorf("model %q looks like an OpenRouter model (contains '/') — use provider: openrouter instead", model)
+		}
+		if strings.HasPrefix(model, "gpt-") || strings.HasPrefix(model, "o1") || strings.HasPrefix(model, "o3") || strings.HasPrefix(model, "o4") || strings.HasPrefix(model, "chatgpt") {
+			return fmt.Errorf("model %q looks like an OpenAI model — use provider: openai, or provider: openrouter to mix models", model)
+		}
+	}
 	return nil
 }
 

--- a/internal/review/provider_openai.go
+++ b/internal/review/provider_openai.go
@@ -3,6 +3,7 @@ package review
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 func init() {
@@ -36,6 +37,20 @@ func init() {
 func validateOpenAI(cfg *ReviewConfig) error {
 	if cfg.APIBase != "" && !isValidURL(cfg.APIBase) {
 		return fmt.Errorf("invalid api_base %q: must be an HTTP(S) URL", cfg.APIBase)
+	}
+	// Skip model checks when api_base is overridden — custom endpoints can serve any model.
+	if cfg.APIBase == "" {
+		for _, model := range []string{cfg.ReviewModel, cfg.TriageModel} {
+			if model == "" {
+				continue
+			}
+			if strings.Contains(model, "/") {
+				return fmt.Errorf("model %q looks like an OpenRouter model (contains '/') — use provider: openrouter instead", model)
+			}
+			if strings.HasPrefix(model, "claude-") || model == "haiku" || model == "sonnet" || model == "opus" {
+				return fmt.Errorf("model %q looks like an Anthropic model — use provider: anthropic, or provider: openrouter to mix models", model)
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Reject obvious cross-provider model mismatches at config validation time (e.g. `gpt-5.4-mini` on `provider: anthropic`)
- `anthropic` rejects OpenAI-style models (`gpt-*`, `o1/o3/o4*`) and OpenRouter slash-paths
- `openai` rejects Anthropic models (`claude-*`, `haiku`/`sonnet`/`opus`) and slash-paths — but skips the check when `api_base` is set (custom endpoints like Ollama can serve any model)
- `openrouter` has no restrictions (it proxies all providers)
- `claude` was already guarded via `validCLIModels`
- Document the constraint in README

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Verify `provider: anthropic` + `triage_model: gpt-5.4-mini` fails with helpful error
- [ ] Verify `provider: openai` + `triage_model: claude-haiku-4-5-20251001` fails with helpful error
- [ ] Verify `provider: openai` + `api_base: http://localhost:11434/v1` + `triage_model: claude-haiku-4-5-20251001` passes (custom endpoint)
- [ ] Verify `provider: openrouter` allows any model combination