### PR TITLE
fix: add required model fields to project config

### DIFF
--- a/.codecanary/config.yml
+++ b/.codecanary/config.yml
@@ -1,6 +1,8 @@
 version: 1
 
 provider: claude
+review_model: claude-sonnet-4-6
+triage_model: haiku
 
 context: |
   Go CLI tool for AI-powered GitHub PR code reviews. Single binary with review, setup,


### PR DESCRIPTION
## Summary
- Adds `review_model: claude-sonnet-4-6` and `triage_model: haiku` to `.codecanary/config.yml`
- The `triage_model` field was made required in #56 but the project's own config wasn't updated, breaking reviews

## Test plan
- [ ] Run `codecanary review` against a PR and confirm it no longer fails on config validation