### PR TITLE
feat: include title and severity in incremental prompt known issues

### DIFF
--- a/cmd/review/cli/review.go
+++ b/cmd/review/cli/review.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/alansikora/codecanary/internal/review"
 	"github.com/spf13/cobra"
@@ -25,18 +26,17 @@ var reviewCmd = &cobra.Command{
 		baseBranch, _ := cmd.Flags().GetString("base")
 		failOn, _ := cmd.Flags().GetString("fail-on")
 
-		// Validate --fail-on value.
+		// Validate --fail-on value against the canonical severity list.
 		if failOn != "" {
-			validSeverities := []string{"critical", "bug", "warning", "suggestion", "nitpick"}
 			valid := false
-			for _, s := range validSeverities {
+			for _, s := range review.ValidSeverities {
 				if failOn == s {
 					valid = true
 					break
 				}
 			}
 			if !valid {
-				return fmt.Errorf("invalid --fail-on value %q: must be one of: critical, bug, warning, suggestion, nitpick", failOn)
+				return fmt.Errorf("invalid --fail-on value %q: must be one of: %s", failOn, strings.Join(review.ValidSeverities, ", "))
 			}
 		}
 

--- a/cmd/review/cli/review.go
+++ b/cmd/review/cli/review.go
@@ -23,6 +23,22 @@ var reviewCmd = &cobra.Command{
 		replyOnly, _ := cmd.Flags().GetBool("reply-only")
 		claudePath, _ := cmd.Flags().GetString("claude-path")
 		baseBranch, _ := cmd.Flags().GetString("base")
+		failOn, _ := cmd.Flags().GetString("fail-on")
+
+		// Validate --fail-on value.
+		if failOn != "" {
+			validSeverities := []string{"critical", "bug", "warning", "suggestion", "nitpick"}
+			valid := false
+			for _, s := range validSeverities {
+				if failOn == s {
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				return fmt.Errorf("invalid --fail-on value %q: must be one of: critical, bug, warning, suggestion, nitpick", failOn)
+			}
+		}
 
 		// Explicit PR number — GitHub mode.
 		if len(args) > 0 {
@@ -34,15 +50,16 @@ var reviewCmd = &cobra.Command{
 				review.Stderrf(review.ColorYellow, "Warning: --base ignored in PR mode\n")
 			}
 			return review.Run(review.RunOptions{
-				Repo:       repo,
-				PRNumber:   prNumber,
-				ConfigPath: configPath,
-				Output:     output,
-				Post:       post,
-				DryRun:     dryRun,
-				ReplyOnly:  replyOnly,
-				ClaudePath: claudePath,
-				Version:    Version,
+				Repo:           repo,
+				PRNumber:       prNumber,
+				ConfigPath:     configPath,
+				Output:         output,
+				Post:           post,
+				DryRun:         dryRun,
+				ReplyOnly:      replyOnly,
+				ClaudePath:     claudePath,
+				FailOnSeverity: failOn,
+				Version:        Version,
 				Platform: &review.GithubPlatform{
 					Repo:         repo,
 					PRNumber:     prNumber,
@@ -60,15 +77,16 @@ var reviewCmd = &cobra.Command{
 				review.Stderrf(review.ColorYellow, "Warning: --base ignored in PR mode\n")
 			}
 			return review.Run(review.RunOptions{
-				Repo:       repo,
-				PRNumber:   prNumber,
-				ConfigPath: configPath,
-				Output:     output,
-				Post:       post,
-				DryRun:     dryRun,
-				ReplyOnly:  replyOnly,
-				ClaudePath: claudePath,
-				Version:    Version,
+				Repo:           repo,
+				PRNumber:       prNumber,
+				ConfigPath:     configPath,
+				Output:         output,
+				Post:           post,
+				DryRun:         dryRun,
+				ReplyOnly:      replyOnly,
+				ClaudePath:     claudePath,
+				FailOnSeverity: failOn,
+				Version:        Version,
 				Platform: &review.GithubPlatform{
 					Repo:         repo,
 					PRNumber:     prNumber,
@@ -96,14 +114,15 @@ var reviewCmd = &cobra.Command{
 		}
 
 		return review.Run(review.RunOptions{
-			PR:         pr,
-			ConfigPath: configPath,
-			Output:     output,
-			Post:       post,
-			DryRun:     dryRun,
-			ReplyOnly:  replyOnly,
-			ClaudePath: claudePath,
-			Version:    Version,
+			PR:             pr,
+			ConfigPath:     configPath,
+			Output:         output,
+			Post:           post,
+			DryRun:         dryRun,
+			ReplyOnly:      replyOnly,
+			ClaudePath:     claudePath,
+			FailOnSeverity: failOn,
+			Version:        Version,
 			Platform: &review.LocalPlatform{
 				Branch:       pr.HeadBranch,
 				OutputFormat: output,
@@ -120,6 +139,7 @@ func init() {
 	reviewCmd.Flags().Bool("reply-only", false, "Evaluate thread replies only, skip new findings")
 	reviewCmd.Flags().String("claude-path", "", "Path to the Claude CLI binary (overrides config claude_path)")
 	reviewCmd.Flags().StringP("base", "b", "", "Base branch for local review (auto-detected if empty)")
+	reviewCmd.Flags().String("fail-on", "", "Exit non-zero when findings at or above this severity exist (critical, bug, warning, suggestion, nitpick)")
 	reviewCmd.PersistentFlags().Bool("dry-run", false, "Show prompt without running Claude")
 	rootCmd.AddCommand(reviewCmd)
 }

--- a/internal/review/formatter.go
+++ b/internal/review/formatter.go
@@ -22,6 +22,17 @@ func threadLabel(t ReviewThread) string {
 	return fmt.Sprintf("%s:%d", t.Path, t.Line)
 }
 
+// titleFromThreadBody extracts the finding title from a thread body.
+// It tries the embedded JSON first (lossless roundtrip), then falls back to
+// deriving the title from the parsed markdown body.
+func titleFromThreadBody(body string) string {
+	if f, ok := findingFromEmbeddedJSON(body); ok && f.Title != "" {
+		return f.Title
+	}
+	desc, _ := parseThreadBody(body)
+	return firstSentence(desc)
+}
+
 // severityIcon returns the emoji icon for a severity level.
 func severityIcon(severity string) string {
 	switch strings.ToLower(severity) {

--- a/internal/review/formatter.go
+++ b/internal/review/formatter.go
@@ -51,6 +51,10 @@ func severityIcon(severity string) string {
 	}
 }
 
+// ValidSeverities lists the accepted severity values in order from most to least severe.
+// Used for CLI validation and runner threshold checks.
+var ValidSeverities = []string{"critical", "bug", "warning", "suggestion", "nitpick"}
+
 // severityOrder returns a sort rank for a severity level (lower = more severe).
 func severityOrder(severity string) int {
 	switch strings.ToLower(severity) {

--- a/internal/review/prompt.go
+++ b/internal/review/prompt.go
@@ -5,7 +5,66 @@ import (
 	"maps"
 	"slices"
 	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
 )
+
+// filterRulesForFiles returns only the rules that apply to the given file list.
+// A rule applies when:
+//   - It has no Paths and no ExcludePaths (always applies).
+//   - It has Paths: at least one file matches at least one Paths pattern AND is
+//     not excluded by all ExcludePaths patterns (i.e. at least one matching file
+//     survives exclusion).
+//   - It has only ExcludePaths (no Paths): at least one file is NOT matched by
+//     any ExcludePaths pattern.
+//
+// When files is empty, all rules are returned (no file list to filter against).
+// Match errors from doublestar.Match are treated as no match.
+func filterRulesForFiles(rules []Rule, files []string) []Rule {
+	if len(files) == 0 {
+		return rules
+	}
+
+	out := make([]Rule, 0, len(rules))
+	for _, r := range rules {
+		if len(r.Paths) == 0 && len(r.ExcludePaths) == 0 {
+			out = append(out, r)
+			continue
+		}
+
+		if len(r.Paths) == 0 {
+			// Only ExcludePaths: include if at least one file is not excluded.
+			for _, f := range files {
+				if !matchesAny(f, r.ExcludePaths) {
+					out = append(out, r)
+					break
+				}
+			}
+			continue
+		}
+
+		// Has Paths (and possibly ExcludePaths): include if at least one file
+		// matches Paths and is not excluded.
+		for _, f := range files {
+			if matchesAny(f, r.Paths) && !matchesAny(f, r.ExcludePaths) {
+				out = append(out, r)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// matchesAny reports whether file matches any of the given glob patterns.
+// Errors from doublestar.Match are treated as no match.
+func matchesAny(file string, patterns []string) bool {
+	for _, pat := range patterns {
+		if matched, _ := doublestar.Match(pat, file); matched {
+			return true
+		}
+	}
+	return false
+}
 
 // escapePromptTag neutralises any XML-like tag matching tagName in content,
 // preventing adversarial repos from injecting fake prompt sections.
@@ -76,12 +135,17 @@ func BuildPrompt(pr *PRData, cfg *ReviewConfig, startIndex int, projectDocs map[
 
 	// Review rules.
 	if cfg != nil && len(cfg.Rules) > 0 {
-		b.WriteString("## Review Rules\n")
-		b.WriteString("Apply the following rules when reviewing:\n\n")
-		for _, rule := range cfg.Rules {
-			fmt.Fprintf(&b, "- **%s** (severity: %s): %s\n", rule.ID, rule.Severity, rule.Description)
+		rules := filterRulesForFiles(cfg.Rules, pr.Files)
+		if len(rules) > 0 {
+			b.WriteString("## Review Rules\n")
+			b.WriteString("Apply the following rules when reviewing:\n\n")
+			for _, rule := range rules {
+				fmt.Fprintf(&b, "- **%s** (severity: %s): %s\n", rule.ID, rule.Severity, rule.Description)
+			}
+			b.WriteString("\n")
+		} else {
+			b.WriteString("## Review Rules\nNo specific rules are defined. Perform a general code review covering correctness, security, performance, and maintainability.\n\n")
 		}
-		b.WriteString("\n")
 	} else {
 		b.WriteString("## Review Rules\nNo specific rules are defined. Perform a general code review covering correctness, security, performance, and maintainability.\n\n")
 	}
@@ -184,12 +248,17 @@ func BuildIncrementalPrompt(diff string, cfg *ReviewConfig, knownIssues []Review
 
 	// Review rules.
 	if cfg != nil && len(cfg.Rules) > 0 {
-		b.WriteString("## Review Rules\n")
-		b.WriteString("Apply the following rules when reviewing:\n\n")
-		for _, rule := range cfg.Rules {
-			fmt.Fprintf(&b, "- **%s** (severity: %s): %s\n", rule.ID, rule.Severity, rule.Description)
+		rules := filterRulesForFiles(cfg.Rules, files)
+		if len(rules) > 0 {
+			b.WriteString("## Review Rules\n")
+			b.WriteString("Apply the following rules when reviewing:\n\n")
+			for _, rule := range rules {
+				fmt.Fprintf(&b, "- **%s** (severity: %s): %s\n", rule.ID, rule.Severity, rule.Description)
+			}
+			b.WriteString("\n")
+		} else {
+			b.WriteString("## Review Rules\nNo specific rules are defined. Perform a general code review covering correctness, security, performance, and maintainability.\n\n")
 		}
-		b.WriteString("\n")
 	} else {
 		b.WriteString("## Review Rules\nNo specific rules are defined. Perform a general code review covering correctness, security, performance, and maintainability.\n\n")
 	}

--- a/internal/review/prompt.go
+++ b/internal/review/prompt.go
@@ -277,7 +277,15 @@ func BuildIncrementalPrompt(diff string, cfg *ReviewConfig, knownIssues []Review
 		b.WriteString("## Known Issues (DO NOT DUPLICATE)\n")
 		b.WriteString("These issues are already reported and unresolved. Do NOT report them again:\n\n")
 		for _, t := range knownIssues {
-			fmt.Fprintf(&b, "- `%s:%d`\n", t.Path, t.Line)
+			sev := severityFromThreadBody(t.Body)
+			id := FindingIDFromThread(t.Body)
+			title := titleFromThreadBody(t.Body)
+			if id != "" && title != "" {
+				icon := severityIcon(sev)
+				fmt.Fprintf(&b, "- `%s:%d` \u2014 %s %s \u2014 %s: %s\n", t.Path, t.Line, icon, sev, id, title)
+			} else {
+				fmt.Fprintf(&b, "- `%s:%d`\n", t.Path, t.Line)
+			}
 		}
 		b.WriteString("\n")
 	}

--- a/internal/review/prompt.go
+++ b/internal/review/prompt.go
@@ -282,7 +282,7 @@ func BuildIncrementalPrompt(diff string, cfg *ReviewConfig, knownIssues []Review
 			title := titleFromThreadBody(t.Body)
 			if id != "" && title != "" {
 				icon := severityIcon(sev)
-				fmt.Fprintf(&b, "- `%s:%d` \u2014 %s %s \u2014 %s: %s\n", t.Path, t.Line, icon, sev, id, title)
+				fmt.Fprintf(&b, "- `%s:%d` \u2014 %s %s \u2014 %s: %s\n", t.Path, t.Line, icon, sev, id, escapeAllTags(title))
 			} else {
 				fmt.Fprintf(&b, "- `%s:%d`\n", t.Path, t.Line)
 			}

--- a/internal/review/prompt.go
+++ b/internal/review/prompt.go
@@ -154,49 +154,6 @@ type ResolvedContext struct {
 	Reason string // "code_change", "dismissed", "acknowledged", "rebutted"
 }
 
-// Deprecated: BuildReevaluatePrompt is replaced by per-thread evaluation in triage.go.
-// Kept temporarily for reference; will be removed in a future release.
-func BuildReevaluatePrompt(threads []ReviewThread, incrementalDiff string) string {
-	var b strings.Builder
-
-	b.WriteString("You are a code reviewer. You previously left findings on a pull request. The author has pushed new changes.\n\n")
-	b.WriteString("## Previous Findings\n")
-	b.WriteString("Here are the unresolved findings from previous reviews:\n\n")
-
-	for i, t := range threads {
-		fmt.Fprintf(&b, "- **thread-%d** at `%s:%d`\n", i, t.Path, t.Line)
-		// Extract the first line of the body as the severity+rule summary.
-		firstLine := t.Body
-		if idx := strings.Index(t.Body, "\n"); idx >= 0 {
-			firstLine = t.Body[:idx]
-		}
-		fmt.Fprintf(&b, "  %s\n", firstLine)
-		for _, r := range t.Replies {
-			normalizedBody := strings.ReplaceAll(r.Body, "\n", " ")
-			fmt.Fprintf(&b, "  > **@%s** replied: %s\n", r.Author, normalizedBody)
-		}
-	}
-
-	b.WriteString("\n## Changes Since Last Review\n")
-	writeFencedBlock(&b, "diff", incrementalDiff)
-	b.WriteString("\n")
-
-	b.WriteString("## Task\n")
-	b.WriteString("Determine which of the previous findings should be resolved.\n\n")
-	b.WriteString("A finding should be resolved if ANY of the following apply:\n")
-	b.WriteString("1. **Fixed by code changes** — the new diff addresses the issue.\n")
-	b.WriteString("2. **Dismissed by the author** — a human reply explicitly asks the reviewer to dismiss, ignore, or skip the finding (e.g. \"dismiss this\", \"you can safely dismiss\", \"please ignore\", \"skip this one\"). The author is exercising their authority to close the thread.\n")
-	b.WriteString("3. **Acknowledged by the author** — a human reply indicates the finding is intentional, accepted as-is, or will be addressed separately (e.g. \"that's fine\", \"intentional\", \"will fix in a future PR\", \"tracked in issue #N\").\n")
-	b.WriteString("4. **Rebutted by the author** — a human reply provides a concrete technical explanation showing the finding is not applicable, the concern is mitigated, or the tradeoff is justified in this context (e.g. the behaviour cannot occur due to framework semantics, the impact is negligible because of how the system is configured, or a project convention makes the approach intentional). A vague disagreement like \"I don't think so\" does NOT qualify — the reply must cite specific technical details, framework behaviour, or project constraints.\n\n")
-	b.WriteString("A reply that merely asks a question or expresses disagreement without substantive technical reasoning should NOT count.\n\n")
-	b.WriteString("Return a JSON array of objects for findings that should be resolved inside a ```json code fence.\n")
-	b.WriteString("Each object must have `thread` (the thread ID) and `reason` (one of `code_change`, `dismissed`, `acknowledged`, or `rebutted`).\n")
-	b.WriteString("If none should be resolved, return an empty array: `[]`.\n\n")
-	b.WriteString("Example:\n```json\n[{\"thread\": \"thread-0\", \"reason\": \"code_change\"}, {\"thread\": \"thread-1\", \"reason\": \"dismissed\"}, {\"thread\": \"thread-2\", \"reason\": \"rebutted\"}]\n```\n")
-
-	return b.String()
-}
-
 // BuildIncrementalPrompt reviews only new code, avoiding duplicate reports.
 // startIndex is the number of existing findings so fix_ref numbering continues.
 // resolved provides context about recently resolved findings to prevent ping-ponging.

--- a/internal/review/prompt_test.go
+++ b/internal/review/prompt_test.go
@@ -111,7 +111,7 @@ func TestFilterRulesForFiles_PathsAndExcludePaths_AllMatchExcluded(t *testing.T)
 func TestFilterRulesForFiles_EmptyFiles_ReturnsAll(t *testing.T) {
 	rules := []Rule{
 		{ID: "rule-a", Paths: []string{"internal/**"}, Severity: "warning"},
-		{ID: "rule-b", ExcludePaths: []string{"**_test.go"}, Severity: "bug"},
+		{ID: "rule-b", ExcludePaths: []string{"**/*_test.go"}, Severity: "bug"},
 		{ID: "rule-c", Severity: "nitpick"},
 	}
 	got := filterRulesForFiles(rules, []string{})

--- a/internal/review/prompt_test.go
+++ b/internal/review/prompt_test.go
@@ -1,0 +1,141 @@
+package review
+
+import (
+	"testing"
+)
+
+func TestFilterRulesForFiles_NoPaths(t *testing.T) {
+	rules := []Rule{
+		{ID: "no-paths", Description: "always applies", Severity: "warning"},
+	}
+	files := []string{"internal/auth/auth.go", "cmd/main.go"}
+	got := filterRulesForFiles(rules, files)
+	if len(got) != 1 || got[0].ID != "no-paths" {
+		t.Errorf("expected rule with no paths to always be included, got %v", got)
+	}
+}
+
+func TestFilterRulesForFiles_NoPaths_EmptyFiles(t *testing.T) {
+	rules := []Rule{
+		{ID: "no-paths", Description: "always applies", Severity: "warning"},
+	}
+	got := filterRulesForFiles(rules, nil)
+	if len(got) != 1 {
+		t.Errorf("expected all rules returned when files is empty, got %v", got)
+	}
+}
+
+func TestFilterRulesForFiles_WithPaths_Matching(t *testing.T) {
+	rules := []Rule{
+		{ID: "auth-rule", Description: "auth only", Severity: "bug", Paths: []string{"internal/auth/**"}},
+	}
+	files := []string{"internal/auth/auth.go", "cmd/main.go"}
+	got := filterRulesForFiles(rules, files)
+	if len(got) != 1 || got[0].ID != "auth-rule" {
+		t.Errorf("expected auth-rule to be included when matching file is present, got %v", got)
+	}
+}
+
+func TestFilterRulesForFiles_WithPaths_NotMatching(t *testing.T) {
+	rules := []Rule{
+		{ID: "auth-rule", Description: "auth only", Severity: "bug", Paths: []string{"internal/auth/**"}},
+	}
+	files := []string{"cmd/main.go", "internal/review/prompt.go"}
+	got := filterRulesForFiles(rules, files)
+	if len(got) != 0 {
+		t.Errorf("expected auth-rule to be excluded when no matching file is present, got %v", got)
+	}
+}
+
+func TestFilterRulesForFiles_OnlyExcludePaths_SomeExcluded(t *testing.T) {
+	rules := []Rule{
+		{ID: "no-test-rule", Description: "skip test files", Severity: "warning", ExcludePaths: []string{"**/*_test.go"}},
+	}
+	// One test file and one non-test file — rule applies because a non-excluded file exists.
+	files := []string{"internal/review/prompt_test.go", "internal/review/prompt.go"}
+	got := filterRulesForFiles(rules, files)
+	if len(got) != 1 || got[0].ID != "no-test-rule" {
+		t.Errorf("expected rule to be included when at least one non-excluded file exists, got %v", got)
+	}
+}
+
+func TestFilterRulesForFiles_OnlyExcludePaths_AllExcluded(t *testing.T) {
+	rules := []Rule{
+		{ID: "no-test-rule", Description: "skip test files", Severity: "warning", ExcludePaths: []string{"**/*_test.go"}},
+	}
+	// Only test files — rule is excluded.
+	files := []string{"internal/review/prompt_test.go", "internal/review/config_test.go"}
+	got := filterRulesForFiles(rules, files)
+	if len(got) != 0 {
+		t.Errorf("expected rule to be excluded when all files are excluded, got %v", got)
+	}
+}
+
+func TestFilterRulesForFiles_PathsAndExcludePaths_SomeMatchSurvive(t *testing.T) {
+	rules := []Rule{
+		{
+			ID:           "auth-non-test",
+			Description:  "auth files, excluding tests",
+			Severity:     "bug",
+			Paths:        []string{"internal/auth/**"},
+			ExcludePaths: []string{"**/*_test.go"},
+		},
+	}
+	// One matching auth file (not a test) and one auth test file — rule applies
+	// because internal/auth/auth.go matches Paths and is not excluded.
+	files := []string{"internal/auth/auth.go", "internal/auth/auth_test.go"}
+	got := filterRulesForFiles(rules, files)
+	if len(got) != 1 || got[0].ID != "auth-non-test" {
+		t.Errorf("expected rule included when a matching non-excluded file exists, got %v", got)
+	}
+}
+
+func TestFilterRulesForFiles_PathsAndExcludePaths_AllMatchExcluded(t *testing.T) {
+	rules := []Rule{
+		{
+			ID:           "auth-non-test",
+			Description:  "auth files, excluding tests",
+			Severity:     "bug",
+			Paths:        []string{"internal/auth/**"},
+			ExcludePaths: []string{"**/*_test.go"},
+		},
+	}
+	// Only auth test files — all matching Paths files are also excluded.
+	files := []string{"internal/auth/auth_test.go", "cmd/main.go"}
+	got := filterRulesForFiles(rules, files)
+	if len(got) != 0 {
+		t.Errorf("expected rule excluded when all Paths-matching files are also excluded, got %v", got)
+	}
+}
+
+func TestFilterRulesForFiles_EmptyFiles_ReturnsAll(t *testing.T) {
+	rules := []Rule{
+		{ID: "rule-a", Paths: []string{"internal/**"}, Severity: "warning"},
+		{ID: "rule-b", ExcludePaths: []string{"**_test.go"}, Severity: "bug"},
+		{ID: "rule-c", Severity: "nitpick"},
+	}
+	got := filterRulesForFiles(rules, []string{})
+	if len(got) != len(rules) {
+		t.Errorf("expected all %d rules returned for empty files, got %d", len(rules), len(got))
+	}
+}
+
+func TestFilterRulesForFiles_MultipleRules_MixedResults(t *testing.T) {
+	rules := []Rule{
+		{ID: "always", Severity: "warning"},
+		{ID: "auth-only", Severity: "bug", Paths: []string{"internal/auth/**"}},
+		{ID: "no-tests", Severity: "nitpick", ExcludePaths: []string{"**/*_test.go"}},
+	}
+	files := []string{"cmd/main.go"} // no auth files, not a test file
+	got := filterRulesForFiles(rules, files)
+	if len(got) != 2 {
+		t.Errorf("expected 2 rules (always + no-tests), got %d: %v", len(got), got)
+	}
+	ids := make(map[string]bool, len(got))
+	for _, r := range got {
+		ids[r.ID] = true
+	}
+	if !ids["always"] || !ids["no-tests"] {
+		t.Errorf("expected 'always' and 'no-tests' to be included, got %v", ids)
+	}
+}

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -491,7 +491,9 @@ func Run(opts RunOptions) error {
 	tracker.SetPRSize(linesAdded, linesRemoved, filesChanged)
 	platform.ReportUsage(tracker)
 
-	// 11b. --fail-on: non-zero exit when new findings meet the severity threshold.
+	// 11b. --fail-on: compute whether findings meet the severity threshold.
+	// Deferred until after telemetry so that failing runs still emit usage data.
+	var failOnErr error
 	if opts.FailOnSeverity != "" {
 		threshold := severityOrder(opts.FailOnSeverity)
 		var count int
@@ -501,7 +503,7 @@ func Run(opts RunOptions) error {
 			}
 		}
 		if count > 0 {
-			return &FailOnSeverityError{Severity: opts.FailOnSeverity, Count: count}
+			failOnErr = &FailOnSeverityError{Severity: opts.FailOnSeverity, Count: count}
 		}
 	}
 
@@ -546,7 +548,7 @@ func Run(opts RunOptions) error {
 		})
 	}
 
-	return nil
+	return failOnErr
 }
 
 // runTriage handles the incremental review: classify previous threads, evaluate

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -14,17 +14,30 @@ import (
 
 // RunOptions configures a review run.
 type RunOptions struct {
-	Repo       string
-	PRNumber   int
-	ConfigPath string
-	Output     string // "markdown" or "json"
-	Post       bool
-	DryRun     bool
-	ReplyOnly  bool           // evaluate thread replies only, skip new findings
-	ClaudePath string         // override claude CLI binary path (overrides config claude_path)
-	Version    string         // binary version (for telemetry)
-	PR         *PRData        // pre-fetched PRData (used in local mode)
-	Platform   ReviewPlatform // environment adapter (GitHub or local)
+	Repo           string
+	PRNumber       int
+	ConfigPath     string
+	Output         string // "markdown" or "json"
+	Post           bool
+	DryRun         bool
+	ReplyOnly      bool           // evaluate thread replies only, skip new findings
+	ClaudePath     string         // override claude CLI binary path (overrides config claude_path)
+	FailOnSeverity string         // non-zero exit when findings at or above this severity exist
+	Version        string         // binary version (for telemetry)
+	PR             *PRData        // pre-fetched PRData (used in local mode)
+	Platform       ReviewPlatform // environment adapter (GitHub or local)
+}
+
+// FailOnSeverityError is returned when --fail-on is set and findings at or
+// above the given severity threshold are found. It is a distinct type so
+// callers can detect it via errors.As.
+type FailOnSeverityError struct {
+	Severity string
+	Count    int
+}
+
+func (e *FailOnSeverityError) Error() string {
+	return fmt.Sprintf("found %d finding(s) at or above severity %q (--fail-on %s)", e.Count, e.Severity, e.Severity)
 }
 
 // allowedEnvPrefixes lists environment variable prefixes passed to the LLM subprocess.
@@ -477,6 +490,20 @@ func Run(opts RunOptions) error {
 	filesChanged := len(FilesFromDiff(prDiffForSize))
 	tracker.SetPRSize(linesAdded, linesRemoved, filesChanged)
 	platform.ReportUsage(tracker)
+
+	// 11b. --fail-on: non-zero exit when new findings meet the severity threshold.
+	if opts.FailOnSeverity != "" {
+		threshold := severityOrder(opts.FailOnSeverity)
+		var count int
+		for _, f := range result.Findings {
+			if severityOrder(f.Severity) <= threshold {
+				count++
+			}
+		}
+		if count > 0 {
+			return &FailOnSeverityError{Severity: opts.FailOnSeverity, Count: count}
+		}
+	}
 
 	// 12. Anonymous telemetry (fire-and-forget).
 	if !opts.DryRun && telemetry.Enabled() {

--- a/internal/review/triage.go
+++ b/internal/review/triage.go
@@ -336,6 +336,10 @@ func ClassifyThreads(threads []ReviewThread, activityDiff, contextDiff, botLogin
 			case TriageCrossFileChange:
 				// Show finding's file context even though the diff is in other files.
 				fileSnippet = ExtractFileSnippet(content, t.Line, "", 200)
+			case TriageHasReply:
+				// Show current file state so the LLM can judge whether the author's
+				// rebuttal is technically accurate given the code as it stands.
+				fileSnippet = ExtractFileSnippet(content, t.Line, "", 200)
 			}
 		}
 
@@ -477,6 +481,7 @@ func buildReplyPrompt(t TriagedThread, cfg *ReviewConfig) string {
 
 	writeFinding(&b, t.Thread)
 	writeReplies(&b, t.Thread, t.BotLogin)
+	writeFileSnippet(&b, t.FileSnippet)
 
 	if ctx := evalContext(cfg, "reply"); ctx != "" {
 		fmt.Fprintf(&b, "## Additional Context\n%s\n\n", ctx)

--- a/internal/review/usage.go
+++ b/internal/review/usage.go
@@ -140,7 +140,8 @@ func (u *UsageTracker) Report(repo string, prNumber int) *UsageReport {
 
 // WriteUsageEnv writes the usage report as a CODECANARY_USAGE env var
 // to $GITHUB_ENV so subsequent workflow steps can read it. No-op outside
-// GitHub Actions.
+// GitHub Actions. Also writes a markdown summary to $GITHUB_STEP_SUMMARY
+// when that env var is set.
 func WriteUsageEnv(report *UsageReport) error {
 	path := os.Getenv("GITHUB_ENV")
 	if path == "" {
@@ -161,6 +162,63 @@ func WriteUsageEnv(report *UsageReport) error {
 	if _, err := fmt.Fprintf(f, "CODECANARY_USAGE=%s\n", data); err != nil {
 		return fmt.Errorf("writing to GITHUB_ENV: %w", err)
 	}
+
+	if err := writeStepSummary(report); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to write GitHub Step Summary: %v\n", err)
+	}
+
+	return nil
+}
+
+// formatInt formats an integer with thousands separators (e.g. 1234567 -> "1,234,567").
+func formatInt(n int) string {
+	s := fmt.Sprintf("%d", n)
+	if n < 0 {
+		s = s[1:]
+	}
+	var result []byte
+	for i, c := range s {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			result = append(result, ',')
+		}
+		result = append(result, byte(c))
+	}
+	if n < 0 {
+		return "-" + string(result)
+	}
+	return string(result)
+}
+
+// writeStepSummary appends a markdown usage table to $GITHUB_STEP_SUMMARY.
+// No-op if $GITHUB_STEP_SUMMARY is not set or if the report has no calls.
+func writeStepSummary(report *UsageReport) error {
+	path := os.Getenv("GITHUB_STEP_SUMMARY")
+	if path == "" {
+		return nil
+	}
+	if len(report.Calls) == 0 {
+		return nil
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("opening GITHUB_STEP_SUMMARY: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	fmt.Fprintln(f, "## CodeCanary Usage")
+	fmt.Fprintln(f, "")
+	fmt.Fprintln(f, "| Phase | Model | Input tokens | Output tokens | Cost |")
+	fmt.Fprintln(f, "|-------|-------|-------------|---------------|------|")
+	for _, c := range report.Calls {
+		fmt.Fprintf(f, "| %s | %s | %s | %s | $%.4f |\n",
+			c.Phase, c.Model,
+			formatInt(c.InputTokens), formatInt(c.OutputTokens),
+			c.CostUSD)
+	}
+	fmt.Fprintf(f, "| **Total** | | **%s** | **%s** | **$%.4f** |\n",
+		formatInt(report.TotalInputTokens), formatInt(report.TotalOutputTokens),
+		report.TotalCostUSD)
 
 	return nil
 }

--- a/internal/review/usage.go
+++ b/internal/review/usage.go
@@ -171,17 +171,18 @@ func WriteUsageEnv(report *UsageReport) error {
 }
 
 // formatInt formats an integer with thousands separators (e.g. 1234567 -> "1,234,567").
+// Iterates by byte index since fmt.Sprintf("%d", n) produces ASCII-only output.
 func formatInt(n int) string {
 	s := fmt.Sprintf("%d", n)
 	if n < 0 {
 		s = s[1:]
 	}
 	var result []byte
-	for i, c := range s {
+	for i := 0; i < len(s); i++ {
 		if i > 0 && (len(s)-i)%3 == 0 {
 			result = append(result, ',')
 		}
-		result = append(result, byte(c))
+		result = append(result, s[i])
 	}
 	if n < 0 {
 		return "-" + string(result)


### PR DESCRIPTION
## Summary

- Adds `titleFromThreadBody()` helper in `formatter.go` that extracts a finding title from a thread body, using embedded JSON first and falling back to parsing the markdown body
- Updates the Known Issues loop in `BuildIncrementalPrompt()` (`prompt.go`) to emit `` `file:line` — <icon> <severity> — <id>: <title> `` when the thread has a parseable ID and title, falling back to `` `file:line` `` for old-format threads

Example output:
```
- `internal/auth/handler.go:42` — 🔴 critical — missing-auth-check: Missing authentication check on admin endpoint
- `internal/db/query.go:87` — 🟡 warning — sql-injection: User input passed directly to query builder
```

## Test plan

- [ ] `go build ./...` passes (verified)
- [ ] `go vet ./...` passes (verified)
- [ ] `go test ./...` passes (verified)
- [ ] Manually confirm incremental prompt output includes title/severity for threads with embedded JSON and old-format threads fall back cleanly to `file:line`