### PR TITLE
feat: add --fail-on <severity> flag to codecanary review

### DIFF
--- a/cmd/review/cli/review.go
+++ b/cmd/review/cli/review.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/alansikora/codecanary/internal/review"
 	"github.com/spf13/cobra"
@@ -25,18 +26,17 @@ var reviewCmd = &cobra.Command{
 		baseBranch, _ := cmd.Flags().GetString("base")
 		failOn, _ := cmd.Flags().GetString("fail-on")
 
-		// Validate --fail-on value.
+		// Validate --fail-on value against the canonical severity list.
 		if failOn != "" {
-			validSeverities := []string{"critical", "bug", "warning", "suggestion", "nitpick"}
 			valid := false
-			for _, s := range validSeverities {
+			for _, s := range review.ValidSeverities {
 				if failOn == s {
 					valid = true
 					break
 				}
 			}
 			if !valid {
-				return fmt.Errorf("invalid --fail-on value %q: must be one of: critical, bug, warning, suggestion, nitpick", failOn)
+				return fmt.Errorf("invalid --fail-on value %q: must be one of: %s", failOn, strings.Join(review.ValidSeverities, ", "))
 			}
 		}
 

--- a/cmd/review/cli/review.go
+++ b/cmd/review/cli/review.go
@@ -23,6 +23,22 @@ var reviewCmd = &cobra.Command{
 		replyOnly, _ := cmd.Flags().GetBool("reply-only")
 		claudePath, _ := cmd.Flags().GetString("claude-path")
 		baseBranch, _ := cmd.Flags().GetString("base")
+		failOn, _ := cmd.Flags().GetString("fail-on")
+
+		// Validate --fail-on value.
+		if failOn != "" {
+			validSeverities := []string{"critical", "bug", "warning", "suggestion", "nitpick"}
+			valid := false
+			for _, s := range validSeverities {
+				if failOn == s {
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				return fmt.Errorf("invalid --fail-on value %q: must be one of: critical, bug, warning, suggestion, nitpick", failOn)
+			}
+		}
 
 		// Explicit PR number — GitHub mode.
 		if len(args) > 0 {
@@ -34,15 +50,16 @@ var reviewCmd = &cobra.Command{
 				review.Stderrf(review.ColorYellow, "Warning: --base ignored in PR mode\n")
 			}
 			return review.Run(review.RunOptions{
-				Repo:       repo,
-				PRNumber:   prNumber,
-				ConfigPath: configPath,
-				Output:     output,
-				Post:       post,
-				DryRun:     dryRun,
-				ReplyOnly:  replyOnly,
-				ClaudePath: claudePath,
-				Version:    Version,
+				Repo:           repo,
+				PRNumber:       prNumber,
+				ConfigPath:     configPath,
+				Output:         output,
+				Post:           post,
+				DryRun:         dryRun,
+				ReplyOnly:      replyOnly,
+				ClaudePath:     claudePath,
+				FailOnSeverity: failOn,
+				Version:        Version,
 				Platform: &review.GithubPlatform{
 					Repo:         repo,
 					PRNumber:     prNumber,
@@ -60,15 +77,16 @@ var reviewCmd = &cobra.Command{
 				review.Stderrf(review.ColorYellow, "Warning: --base ignored in PR mode\n")
 			}
 			return review.Run(review.RunOptions{
-				Repo:       repo,
-				PRNumber:   prNumber,
-				ConfigPath: configPath,
-				Output:     output,
-				Post:       post,
-				DryRun:     dryRun,
-				ReplyOnly:  replyOnly,
-				ClaudePath: claudePath,
-				Version:    Version,
+				Repo:           repo,
+				PRNumber:       prNumber,
+				ConfigPath:     configPath,
+				Output:         output,
+				Post:           post,
+				DryRun:         dryRun,
+				ReplyOnly:      replyOnly,
+				ClaudePath:     claudePath,
+				FailOnSeverity: failOn,
+				Version:        Version,
 				Platform: &review.GithubPlatform{
 					Repo:         repo,
 					PRNumber:     prNumber,
@@ -96,14 +114,15 @@ var reviewCmd = &cobra.Command{
 		}
 
 		return review.Run(review.RunOptions{
-			PR:         pr,
-			ConfigPath: configPath,
-			Output:     output,
-			Post:       post,
-			DryRun:     dryRun,
-			ReplyOnly:  replyOnly,
-			ClaudePath: claudePath,
-			Version:    Version,
+			PR:             pr,
+			ConfigPath:     configPath,
+			Output:         output,
+			Post:           post,
+			DryRun:         dryRun,
+			ReplyOnly:      replyOnly,
+			ClaudePath:     claudePath,
+			FailOnSeverity: failOn,
+			Version:        Version,
 			Platform: &review.LocalPlatform{
 				Branch:       pr.HeadBranch,
 				OutputFormat: output,
@@ -120,6 +139,7 @@ func init() {
 	reviewCmd.Flags().Bool("reply-only", false, "Evaluate thread replies only, skip new findings")
 	reviewCmd.Flags().String("claude-path", "", "Path to the Claude CLI binary (overrides config claude_path)")
 	reviewCmd.Flags().StringP("base", "b", "", "Base branch for local review (auto-detected if empty)")
+	reviewCmd.Flags().String("fail-on", "", "Exit non-zero when findings at or above this severity exist (critical, bug, warning, suggestion, nitpick)")
 	reviewCmd.PersistentFlags().Bool("dry-run", false, "Show prompt without running Claude")
 	rootCmd.AddCommand(reviewCmd)
 }

--- a/internal/review/formatter.go
+++ b/internal/review/formatter.go
@@ -40,6 +40,10 @@ func severityIcon(severity string) string {
 	}
 }
 
+// ValidSeverities lists the accepted severity values in order from most to least severe.
+// Used for CLI validation and runner threshold checks.
+var ValidSeverities = []string{"critical", "bug", "warning", "suggestion", "nitpick"}
+
 // severityOrder returns a sort rank for a severity level (lower = more severe).
 func severityOrder(severity string) int {
 	switch strings.ToLower(severity) {

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -491,7 +491,9 @@ func Run(opts RunOptions) error {
 	tracker.SetPRSize(linesAdded, linesRemoved, filesChanged)
 	platform.ReportUsage(tracker)
 
-	// 11b. --fail-on: non-zero exit when new findings meet the severity threshold.
+	// 11b. --fail-on: compute whether findings meet the severity threshold.
+	// Deferred until after telemetry so that failing runs still emit usage data.
+	var failOnErr error
 	if opts.FailOnSeverity != "" {
 		threshold := severityOrder(opts.FailOnSeverity)
 		var count int
@@ -501,7 +503,7 @@ func Run(opts RunOptions) error {
 			}
 		}
 		if count > 0 {
-			return &FailOnSeverityError{Severity: opts.FailOnSeverity, Count: count}
+			failOnErr = &FailOnSeverityError{Severity: opts.FailOnSeverity, Count: count}
 		}
 	}
 
@@ -546,7 +548,7 @@ func Run(opts RunOptions) error {
 		})
 	}
 
-	return nil
+	return failOnErr
 }
 
 // runTriage handles the incremental review: classify previous threads, evaluate

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -14,17 +14,30 @@ import (
 
 // RunOptions configures a review run.
 type RunOptions struct {
-	Repo       string
-	PRNumber   int
-	ConfigPath string
-	Output     string // "markdown" or "json"
-	Post       bool
-	DryRun     bool
-	ReplyOnly  bool           // evaluate thread replies only, skip new findings
-	ClaudePath string         // override claude CLI binary path (overrides config claude_path)
-	Version    string         // binary version (for telemetry)
-	PR         *PRData        // pre-fetched PRData (used in local mode)
-	Platform   ReviewPlatform // environment adapter (GitHub or local)
+	Repo           string
+	PRNumber       int
+	ConfigPath     string
+	Output         string // "markdown" or "json"
+	Post           bool
+	DryRun         bool
+	ReplyOnly      bool           // evaluate thread replies only, skip new findings
+	ClaudePath     string         // override claude CLI binary path (overrides config claude_path)
+	FailOnSeverity string         // non-zero exit when findings at or above this severity exist
+	Version        string         // binary version (for telemetry)
+	PR             *PRData        // pre-fetched PRData (used in local mode)
+	Platform       ReviewPlatform // environment adapter (GitHub or local)
+}
+
+// FailOnSeverityError is returned when --fail-on is set and findings at or
+// above the given severity threshold are found. It is a distinct type so
+// callers can detect it via errors.As.
+type FailOnSeverityError struct {
+	Severity string
+	Count    int
+}
+
+func (e *FailOnSeverityError) Error() string {
+	return fmt.Sprintf("found %d finding(s) at or above severity %q (--fail-on %s)", e.Count, e.Severity, e.Severity)
 }
 
 // allowedEnvPrefixes lists environment variable prefixes passed to the LLM subprocess.
@@ -477,6 +490,20 @@ func Run(opts RunOptions) error {
 	filesChanged := len(FilesFromDiff(prDiffForSize))
 	tracker.SetPRSize(linesAdded, linesRemoved, filesChanged)
 	platform.ReportUsage(tracker)
+
+	// 11b. --fail-on: non-zero exit when new findings meet the severity threshold.
+	if opts.FailOnSeverity != "" {
+		threshold := severityOrder(opts.FailOnSeverity)
+		var count int
+		for _, f := range result.Findings {
+			if severityOrder(f.Severity) <= threshold {
+				count++
+			}
+		}
+		if count > 0 {
+			return &FailOnSeverityError{Severity: opts.FailOnSeverity, Count: count}
+		}
+	}
 
 	// 12. Anonymous telemetry (fire-and-forget).
 	if !opts.DryRun && telemetry.Enabled() {


### PR DESCRIPTION
## Summary

- Adds a `--fail-on <severity>` flag to `codecanary review` that causes a non-zero exit when any **new** finding at or above the given severity level exists
- Valid values: `critical`, `bug`, `warning`, `suggestion`, `nitpick` (uses the existing `severityOrder()` ranking from `formatter.go`)
- Applies only to `result.Findings` (new findings), not `result.StillOpen` — intentional so CI gates don't fire on pre-existing issues that haven't been resolved yet

## Changes

- **`cmd/review/cli/review.go`**: Adds `--fail-on` string flag, validates the value against known severities before running, and threads `FailOnSeverity` through all three call sites (explicit PR, auto-detected PR, local mode)
- **`internal/review/runner.go`**: Adds `FailOnSeverity string` to `RunOptions`, defines the exported `FailOnSeverityError` type (with `Severity` and `Count` fields) for distinguishable detection via `errors.As`, and performs the threshold check after publish + save state

## Example usage

```sh
# Fail CI on any bug or worse
codecanary review 42 --fail-on bug

# Fail on any finding at all
codecanary review 42 --fail-on nitpick

# Invalid value is rejected early with a clear error
codecanary review 42 --fail-on medium
# Error: invalid --fail-on value "medium": must be one of: critical, bug, warning, suggestion, nitpick
```

## Test plan

- [x] `go build ./...` — passes
- [x] `go vet ./...` — passes
- [x] `go test ./...` — all existing tests pass
- [ ] Manual: run a review with `--fail-on bug` and confirm exit code 1 when bugs are found, exit code 0 when only suggestions/nitpicks are found
- [ ] Manual: confirm `--fail-on` with an invalid severity prints a clear error before any LLM call is made