### PR TITLE
feat: add review.local.yml support for personal review overrides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ There is a **single `Run()` function** — not separate paths for GitHub vs. loc
 
 ### Other architecture notes
 
-- **Config** is split across two files in `.codecanary/`: `config.yml` (provider, models, budgets, timeouts) and `review.yml` (rules, context, ignore patterns). `review.yml` is optional — if present, its fields override rules/context/ignore in `config.yml`. Legacy `.codecanary.yml` at repo root is still supported with a deprecation warning.
+- **Config** is split across two files in `.codecanary/`: `config.yml` (provider, models, budgets, timeouts) and `review.yml` (rules, context, ignore patterns). `review.yml` is optional — if present, its fields override rules/context/ignore in `config.yml`. A personal `review.local.yml` can add rules, context, and ignore patterns on top of `review.yml` (append semantics, not replacement). Legacy `.codecanary.yml` at repo root is still supported with a deprecation warning.
 - **Incremental reviews**: on re-push, triage existing threads (Go-driven classifier in `triage.go`), evaluate changed threads via provider (triage model), then review only new code
 - **Dual marker detection**: reads both `codecanary:review` and legacy `clanopy:review` HTML markers for backward compatibility
 - **Anti-hallucination**: explicit file allowlist, line validation against diff, max finding distance threshold

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ review_model: claude-sonnet-4-6
 triage_model: haiku
 ```
 
+You can also create a `.codecanary/review.local.yml` for personal overrides (gitignored) — its rules, context, and ignore patterns are appended to the shared `review.yml`.
+
 For the full config reference including budget controls, size limits, timeouts, evaluation context, and the `review.yml` override file, see [docs/configuration.md](docs/configuration.md).
 
 ## Credential Management

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,6 +174,39 @@ ignore:
   - "*.lock"
 ```
 
+## Personal overrides: review.local.yml
+
+You can create a `.codecanary/review.local.yml` for personal review preferences that should not be committed to the repository. Its fields are **appended** to `review.yml` (not replaced), so your personal settings layer on top of the team's shared configuration.
+
+- **`context`** — concatenated after the shared context (newline-separated)
+- **`rules`** — appended after the shared rules
+- **`ignore`** — appended after the shared ignore patterns
+
+`review.local.yml` works even without a `review.yml` — the local file is loaded independently.
+
+```yaml
+# .codecanary/review.local.yml (add to .gitignore)
+context: |
+  I am working on the payments module. Pay extra attention to
+  transaction atomicity and idempotency in this area.
+
+rules:
+  - id: no-console-log
+    description: "Remove console.log statements before merging"
+    severity: nitpick
+    paths: ["**/*.ts"]
+
+ignore:
+  - "docs/**"
+```
+
+Add `review.local.yml` to your `.gitignore` so it is not committed:
+
+```
+# .gitignore
+.codecanary/review.local.yml
+```
+
 ## Project docs auto-discovery
 
 CodeCanary automatically reads `CLAUDE.md` files from your repo root, `.claude/` directory, and top-level subdirectories. These are injected into the review prompt as additional context. Per-file cap is 4KB, total cap is 12KB.

--- a/docs/review-flow.md
+++ b/docs/review-flow.md
@@ -35,7 +35,7 @@ If the PR is a setup PR (only adds workflow files with no real code changes), th
 
 `prepareReview()` loads everything the review needs:
 
-- **Config**: Reads `config.yml` (provider, models, budgets, timeouts). If a `review.yml` exists alongside it, its rules/context/ignore fields override the config.
+- **Config**: Reads `config.yml` (provider, models, budgets, timeouts). If a `review.yml` exists alongside it, its rules/context/ignore fields override the config. If a `review.local.yml` also exists, its fields are appended (not replaced) on top of `review.yml`.
 - **Project docs**: Discovers CLAUDE.md files (root, `.claude/`, top-level directories). Up to 5 files, 4KB each, 12KB total.
 - **File contents**: Reads changed files from disk with size limits (default 100KB per file, 500KB total). Skips binary files, ignored patterns, and files exceeding limits.
 - **Environment**: Builds a filtered env for LLM subprocesses (only allowed prefixes like `CODECANARY_`, `GITHUB_`, plus essential vars like `PATH`). Injects keychain credentials if not already set.

--- a/internal/review/config.go
+++ b/internal/review/config.go
@@ -236,25 +236,25 @@ func LocalConfigPath() (string, error) {
 	return filepath.Join(home, ".codecanary", "repos", slug, "config.yml"), nil
 }
 
-// findReviewPolicy looks for review.yml in the repo. It first checks
+// findPolicyFile looks for a review policy file by name. It first checks
 // the directory of the given config path (covers the case where config
 // is in .codecanary/), then walks up from cwd looking for
-// .codecanary/review.yml (covers the case where config is in ~/.codecanary/).
-// Returns nil (no error) if no review.yml is found.
-func findReviewPolicy(configPath string) (*ReviewPolicy, error) {
+// .codecanary/<filename> (covers the case where config is in ~/.codecanary/).
+// Returns nil (no error) if the file is not found.
+func findPolicyFile(configPath, filename string) (*ReviewPolicy, error) {
 	// Try adjacent to the config file first.
-	adjacent := filepath.Join(filepath.Dir(configPath), "review.yml")
+	adjacent := filepath.Join(filepath.Dir(configPath), filename)
 	if policy, err := loadReviewPolicyFile(adjacent); policy != nil || err != nil {
 		return policy, err
 	}
 
-	// Walk up from cwd to find .codecanary/review.yml in the repo.
+	// Walk up from cwd to find .codecanary/<filename> in the repo.
 	dir, err := os.Getwd()
 	if err != nil {
 		return nil, nil
 	}
 	for {
-		policyPath := filepath.Join(dir, ".codecanary", "review.yml")
+		policyPath := filepath.Join(dir, ".codecanary", filename)
 		if policyPath != adjacent { // avoid re-checking
 			if policy, err := loadReviewPolicyFile(policyPath); policy != nil || err != nil {
 				return policy, err
@@ -267,6 +267,47 @@ func findReviewPolicy(configPath string) (*ReviewPolicy, error) {
 		dir = parent
 	}
 	return nil, nil
+}
+
+// findReviewPolicy looks for review.yml in the repo.
+// Returns nil (no error) if no review.yml is found.
+func findReviewPolicy(configPath string) (*ReviewPolicy, error) {
+	return findPolicyFile(configPath, "review.yml")
+}
+
+// mergeLocalPolicy appends the local policy fields onto the base policy.
+// Context is concatenated (newline-separated), Rules and Ignore are appended.
+// If base is nil, the local policy is used as-is and vice versa.
+func mergeLocalPolicy(base, local *ReviewPolicy) *ReviewPolicy {
+	if local == nil {
+		return base
+	}
+	if base == nil {
+		return local
+	}
+	merged := &ReviewPolicy{}
+
+	// Context: append with newline separator.
+	merged.Context = base.Context
+	if local.Context != "" {
+		if merged.Context != "" {
+			merged.Context = strings.TrimRight(merged.Context, "\n") + "\n" + local.Context
+		} else {
+			merged.Context = local.Context
+		}
+	}
+
+	// Rules: append local rules after base rules.
+	merged.Rules = make([]Rule, 0, len(base.Rules)+len(local.Rules))
+	merged.Rules = append(merged.Rules, base.Rules...)
+	merged.Rules = append(merged.Rules, local.Rules...)
+
+	// Ignore: append local ignores after base ignores.
+	merged.Ignore = make([]string, 0, len(base.Ignore)+len(local.Ignore))
+	merged.Ignore = append(merged.Ignore, base.Ignore...)
+	merged.Ignore = append(merged.Ignore, local.Ignore...)
+
+	return merged
 }
 
 func loadReviewPolicyFile(path string) (*ReviewPolicy, error) {
@@ -303,10 +344,18 @@ func LoadConfig(path string) (*ReviewConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	if policy != nil {
-		cfg.Rules = policy.Rules
-		cfg.Context = policy.Context
-		cfg.Ignore = policy.Ignore
+
+	// Merge optional review.local.yml (personal overrides, appended).
+	localPolicy, err := findPolicyFile(path, "review.local.yml")
+	if err != nil {
+		return nil, err
+	}
+
+	merged := mergeLocalPolicy(policy, localPolicy)
+	if merged != nil {
+		cfg.Rules = merged.Rules
+		cfg.Context = merged.Context
+		cfg.Ignore = merged.Ignore
 	}
 
 	if err := cfg.Validate(); err != nil {

--- a/internal/review/config.go
+++ b/internal/review/config.go
@@ -269,12 +269,6 @@ func findPolicyFile(configPath, filename string) (*ReviewPolicy, error) {
 	return nil, nil
 }
 
-// findReviewPolicy looks for review.yml in the repo.
-// Returns nil (no error) if no review.yml is found.
-func findReviewPolicy(configPath string) (*ReviewPolicy, error) {
-	return findPolicyFile(configPath, "review.yml")
-}
-
 // mergeLocalPolicy appends the local policy fields onto the base policy.
 // Context is concatenated (newline-separated), Rules and Ignore are appended.
 // If base is nil, the local policy is used as-is and vice versa.
@@ -286,8 +280,6 @@ func mergeLocalPolicy(base, local *ReviewPolicy) *ReviewPolicy {
 		return local
 	}
 	merged := &ReviewPolicy{}
-
-	// Context: append with newline separator.
 	merged.Context = base.Context
 	if local.Context != "" {
 		if merged.Context != "" {
@@ -297,12 +289,10 @@ func mergeLocalPolicy(base, local *ReviewPolicy) *ReviewPolicy {
 		}
 	}
 
-	// Rules: append local rules after base rules.
 	merged.Rules = make([]Rule, 0, len(base.Rules)+len(local.Rules))
 	merged.Rules = append(merged.Rules, base.Rules...)
 	merged.Rules = append(merged.Rules, local.Rules...)
 
-	// Ignore: append local ignores after base ignores.
 	merged.Ignore = make([]string, 0, len(base.Ignore)+len(local.Ignore))
 	merged.Ignore = append(merged.Ignore, base.Ignore...)
 	merged.Ignore = append(merged.Ignore, local.Ignore...)
@@ -320,7 +310,7 @@ func loadReviewPolicyFile(path string) (*ReviewPolicy, error) {
 	}
 	var policy ReviewPolicy
 	if err := yaml.Unmarshal(data, &policy); err != nil {
-		return nil, fmt.Errorf("parsing review.yml: %w", err)
+		return nil, fmt.Errorf("parsing %s: %w", filepath.Base(path), err)
 	}
 	return &policy, nil
 }
@@ -339,13 +329,12 @@ func LoadConfig(path string) (*ReviewConfig, error) {
 		return nil, fmt.Errorf("parsing config file: %w", err)
 	}
 
-	// Merge optional review.yml (rules, context, ignore) from repo.
-	policy, err := findReviewPolicy(path)
+	// Merge optional review policy files (rules, context, ignore) from repo.
+	// review.local.yml fields are appended on top of review.yml.
+	policy, err := findPolicyFile(path, "review.yml")
 	if err != nil {
 		return nil, err
 	}
-
-	// Merge optional review.local.yml (personal overrides, appended).
 	localPolicy, err := findPolicyFile(path, "review.local.yml")
 	if err != nil {
 		return nil, err

--- a/internal/review/config_test.go
+++ b/internal/review/config_test.go
@@ -317,3 +317,220 @@ rules:
 		t.Errorf("expected context in config.yml to be ignored, got %q", cfg.Context)
 	}
 }
+
+func TestLoadConfig_WithReviewLocalPolicy(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, ".codecanary")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("creating config dir: %v", err)
+	}
+
+	configYAML := `version: 1
+provider: anthropic
+review_model: claude-sonnet-4-6
+triage_model: claude-haiku-4-5-20251001
+`
+	reviewYAML := `rules:
+  - id: team-rule
+    description: "Team rule"
+    severity: warning
+context: |
+  Team context.
+ignore:
+  - "dist/**"
+`
+	localYAML := `rules:
+  - id: personal-rule
+    description: "Personal rule"
+    severity: nitpick
+context: |
+  Personal context.
+ignore:
+  - "docs/**"
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.yml"), []byte(configYAML), 0644); err != nil {
+		t.Fatalf("writing config.yml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "review.yml"), []byte(reviewYAML), 0644); err != nil {
+		t.Fatalf("writing review.yml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "review.local.yml"), []byte(localYAML), 0644); err != nil {
+		t.Fatalf("writing review.local.yml: %v", err)
+	}
+
+	cfg, err := LoadConfig(filepath.Join(configDir, "config.yml"))
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	// Rules: should contain both team and personal rules, in order.
+	if len(cfg.Rules) != 2 {
+		t.Fatalf("expected 2 rules, got %d: %v", len(cfg.Rules), cfg.Rules)
+	}
+	if cfg.Rules[0].ID != "team-rule" {
+		t.Errorf("expected first rule to be 'team-rule', got %q", cfg.Rules[0].ID)
+	}
+	if cfg.Rules[1].ID != "personal-rule" {
+		t.Errorf("expected second rule to be 'personal-rule', got %q", cfg.Rules[1].ID)
+	}
+
+	// Context: should contain both contexts.
+	if !strings.Contains(cfg.Context, "Team context") {
+		t.Errorf("expected context to contain 'Team context', got %q", cfg.Context)
+	}
+	if !strings.Contains(cfg.Context, "Personal context") {
+		t.Errorf("expected context to contain 'Personal context', got %q", cfg.Context)
+	}
+
+	// Ignore: should contain both patterns.
+	if len(cfg.Ignore) != 2 {
+		t.Fatalf("expected 2 ignore patterns, got %d: %v", len(cfg.Ignore), cfg.Ignore)
+	}
+	if cfg.Ignore[0] != "dist/**" {
+		t.Errorf("expected first ignore to be 'dist/**', got %q", cfg.Ignore[0])
+	}
+	if cfg.Ignore[1] != "docs/**" {
+		t.Errorf("expected second ignore to be 'docs/**', got %q", cfg.Ignore[1])
+	}
+}
+
+func TestLoadConfig_WithReviewLocalPolicyOnly(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, ".codecanary")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("creating config dir: %v", err)
+	}
+
+	configYAML := `version: 1
+provider: anthropic
+review_model: claude-sonnet-4-6
+triage_model: claude-haiku-4-5-20251001
+`
+	localYAML := `rules:
+  - id: local-only-rule
+    description: "Local only"
+    severity: suggestion
+context: |
+  Local only context.
+ignore:
+  - "tmp/**"
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.yml"), []byte(configYAML), 0644); err != nil {
+		t.Fatalf("writing config.yml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "review.local.yml"), []byte(localYAML), 0644); err != nil {
+		t.Fatalf("writing review.local.yml: %v", err)
+	}
+
+	cfg, err := LoadConfig(filepath.Join(configDir, "config.yml"))
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	if len(cfg.Rules) != 1 || cfg.Rules[0].ID != "local-only-rule" {
+		t.Errorf("expected 1 rule 'local-only-rule', got %v", cfg.Rules)
+	}
+	if !strings.Contains(cfg.Context, "Local only context") {
+		t.Errorf("expected context from review.local.yml, got %q", cfg.Context)
+	}
+	if len(cfg.Ignore) != 1 || cfg.Ignore[0] != "tmp/**" {
+		t.Errorf("expected ignore from review.local.yml, got %v", cfg.Ignore)
+	}
+}
+
+func TestLoadConfig_ReviewLocalPolicyEmptyFields(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, ".codecanary")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("creating config dir: %v", err)
+	}
+
+	configYAML := `version: 1
+provider: anthropic
+review_model: claude-sonnet-4-6
+triage_model: claude-haiku-4-5-20251001
+`
+	reviewYAML := `rules:
+  - id: team-rule
+    description: "Team rule"
+    severity: warning
+context: |
+  Team context.
+ignore:
+  - "dist/**"
+`
+	// Empty local policy — should not change anything.
+	localYAML := `# empty local overrides
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.yml"), []byte(configYAML), 0644); err != nil {
+		t.Fatalf("writing config.yml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "review.yml"), []byte(reviewYAML), 0644); err != nil {
+		t.Fatalf("writing review.yml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "review.local.yml"), []byte(localYAML), 0644); err != nil {
+		t.Fatalf("writing review.local.yml: %v", err)
+	}
+
+	cfg, err := LoadConfig(filepath.Join(configDir, "config.yml"))
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	if len(cfg.Rules) != 1 || cfg.Rules[0].ID != "team-rule" {
+		t.Errorf("expected original rules unchanged, got %v", cfg.Rules)
+	}
+	if !strings.Contains(cfg.Context, "Team context") {
+		t.Errorf("expected original context unchanged, got %q", cfg.Context)
+	}
+	if len(cfg.Ignore) != 1 || cfg.Ignore[0] != "dist/**" {
+		t.Errorf("expected original ignore unchanged, got %v", cfg.Ignore)
+	}
+}
+
+func TestMergeLocalPolicy(t *testing.T) {
+	t.Run("BothNil", func(t *testing.T) {
+		if got := mergeLocalPolicy(nil, nil); got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("NilBase", func(t *testing.T) {
+		local := &ReviewPolicy{Context: "local", Rules: []Rule{{ID: "r1"}}, Ignore: []string{"a"}}
+		got := mergeLocalPolicy(nil, local)
+		if got != local {
+			t.Errorf("expected local policy returned as-is")
+		}
+	})
+
+	t.Run("NilLocal", func(t *testing.T) {
+		base := &ReviewPolicy{Context: "base", Rules: []Rule{{ID: "r1"}}, Ignore: []string{"a"}}
+		got := mergeLocalPolicy(base, nil)
+		if got != base {
+			t.Errorf("expected base policy returned as-is")
+		}
+	})
+
+	t.Run("BothPresent", func(t *testing.T) {
+		base := &ReviewPolicy{
+			Context: "base context\n",
+			Rules:   []Rule{{ID: "base-rule"}},
+			Ignore:  []string{"base-ignore"},
+		}
+		local := &ReviewPolicy{
+			Context: "local context\n",
+			Rules:   []Rule{{ID: "local-rule"}},
+			Ignore:  []string{"local-ignore"},
+		}
+		got := mergeLocalPolicy(base, local)
+		if !strings.Contains(got.Context, "base context") || !strings.Contains(got.Context, "local context") {
+			t.Errorf("expected merged context, got %q", got.Context)
+		}
+		if len(got.Rules) != 2 || got.Rules[0].ID != "base-rule" || got.Rules[1].ID != "local-rule" {
+			t.Errorf("expected merged rules [base-rule, local-rule], got %v", got.Rules)
+		}
+		if len(got.Ignore) != 2 || got.Ignore[0] != "base-ignore" || got.Ignore[1] != "local-ignore" {
+			t.Errorf("expected merged ignore [base-ignore, local-ignore], got %v", got.Ignore)
+		}
+	})
+}

--- a/internal/setup/forms.go
+++ b/internal/setup/forms.go
@@ -251,6 +251,10 @@ func writeReviewPolicy(configPath string) (bool, error) {
 #   - "vendor/**"
 #   - "**/*.generated.go"
 #   - "*.min.js"
+
+# For personal overrides (not committed to the repo), create
+# review.local.yml in this same directory and add it to .gitignore.
+# Fields in review.local.yml are appended to this file's values.
 `
 
 	if err := os.WriteFile(policyPath, []byte(content), 0644); err != nil {

--- a/internal/setup/github.go
+++ b/internal/setup/github.go
@@ -300,6 +300,7 @@ func RunGitHub(canary bool, version string) error {
 	fmt.Fprintf(os.Stderr, "  %s\n", strings.TrimSpace(string(prOut)))
 	fmt.Fprintf(os.Stderr, "\nDone! Merge the PR to enable automated reviews.\n")
 	fmt.Fprintf(os.Stderr, "Customize review rules and context in .codecanary/review.yml\n")
+	fmt.Fprintf(os.Stderr, "For personal overrides, create .codecanary/review.local.yml (add to .gitignore)\n")
 	fmt.Fprintf(os.Stderr, "To also review locally, run: codecanary setup local\n")
 
 	return nil

--- a/internal/setup/local.go
+++ b/internal/setup/local.go
@@ -75,5 +75,6 @@ func RunLocal(version string) error {
 	}
 	fmt.Fprintf(os.Stderr, "\nSetup complete! Run `codecanary review` to review your current changes.\n")
 	fmt.Fprintf(os.Stderr, "Customize review rules and context in .codecanary/review.yml\n")
+	fmt.Fprintf(os.Stderr, "For personal overrides, create .codecanary/review.local.yml (add to .gitignore)\n")
 	return nil
 }


### PR DESCRIPTION
## Summary

- Add `review.local.yml` support — a personal, gitignored override file that **appends** rules, context, and ignore patterns on top of the shared `review.yml`
- Context is concatenated (newline-separated), rules and ignore patterns are appended — personal settings layer on top of team config without replacing it
- Works independently of `review.yml` (if only `review.local.yml` exists, it is loaded standalone)

This mirrors how Claude Code supports `CLAUDE.local.md` and `settings.local.yml`, letting users customize review behavior without touching shared source code.

## Changes

- **`internal/review/config.go`**: Refactored `findReviewPolicy` into reusable `findPolicyFile(configPath, filename)`. Added `mergeLocalPolicy` with append semantics. Updated `LoadConfig` to discover and merge `review.local.yml`.
- **`internal/review/config_test.go`**: Added 7 new tests covering all merge combinations (both files, only local, empty fields, unit tests for merge logic).
- **`docs/configuration.md`**: New "Personal overrides: review.local.yml" section with examples and gitignore guidance.
- **`README.md`**: Brief mention pointing to the full docs.
- **`docs/review-flow.md`** and **`CLAUDE.md`**: Updated architecture notes.
- **`internal/setup/forms.go`**: Added comment to `review.yml` template mentioning `review.local.yml`.
- **`internal/setup/local.go`** and **`internal/setup/github.go`**: Added guidance line after setup completion.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` clean
- [x] New tests cover: both files present (append), only review.local.yml (standalone), empty local file (no-op), unit tests for mergeLocalPolicy (nil/nil, nil/local, base/nil, both present)
- [ ] Manual: create `.codecanary/review.yml` + `.codecanary/review.local.yml`, run `codecanary review --dry-run`, confirm prompt includes both sets of rules/context

🤖 Generated with [Claude Code](https://claude.com/claude-code)