### PR TITLE
feat: write usage cost/token breakdown to GitHub Step Summary

### DIFF
--- a/cmd/review/cli/review.go
+++ b/cmd/review/cli/review.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/alansikora/codecanary/internal/review"
 	"github.com/spf13/cobra"
@@ -25,18 +26,17 @@ var reviewCmd = &cobra.Command{
 		baseBranch, _ := cmd.Flags().GetString("base")
 		failOn, _ := cmd.Flags().GetString("fail-on")
 
-		// Validate --fail-on value.
+		// Validate --fail-on value against the canonical severity list.
 		if failOn != "" {
-			validSeverities := []string{"critical", "bug", "warning", "suggestion", "nitpick"}
 			valid := false
-			for _, s := range validSeverities {
+			for _, s := range review.ValidSeverities {
 				if failOn == s {
 					valid = true
 					break
 				}
 			}
 			if !valid {
-				return fmt.Errorf("invalid --fail-on value %q: must be one of: critical, bug, warning, suggestion, nitpick", failOn)
+				return fmt.Errorf("invalid --fail-on value %q: must be one of: %s", failOn, strings.Join(review.ValidSeverities, ", "))
 			}
 		}
 

--- a/cmd/review/cli/review.go
+++ b/cmd/review/cli/review.go
@@ -23,6 +23,22 @@ var reviewCmd = &cobra.Command{
 		replyOnly, _ := cmd.Flags().GetBool("reply-only")
 		claudePath, _ := cmd.Flags().GetString("claude-path")
 		baseBranch, _ := cmd.Flags().GetString("base")
+		failOn, _ := cmd.Flags().GetString("fail-on")
+
+		// Validate --fail-on value.
+		if failOn != "" {
+			validSeverities := []string{"critical", "bug", "warning", "suggestion", "nitpick"}
+			valid := false
+			for _, s := range validSeverities {
+				if failOn == s {
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				return fmt.Errorf("invalid --fail-on value %q: must be one of: critical, bug, warning, suggestion, nitpick", failOn)
+			}
+		}
 
 		// Explicit PR number — GitHub mode.
 		if len(args) > 0 {
@@ -34,15 +50,16 @@ var reviewCmd = &cobra.Command{
 				review.Stderrf(review.ColorYellow, "Warning: --base ignored in PR mode\n")
 			}
 			return review.Run(review.RunOptions{
-				Repo:       repo,
-				PRNumber:   prNumber,
-				ConfigPath: configPath,
-				Output:     output,
-				Post:       post,
-				DryRun:     dryRun,
-				ReplyOnly:  replyOnly,
-				ClaudePath: claudePath,
-				Version:    Version,
+				Repo:           repo,
+				PRNumber:       prNumber,
+				ConfigPath:     configPath,
+				Output:         output,
+				Post:           post,
+				DryRun:         dryRun,
+				ReplyOnly:      replyOnly,
+				ClaudePath:     claudePath,
+				FailOnSeverity: failOn,
+				Version:        Version,
 				Platform: &review.GithubPlatform{
 					Repo:         repo,
 					PRNumber:     prNumber,
@@ -60,15 +77,16 @@ var reviewCmd = &cobra.Command{
 				review.Stderrf(review.ColorYellow, "Warning: --base ignored in PR mode\n")
 			}
 			return review.Run(review.RunOptions{
-				Repo:       repo,
-				PRNumber:   prNumber,
-				ConfigPath: configPath,
-				Output:     output,
-				Post:       post,
-				DryRun:     dryRun,
-				ReplyOnly:  replyOnly,
-				ClaudePath: claudePath,
-				Version:    Version,
+				Repo:           repo,
+				PRNumber:       prNumber,
+				ConfigPath:     configPath,
+				Output:         output,
+				Post:           post,
+				DryRun:         dryRun,
+				ReplyOnly:      replyOnly,
+				ClaudePath:     claudePath,
+				FailOnSeverity: failOn,
+				Version:        Version,
 				Platform: &review.GithubPlatform{
 					Repo:         repo,
 					PRNumber:     prNumber,
@@ -96,14 +114,15 @@ var reviewCmd = &cobra.Command{
 		}
 
 		return review.Run(review.RunOptions{
-			PR:         pr,
-			ConfigPath: configPath,
-			Output:     output,
-			Post:       post,
-			DryRun:     dryRun,
-			ReplyOnly:  replyOnly,
-			ClaudePath: claudePath,
-			Version:    Version,
+			PR:             pr,
+			ConfigPath:     configPath,
+			Output:         output,
+			Post:           post,
+			DryRun:         dryRun,
+			ReplyOnly:      replyOnly,
+			ClaudePath:     claudePath,
+			FailOnSeverity: failOn,
+			Version:        Version,
 			Platform: &review.LocalPlatform{
 				Branch:       pr.HeadBranch,
 				OutputFormat: output,
@@ -120,6 +139,7 @@ func init() {
 	reviewCmd.Flags().Bool("reply-only", false, "Evaluate thread replies only, skip new findings")
 	reviewCmd.Flags().String("claude-path", "", "Path to the Claude CLI binary (overrides config claude_path)")
 	reviewCmd.Flags().StringP("base", "b", "", "Base branch for local review (auto-detected if empty)")
+	reviewCmd.Flags().String("fail-on", "", "Exit non-zero when findings at or above this severity exist (critical, bug, warning, suggestion, nitpick)")
 	reviewCmd.PersistentFlags().Bool("dry-run", false, "Show prompt without running Claude")
 	rootCmd.AddCommand(reviewCmd)
 }

--- a/internal/review/formatter.go
+++ b/internal/review/formatter.go
@@ -40,6 +40,10 @@ func severityIcon(severity string) string {
 	}
 }
 
+// ValidSeverities lists the accepted severity values in order from most to least severe.
+// Used for CLI validation and runner threshold checks.
+var ValidSeverities = []string{"critical", "bug", "warning", "suggestion", "nitpick"}
+
 // severityOrder returns a sort rank for a severity level (lower = more severe).
 func severityOrder(severity string) int {
 	switch strings.ToLower(severity) {

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -491,7 +491,9 @@ func Run(opts RunOptions) error {
 	tracker.SetPRSize(linesAdded, linesRemoved, filesChanged)
 	platform.ReportUsage(tracker)
 
-	// 11b. --fail-on: non-zero exit when new findings meet the severity threshold.
+	// 11b. --fail-on: compute whether findings meet the severity threshold.
+	// Deferred until after telemetry so that failing runs still emit usage data.
+	var failOnErr error
 	if opts.FailOnSeverity != "" {
 		threshold := severityOrder(opts.FailOnSeverity)
 		var count int
@@ -501,7 +503,7 @@ func Run(opts RunOptions) error {
 			}
 		}
 		if count > 0 {
-			return &FailOnSeverityError{Severity: opts.FailOnSeverity, Count: count}
+			failOnErr = &FailOnSeverityError{Severity: opts.FailOnSeverity, Count: count}
 		}
 	}
 
@@ -546,7 +548,7 @@ func Run(opts RunOptions) error {
 		})
 	}
 
-	return nil
+	return failOnErr
 }
 
 // runTriage handles the incremental review: classify previous threads, evaluate

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -14,17 +14,30 @@ import (
 
 // RunOptions configures a review run.
 type RunOptions struct {
-	Repo       string
-	PRNumber   int
-	ConfigPath string
-	Output     string // "markdown" or "json"
-	Post       bool
-	DryRun     bool
-	ReplyOnly  bool           // evaluate thread replies only, skip new findings
-	ClaudePath string         // override claude CLI binary path (overrides config claude_path)
-	Version    string         // binary version (for telemetry)
-	PR         *PRData        // pre-fetched PRData (used in local mode)
-	Platform   ReviewPlatform // environment adapter (GitHub or local)
+	Repo           string
+	PRNumber       int
+	ConfigPath     string
+	Output         string // "markdown" or "json"
+	Post           bool
+	DryRun         bool
+	ReplyOnly      bool           // evaluate thread replies only, skip new findings
+	ClaudePath     string         // override claude CLI binary path (overrides config claude_path)
+	FailOnSeverity string         // non-zero exit when findings at or above this severity exist
+	Version        string         // binary version (for telemetry)
+	PR             *PRData        // pre-fetched PRData (used in local mode)
+	Platform       ReviewPlatform // environment adapter (GitHub or local)
+}
+
+// FailOnSeverityError is returned when --fail-on is set and findings at or
+// above the given severity threshold are found. It is a distinct type so
+// callers can detect it via errors.As.
+type FailOnSeverityError struct {
+	Severity string
+	Count    int
+}
+
+func (e *FailOnSeverityError) Error() string {
+	return fmt.Sprintf("found %d finding(s) at or above severity %q (--fail-on %s)", e.Count, e.Severity, e.Severity)
 }
 
 // allowedEnvPrefixes lists environment variable prefixes passed to the LLM subprocess.
@@ -477,6 +490,20 @@ func Run(opts RunOptions) error {
 	filesChanged := len(FilesFromDiff(prDiffForSize))
 	tracker.SetPRSize(linesAdded, linesRemoved, filesChanged)
 	platform.ReportUsage(tracker)
+
+	// 11b. --fail-on: non-zero exit when new findings meet the severity threshold.
+	if opts.FailOnSeverity != "" {
+		threshold := severityOrder(opts.FailOnSeverity)
+		var count int
+		for _, f := range result.Findings {
+			if severityOrder(f.Severity) <= threshold {
+				count++
+			}
+		}
+		if count > 0 {
+			return &FailOnSeverityError{Severity: opts.FailOnSeverity, Count: count}
+		}
+	}
 
 	// 12. Anonymous telemetry (fire-and-forget).
 	if !opts.DryRun && telemetry.Enabled() {

--- a/internal/review/triage.go
+++ b/internal/review/triage.go
@@ -336,6 +336,10 @@ func ClassifyThreads(threads []ReviewThread, activityDiff, contextDiff, botLogin
 			case TriageCrossFileChange:
 				// Show finding's file context even though the diff is in other files.
 				fileSnippet = ExtractFileSnippet(content, t.Line, "", 200)
+			case TriageHasReply:
+				// Show current file state so the LLM can judge whether the author's
+				// rebuttal is technically accurate given the code as it stands.
+				fileSnippet = ExtractFileSnippet(content, t.Line, "", 200)
 			}
 		}
 
@@ -477,6 +481,7 @@ func buildReplyPrompt(t TriagedThread, cfg *ReviewConfig) string {
 
 	writeFinding(&b, t.Thread)
 	writeReplies(&b, t.Thread, t.BotLogin)
+	writeFileSnippet(&b, t.FileSnippet)
 
 	if ctx := evalContext(cfg, "reply"); ctx != "" {
 		fmt.Fprintf(&b, "## Additional Context\n%s\n\n", ctx)

--- a/internal/review/usage.go
+++ b/internal/review/usage.go
@@ -140,7 +140,8 @@ func (u *UsageTracker) Report(repo string, prNumber int) *UsageReport {
 
 // WriteUsageEnv writes the usage report as a CODECANARY_USAGE env var
 // to $GITHUB_ENV so subsequent workflow steps can read it. No-op outside
-// GitHub Actions.
+// GitHub Actions. Also writes a markdown summary to $GITHUB_STEP_SUMMARY
+// when that env var is set.
 func WriteUsageEnv(report *UsageReport) error {
 	path := os.Getenv("GITHUB_ENV")
 	if path == "" {
@@ -161,6 +162,63 @@ func WriteUsageEnv(report *UsageReport) error {
 	if _, err := fmt.Fprintf(f, "CODECANARY_USAGE=%s\n", data); err != nil {
 		return fmt.Errorf("writing to GITHUB_ENV: %w", err)
 	}
+
+	if err := writeStepSummary(report); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to write GitHub Step Summary: %v\n", err)
+	}
+
+	return nil
+}
+
+// formatInt formats an integer with thousands separators (e.g. 1234567 -> "1,234,567").
+func formatInt(n int) string {
+	s := fmt.Sprintf("%d", n)
+	if n < 0 {
+		s = s[1:]
+	}
+	var result []byte
+	for i, c := range s {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			result = append(result, ',')
+		}
+		result = append(result, byte(c))
+	}
+	if n < 0 {
+		return "-" + string(result)
+	}
+	return string(result)
+}
+
+// writeStepSummary appends a markdown usage table to $GITHUB_STEP_SUMMARY.
+// No-op if $GITHUB_STEP_SUMMARY is not set or if the report has no calls.
+func writeStepSummary(report *UsageReport) error {
+	path := os.Getenv("GITHUB_STEP_SUMMARY")
+	if path == "" {
+		return nil
+	}
+	if len(report.Calls) == 0 {
+		return nil
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("opening GITHUB_STEP_SUMMARY: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	fmt.Fprintln(f, "## CodeCanary Usage")
+	fmt.Fprintln(f, "")
+	fmt.Fprintln(f, "| Phase | Model | Input tokens | Output tokens | Cost |")
+	fmt.Fprintln(f, "|-------|-------|-------------|---------------|------|")
+	for _, c := range report.Calls {
+		fmt.Fprintf(f, "| %s | %s | %s | %s | $%.4f |\n",
+			c.Phase, c.Model,
+			formatInt(c.InputTokens), formatInt(c.OutputTokens),
+			c.CostUSD)
+	}
+	fmt.Fprintf(f, "| **Total** | | **%s** | **%s** | **$%.4f** |\n",
+		formatInt(report.TotalInputTokens), formatInt(report.TotalOutputTokens),
+		report.TotalCostUSD)
 
 	return nil
 }

--- a/internal/review/usage.go
+++ b/internal/review/usage.go
@@ -171,17 +171,18 @@ func WriteUsageEnv(report *UsageReport) error {
 }
 
 // formatInt formats an integer with thousands separators (e.g. 1234567 -> "1,234,567").
+// Iterates by byte index since fmt.Sprintf("%d", n) produces ASCII-only output.
 func formatInt(n int) string {
 	s := fmt.Sprintf("%d", n)
 	if n < 0 {
 		s = s[1:]
 	}
 	var result []byte
-	for i, c := range s {
+	for i := 0; i < len(s); i++ {
 		if i > 0 && (len(s)-i)%3 == 0 {
 			result = append(result, ',')
 		}
-		result = append(result, byte(c))
+		result = append(result, s[i])
 	}
 	if n < 0 {
 		return "-" + string(result)


### PR DESCRIPTION
## Summary

- Adds `writeStepSummary(report *UsageReport) error` called from `WriteUsageEnv()` that appends a markdown table to `$GITHUB_STEP_SUMMARY` when that env var is set (GitHub Actions only).
- Table includes one row per phase (model, input tokens, output tokens, cost) plus a bold **Total** row.
- Token counts are formatted with thousands separators via a new `formatInt` helper (no new dependencies — `golang.org/x/text` is already indirect but this avoids promoting it to a direct dep).
- No-op if `$GITHUB_STEP_SUMMARY` is unset or if the report has no calls.
- Failures are non-fatal: a warning is printed to stderr, matching the existing pattern in the file.

## Test plan

- [ ] Locally verify `go build ./...` and `go vet ./...` pass (done in branch).
- [ ] In a GitHub Actions workflow, confirm a "CodeCanary Usage" table appears in the job summary after a review run.
- [ ] Confirm no output is produced when `$GITHUB_STEP_SUMMARY` is not set (local runs).
- [ ] Confirm empty report (no calls) produces no table.