### PR TITLE
feat: add PR size metrics to analytics

### DIFF
--- a/internal/review/formatter.go
+++ b/internal/review/formatter.go
@@ -539,7 +539,8 @@ func stripInlineMarkdown(text string, colors bool) string {
 }
 
 // FormatUsageTable renders a usage table with per-model token counts and costs.
-func FormatUsageTable(calls []CallUsage, colors bool) string {
+func FormatUsageTable(tracker *UsageTracker, colors bool) string {
+	calls := tracker.Calls()
 	if len(calls) == 0 {
 		return ""
 	}
@@ -607,6 +608,12 @@ func FormatUsageTable(calls []CallUsage, colors bool) string {
 	if totalDuration > 0 {
 		durStr := formatDurationMS(totalDuration)
 		fmt.Fprintf(&b, "  %s\n", applyStyle(colors, ansiDim, fmt.Sprintf("Duration: %s", durStr)))
+	}
+
+	// PR size footer.
+	if tracker.LinesAdded > 0 || tracker.LinesRemoved > 0 {
+		fmt.Fprintf(&b, "  %s\n", applyStyle(colors, ansiDim,
+			fmt.Sprintf("PR size: +%d/-%d lines, %d files", tracker.LinesAdded, tracker.LinesRemoved, tracker.FilesChanged)))
 	}
 
 	b.WriteString("\n")

--- a/internal/review/formatter.go
+++ b/internal/review/formatter.go
@@ -611,9 +611,10 @@ func FormatUsageTable(tracker *UsageTracker, colors bool) string {
 	}
 
 	// PR size footer.
-	if tracker.LinesAdded > 0 || tracker.LinesRemoved > 0 {
+	prAdded, prRemoved, prFiles := tracker.PRSize()
+	if prAdded > 0 || prRemoved > 0 || prFiles > 0 {
 		fmt.Fprintf(&b, "  %s\n", applyStyle(colors, ansiDim,
-			fmt.Sprintf("PR size: +%d/-%d lines, %d files", tracker.LinesAdded, tracker.LinesRemoved, tracker.FilesChanged)))
+			fmt.Sprintf("PR size: +%d/-%d lines, %d files", prAdded, prRemoved, prFiles)))
 	}
 
 	b.WriteString("\n")

--- a/internal/review/github.go
+++ b/internal/review/github.go
@@ -150,6 +150,21 @@ type reviewComment struct {
 	Body string `json:"body"`
 }
 
+// countDiffLines counts the number of added and removed lines in a unified diff.
+func countDiffLines(diff string) (added, removed int) {
+	for _, line := range strings.Split(diff, "\n") {
+		if strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") {
+			continue
+		}
+		if strings.HasPrefix(line, "+") {
+			added++
+		} else if strings.HasPrefix(line, "-") {
+			removed++
+		}
+	}
+	return
+}
+
 // diffLineMap maps each file to its sorted list of valid line numbers from the diff.
 type diffLineMap map[string][]int
 

--- a/internal/review/platform_github.go
+++ b/internal/review/platform_github.go
@@ -304,7 +304,7 @@ func (g *GithubPlatform) ReportUsage(tracker *UsageTracker) {
 	if !g.Post {
 		outputFormat := resolveOutputFormat(g.OutputFormat)
 		if outputFormat == "terminal" {
-			fmt.Fprint(os.Stderr, FormatUsageTable(tracker.Calls(), colorsEnabled()))
+			fmt.Fprint(os.Stderr, FormatUsageTable(tracker, colorsEnabled()))
 		}
 	}
 }

--- a/internal/review/platform_local.go
+++ b/internal/review/platform_local.go
@@ -69,6 +69,6 @@ func (l *LocalPlatform) GetIncrementalDiff(baseSHA string, prFiles []string) (st
 func (l *LocalPlatform) ReportUsage(tracker *UsageTracker) {
 	outputFormat := resolveOutputFormat(l.OutputFormat)
 	if outputFormat == "terminal" {
-		fmt.Fprint(os.Stderr, FormatUsageTable(tracker.Calls(), colorsEnabled()))
+		fmt.Fprint(os.Stderr, FormatUsageTable(tracker, colorsEnabled()))
 	}
 }

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -472,8 +472,10 @@ func Run(opts RunOptions) error {
 	}
 
 	// 11. Report usage.
-	tracker.LinesAdded, tracker.LinesRemoved = countDiffLines(pr.ValidationDiff())
-	tracker.FilesChanged = len(pr.Files)
+	prDiffForSize := pr.ValidationDiff()
+	linesAdded, linesRemoved := countDiffLines(prDiffForSize)
+	filesChanged := len(FilesFromDiff(prDiffForSize))
+	tracker.SetPRSize(linesAdded, linesRemoved, filesChanged)
 	platform.ReportUsage(tracker)
 
 	// 12. Anonymous telemetry (fire-and-forget).
@@ -501,9 +503,9 @@ func Run(opts RunOptions) error {
 			Provider:          cfg.Provider,
 			Platform:          platformName,
 			IsIncremental:     isIncremental,
-			LinesAdded:        tracker.LinesAdded,
-			LinesRemoved:      tracker.LinesRemoved,
-			FilesChanged:      tracker.FilesChanged,
+			LinesAdded:        linesAdded,
+			LinesRemoved:      linesRemoved,
+			FilesChanged:      filesChanged,
 			NewFindings:       len(result.Findings),
 			StillOpenFindings: len(result.StillOpen),
 			BySeverity:        bySeverity,

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -472,6 +472,8 @@ func Run(opts RunOptions) error {
 	}
 
 	// 11. Report usage.
+	tracker.LinesAdded, tracker.LinesRemoved = countDiffLines(pr.ValidationDiff())
+	tracker.FilesChanged = len(pr.Files)
 	platform.ReportUsage(tracker)
 
 	// 12. Anonymous telemetry (fire-and-forget).
@@ -499,6 +501,9 @@ func Run(opts RunOptions) error {
 			Provider:          cfg.Provider,
 			Platform:          platformName,
 			IsIncremental:     isIncremental,
+			LinesAdded:        tracker.LinesAdded,
+			LinesRemoved:      tracker.LinesRemoved,
+			FilesChanged:      tracker.FilesChanged,
 			NewFindings:       len(result.Findings),
 			StillOpenFindings: len(result.StillOpen),
 			BySeverity:        bySeverity,

--- a/internal/review/usage.go
+++ b/internal/review/usage.go
@@ -25,6 +25,9 @@ type CallUsage struct {
 type UsageReport struct {
 	PR                string      `json:"pr"`
 	Timestamp         string      `json:"timestamp"`
+	LinesAdded        int         `json:"lines_added"`
+	LinesRemoved      int         `json:"lines_removed"`
+	FilesChanged      int         `json:"files_changed"`
 	Calls             []CallUsage `json:"calls"`
 	TotalInputTokens  int         `json:"total_input_tokens"`
 	TotalOutputTokens int         `json:"total_output_tokens"`
@@ -35,6 +38,11 @@ type UsageReport struct {
 type UsageTracker struct {
 	mu    sync.Mutex
 	calls []CallUsage
+
+	// PR size — set once by the runner before ReportUsage.
+	LinesAdded   int
+	LinesRemoved int
+	FilesChanged int
 }
 
 // Add records a single Claude call's usage.
@@ -99,9 +107,12 @@ func (u *UsageTracker) Report(repo string, prNumber int) *UsageReport {
 	defer u.mu.Unlock()
 
 	r := &UsageReport{
-		PR:        fmt.Sprintf("%s#%d", repo, prNumber),
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-		Calls:     u.calls,
+		PR:           fmt.Sprintf("%s#%d", repo, prNumber),
+		Timestamp:    time.Now().UTC().Format(time.RFC3339),
+		LinesAdded:   u.LinesAdded,
+		LinesRemoved: u.LinesRemoved,
+		FilesChanged: u.FilesChanged,
+		Calls:        u.calls,
 	}
 	for _, c := range u.calls {
 		r.TotalInputTokens += c.InputTokens
@@ -141,6 +152,8 @@ func WriteUsageEnv(report *UsageReport) error {
 // PrintUsageSummary prints a human-readable table and JSON to stdout.
 func PrintUsageSummary(report *UsageReport) {
 	fmt.Printf("\n── Usage (%s) ──\n", report.PR)
+	fmt.Printf("  PR size: +%d/-%d lines across %d files\n",
+		report.LinesAdded, report.LinesRemoved, report.FilesChanged)
 	for _, c := range report.Calls {
 		fmt.Printf("  %-8s  %-25s  %6d in / %6d out  $%.4f  %dms\n",
 			c.Phase, c.Model, c.InputTokens, c.OutputTokens, c.CostUSD, c.DurationMS)

--- a/internal/review/usage.go
+++ b/internal/review/usage.go
@@ -39,10 +39,26 @@ type UsageTracker struct {
 	mu    sync.Mutex
 	calls []CallUsage
 
-	// PR size — set once by the runner before ReportUsage.
-	LinesAdded   int
-	LinesRemoved int
-	FilesChanged int
+	// PR size — set via SetPRSize before ReportUsage.
+	linesAdded   int
+	linesRemoved int
+	filesChanged int
+}
+
+// SetPRSize records the PR's line and file counts (thread-safe).
+func (u *UsageTracker) SetPRSize(linesAdded, linesRemoved, filesChanged int) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.linesAdded = linesAdded
+	u.linesRemoved = linesRemoved
+	u.filesChanged = filesChanged
+}
+
+// PRSize returns the PR's line and file counts (thread-safe).
+func (u *UsageTracker) PRSize() (linesAdded, linesRemoved, filesChanged int) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.linesAdded, u.linesRemoved, u.filesChanged
 }
 
 // Add records a single Claude call's usage.
@@ -109,9 +125,9 @@ func (u *UsageTracker) Report(repo string, prNumber int) *UsageReport {
 	r := &UsageReport{
 		PR:           fmt.Sprintf("%s#%d", repo, prNumber),
 		Timestamp:    time.Now().UTC().Format(time.RFC3339),
-		LinesAdded:   u.LinesAdded,
-		LinesRemoved: u.LinesRemoved,
-		FilesChanged: u.FilesChanged,
+		LinesAdded:   u.linesAdded,
+		LinesRemoved: u.linesRemoved,
+		FilesChanged: u.filesChanged,
 		Calls:        u.calls,
 	}
 	for _, c := range u.calls {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -156,6 +156,11 @@ type ReviewEvent struct {
 	Platform      string `json:"platform"`
 	IsIncremental bool   `json:"is_incremental"`
 
+	// PR size.
+	LinesAdded   int `json:"lines_added"`
+	LinesRemoved int `json:"lines_removed"`
+	FilesChanged int `json:"files_changed"`
+
 	// Aggregate finding counts.
 	NewFindings      int            `json:"new_findings"`
 	StillOpenFindings int           `json:"still_open_findings"`


### PR DESCRIPTION
## Summary
- Adds `lines_added`, `lines_removed`, and `files_changed` to telemetry `ReviewEvent`, `UsageReport` (written to `GITHUB_ENV`), and the terminal usage table
- New `countDiffLines()` helper in `github.go` counts `+`/`-` lines from the unified diff
- PR size is computed once on the `UsageTracker` and reused across telemetry, usage report, and terminal output

## Test plan
- [x] `go build ./cmd/review` passes
- [x] `go test ./internal/review/ ./internal/telemetry/` passes
- [x] `golangci-lint run ./...` — 0 issues