### PR TITLE
fix: preserve local state findings across incremental reviews

### DIFF
--- a/internal/review/platform_local.go
+++ b/internal/review/platform_local.go
@@ -13,6 +13,7 @@ type LocalPlatform struct {
 }
 
 func (l *LocalPlatform) LoadPreviousFindings() ([]ReviewThread, string, int) {
+	l.savedFindings = nil
 	state, err := LoadLocalState(l.Branch)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not load local state: %v\n", err)

--- a/internal/review/platform_local.go
+++ b/internal/review/platform_local.go
@@ -7,8 +7,9 @@ import (
 
 // LocalPlatform implements ReviewPlatform for local-only reviews (no PR).
 type LocalPlatform struct {
-	Branch       string
-	OutputFormat string // user-requested output format (may be empty)
+	Branch        string
+	OutputFormat  string    // user-requested output format (may be empty)
+	savedFindings []Finding // original findings from state, indexed parallel to threads
 }
 
 func (l *LocalPlatform) LoadPreviousFindings() ([]ReviewThread, string, int) {
@@ -21,8 +22,19 @@ func (l *LocalPlatform) LoadPreviousFindings() ([]ReviewThread, string, int) {
 	}
 
 	fmt.Fprintf(os.Stderr, "Found previous local review at %s (%d findings)\n", shortSHA(state.SHA), len(state.Findings))
+	l.savedFindings = state.Findings
 	threads := findingsToKnownIssues(state.Findings)
 	return threads, state.SHA, len(state.Findings)
+}
+
+// SavedFinding returns the persisted Finding from the loaded state at the
+// given thread index. This avoids the lossy FindingFromThread reconstruction
+// that drops id, title, description, and suggestion fields.
+func (l *LocalPlatform) SavedFinding(index int) (Finding, bool) {
+	if index < 0 || index >= len(l.savedFindings) {
+		return Finding{}, false
+	}
+	return l.savedFindings[index], true
 }
 
 func (l *LocalPlatform) ExcludedAuthor(_ []ReviewThread) string {

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -560,6 +560,15 @@ func runTriage(
 			continue
 		}
 		unresolved = append(unresolved, t)
+		// Use original finding from local state when available (lossless).
+		// Fall back to FindingFromThread for GitHub mode (has embedded JSON).
+		if lp, ok := platform.(*LocalPlatform); ok {
+			if f, ok := lp.SavedFinding(i); ok {
+				f.Status = "still open"
+				stillOpenFindings = append(stillOpenFindings, f)
+				continue
+			}
+		}
 		stillOpenFindings = append(stillOpenFindings, FindingFromThread(t))
 	}
 

--- a/internal/review/state_test.go
+++ b/internal/review/state_test.go
@@ -7,8 +7,8 @@ import (
 func TestFindingFromThreadLosesLocalStateFields(t *testing.T) {
 	// This test documents the known limitation: FindingFromThread cannot
 	// reconstruct findings from the plain-text body that findingsToKnownIssues
-	// produces. This is why LocalPlatform.OriginalFinding exists — it
-	// bypasses FindingFromThread entirely for local mode via SavedFinding.
+	// produces. This is why LocalPlatform.SavedFinding exists — it
+	// bypasses FindingFromThread entirely for local mode.
 	//
 	// In GitHub mode, FindingFromThread works correctly because PR comments
 	// contain embedded JSON markers (<!-- codecanary:finding {...} -->).

--- a/internal/review/state_test.go
+++ b/internal/review/state_test.go
@@ -1,0 +1,171 @@
+package review
+
+import (
+	"testing"
+)
+
+func TestFindingFromThreadLosesLocalStateFields(t *testing.T) {
+	// This test documents the known limitation: FindingFromThread cannot
+	// reconstruct findings from the plain-text body that findingsToKnownIssues
+	// produces. This is why LocalPlatform.OriginalFinding exists — it
+	// bypasses FindingFromThread entirely for local mode via SavedFinding.
+	//
+	// In GitHub mode, FindingFromThread works correctly because PR comments
+	// contain embedded JSON markers (<!-- codecanary:finding {...} -->).
+
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	branch := "test-branch-lossy"
+	original := []Finding{
+		{
+			ID:          "missing-validation",
+			File:        "api/handler.go",
+			Line:        42,
+			Severity:    "warning",
+			Title:       "Missing input validation",
+			Description: "The handler does not validate the request body before processing.",
+			Suggestion:  "Add validation before the DB call.",
+			FixRef:      "local-1",
+		},
+	}
+
+	err := SaveLocalState(branch, &LocalState{
+		SHA:      "abc123",
+		Branch:   branch,
+		Findings: original,
+	})
+	if err != nil {
+		t.Fatalf("SaveLocalState: %v", err)
+	}
+
+	lp := &LocalPlatform{Branch: branch}
+	threads, _, _ := lp.LoadPreviousFindings()
+
+	// FindingFromThread is lossy for local state bodies — fields are empty.
+	reconstructed := FindingFromThread(threads[0])
+	if reconstructed.ID != "" {
+		t.Errorf("expected empty ID from lossy reconstruction, got %q", reconstructed.ID)
+	}
+	if reconstructed.Title == original[0].Title {
+		t.Error("expected lossy reconstruction to NOT preserve title")
+	}
+}
+
+func TestLocalStillOpenFindingsPreserved(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	branch := "test-stillopen"
+	original := []Finding{
+		{
+			ID:          "missing-check",
+			File:        "handler.go",
+			Line:        25,
+			Severity:    "warning",
+			Title:       "Missing nil check",
+			Description: "The pointer is dereferenced without a nil check.",
+			Suggestion:  "Add a nil guard before the dereference.",
+			FixRef:      "local-1",
+		},
+		{
+			ID:          "error-ignored",
+			File:        "db.go",
+			Line:        50,
+			Severity:    "bug",
+			Title:       "Error return ignored",
+			Description: "The error from Close() is silently discarded.",
+			FixRef:      "local-2",
+		},
+	}
+
+	err := SaveLocalState(branch, &LocalState{
+		SHA:      "aaa111",
+		Branch:   branch,
+		Findings: original,
+	})
+	if err != nil {
+		t.Fatalf("SaveLocalState: %v", err)
+	}
+
+	// Load findings through the platform.
+	lp := &LocalPlatform{Branch: branch}
+	threads, _, _ := lp.LoadPreviousFindings()
+
+	// Simulate runTriage's stillOpenFindings loop with the fix:
+	// use SavedFinding for LocalPlatform, fall back to FindingFromThread.
+	var stillOpen []Finding
+	fixedSet := map[int]bool{} // nothing fixed
+	for i, th := range threads {
+		if fixedSet[i] {
+			continue
+		}
+		if f, ok := lp.SavedFinding(i); ok {
+			f.Status = "still open"
+			stillOpen = append(stillOpen, f)
+		} else {
+			stillOpen = append(stillOpen, FindingFromThread(th))
+		}
+	}
+
+	if len(stillOpen) != 2 {
+		t.Fatalf("expected 2 still-open findings, got %d", len(stillOpen))
+	}
+
+	for i, f := range stillOpen {
+		orig := original[i]
+		if f.ID != orig.ID {
+			t.Errorf("finding %d: ID = %q, want %q", i, f.ID, orig.ID)
+		}
+		if f.Title != orig.Title {
+			t.Errorf("finding %d: Title = %q, want %q", i, f.Title, orig.Title)
+		}
+		if f.Description != orig.Description {
+			t.Errorf("finding %d: Description = %q, want %q", i, f.Description, orig.Description)
+		}
+		if f.Suggestion != orig.Suggestion {
+			t.Errorf("finding %d: Suggestion = %q, want %q", i, f.Suggestion, orig.Suggestion)
+		}
+		if f.Status != "still open" {
+			t.Errorf("finding %d: Status = %q, want %q", i, f.Status, "still open")
+		}
+	}
+
+	// Verify that saving these back preserves all fields.
+	err = SaveLocalState(branch, &LocalState{
+		SHA:      "bbb222",
+		Branch:   branch,
+		Findings: combineFindings(stillOpen, nil),
+	})
+	if err != nil {
+		t.Fatalf("SaveLocalState (round 2): %v", err)
+	}
+
+	reloaded, err := LoadLocalState(branch)
+	if err != nil {
+		t.Fatalf("LoadLocalState: %v", err)
+	}
+	if len(reloaded.Findings) != 2 {
+		t.Fatalf("expected 2 reloaded findings, got %d", len(reloaded.Findings))
+	}
+	for i, f := range reloaded.Findings {
+		orig := original[i]
+		if f.ID != orig.ID {
+			t.Errorf("reloaded %d: ID = %q, want %q", i, f.ID, orig.ID)
+		}
+		if f.Title != orig.Title {
+			t.Errorf("reloaded %d: Title = %q, want %q", i, f.Title, orig.Title)
+		}
+		if f.Description != orig.Description {
+			t.Errorf("reloaded %d: Description = %q, want %q", i, f.Description, orig.Description)
+		}
+	}
+
+	// SavedFinding bounds checks.
+	if _, ok := lp.SavedFinding(-1); ok {
+		t.Error("SavedFinding(-1) should return false")
+	}
+	if _, ok := lp.SavedFinding(999); ok {
+		t.Error("SavedFinding(999) should return false")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a bug where local mode reviews lose finding data (id, title, description, suggestion) on the second run, making incremental reviews unusable.

## Problem

When `codecanary review` runs locally a second time, the saved findings go through a lossy roundtrip:

1. `LoadPreviousFindings` converts `Finding` structs → `ReviewThread` via `findingsToKnownIssues`, which builds a plain-text body: `**title** (severity): description`
2. Later, `runTriage` reconstructs them via `FindingFromThread`, which expects GitHub PR comment format with embedded JSON markers (`<!-- codecanary:finding {...} -->`)
3. The plain-text body can't be parsed back — id, title, description, and suggestion are all empty
4. `SaveState` overwrites the state file with the degraded findings

**Before (state file after second run):**
```json
{
  "findings": [
    {
      "id": "",
      "file": "ansible/roles/technitium-dns/tasks/main.yml",
      "line": 14,
      "severity": "warning",
      "title": "",
      "description": "",
      "fix_ref": ""
    }
  ]
}
```

## Fix

`LocalPlatform` now stores the original `Finding` structs from state when loading, and exposes them via `SavedFinding(index)`. In `runTriage`, the `stillOpenFindings` loop uses this for local mode instead of the lossy `FindingFromThread` path. GitHub mode is unchanged — it continues using `FindingFromThread` which works correctly with embedded JSON markers.

- `platform_local.go`: Added `savedFindings` field, populated in `LoadPreviousFindings`, new `SavedFinding` method
- `runner.go`: Type-assert `*LocalPlatform` in the stillOpenFindings loop, use `SavedFinding` when available
- `state_test.go`: New tests covering the full save → load → triage → re-save roundtrip

## Test plan

- [x] `go test -race -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] Manual test: run `codecanary review` locally, run again with no changes, verify state file retains all fields