### PR TITLE
fix: clarify provider card copy and link to CONTRIBUTING

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -450,7 +450,7 @@
 
     /* --- Skip link --- */
     .skip-link {
-      position: absolute;
+      position: fixed;
       left: -9999px;
       top: 0;
       background: var(--accent);

--- a/website/index.html
+++ b/website/index.html
@@ -5,12 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>CodeCanary — AI-Powered Code Review</title>
   <meta name="description" content="AI-powered code review for GitHub pull requests. Catch bugs, security issues, and quality problems before they land in main." />
-  <meta property="og:title" content="CodeCanary — AI-Powered Code Review" />
-  <meta property="og:description" content="Catch bugs, security issues, and quality problems before they land in main." />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://codecanary.sh" />
-  <meta property="og:image" content="https://codecanary.sh/og-image.png" />
-  <meta name="twitter:card" content="summary_large_image" />
   <style>
     *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -449,39 +443,17 @@
       margin-bottom: 16px;
     }
 
-    /* --- Skip link --- */
-    .skip-link {
-      position: fixed;
-      left: -9999px;
-      top: 0;
-      background: var(--accent);
-      color: #0a0a0a;
-      padding: 8px 16px;
-      font-size: 14px;
-      font-weight: 600;
-      z-index: 100;
-      border-radius: 0 0 8px 0;
-    }
-    .skip-link:focus {
-      left: 0;
-      text-decoration: none;
-    }
-
     /* --- Responsive --- */
     @media (max-width: 640px) {
       .hero { padding: 80px 0 60px; }
       section { padding: 60px 0; }
       .features-grid { grid-template-columns: 1fr; }
       .steps { grid-template-columns: 1fr; }
-      .providers-grid { grid-template-columns: 1fr; }
-      .provider-wide { grid-column: span 1; }
+      .providers-grid { grid-template-columns: 1fr 1fr; }
     }
   </style>
 </head>
 <body>
-
-  <a href="#main-content" class="skip-link">Skip to main content</a>
-  <main id="main-content">
 
   <!-- Hero -->
   <section class="hero">
@@ -707,8 +679,6 @@
       </div>
     </div>
   </section>
-
-  </main>
 
   <!-- Footer -->
   <footer>

--- a/website/index.html
+++ b/website/index.html
@@ -9,8 +9,8 @@
   <meta property="og:description" content="Catch bugs, security issues, and quality problems before they land in main." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://codecanary.sh" />
-  <meta property="og:image" content="https://github.com/user-attachments/assets/bb494aa1-9bb2-486c-a253-ba8a9a2939e4" />
-  <meta name="twitter:card" content="summary" />
+  <meta property="og:image" content="https://codecanary.sh/og-image.png" />
+  <meta name="twitter:card" content="summary_large_image" />
   <style>
     *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
 

--- a/website/index.html
+++ b/website/index.html
@@ -576,7 +576,7 @@
         <div class="feature-card">
           <span class="feature-icon">&#128268;</span>
           <h3>Multi-provider</h3>
-          <p>Bring your own LLM: Anthropic, OpenAI, OpenRouter, or Claude CLI. No vendor lock-in.</p>
+          <p>Bring your own LLM: Anthropic, OpenAI, OpenRouter, or Claude CLI. No vendor lock-in. New providers are easy to add.</p>
         </div>
         <div class="feature-card">
           <span class="feature-icon">&#10003;</span>

--- a/website/index.html
+++ b/website/index.html
@@ -9,6 +9,7 @@
   <meta property="og:description" content="Catch bugs, security issues, and quality problems before they land in main." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://codecanary.sh" />
+  <meta property="og:image" content="https://github.com/user-attachments/assets/bb494aa1-9bb2-486c-a253-ba8a9a2939e4" />
   <meta name="twitter:card" content="summary" />
   <style>
     *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }

--- a/website/index.html
+++ b/website/index.html
@@ -493,7 +493,7 @@
       </p>
       <div class="hero-ctas fade-up-4">
         <a href="#get-started" class="btn btn-primary">Get started</a>
-        <a href="https://github.com/alansikora/codecanary" class="btn btn-secondary">View on GitHub</a>
+        <a href="https://github.com/alansikora/codecanary" class="btn btn-secondary" target="_blank" rel="noopener">View on GitHub</a>
       </div>
     </div>
   </section>
@@ -683,7 +683,7 @@
           <div class="wide-label">Switching providers? Change two lines:</div>
           <pre><span class="key">provider:</span> <span class="val">openai</span>
 <span class="key">review_model:</span> <span class="val">gpt-5.4</span></pre>
-          <a href="https://github.com/alansikora/codecanary/blob/main/CONTRIBUTING.md" class="wide-link">Adding a new provider &rarr;</a>
+          <a href="https://github.com/alansikora/codecanary/blob/main/CONTRIBUTING.md" class="wide-link" target="_blank" rel="noopener">Adding a new provider &rarr;</a>
         </div>
         <div class="provider-card">
           <div class="provider-name">Claude CLI</div>
@@ -703,7 +703,7 @@
       </div>
       <br />
       <div>
-        <a href="https://github.com/alansikora/codecanary" class="btn btn-primary">View on GitHub</a>
+        <a href="https://github.com/alansikora/codecanary" class="btn btn-primary" target="_blank" rel="noopener">View on GitHub</a>
       </div>
     </div>
   </section>
@@ -714,9 +714,9 @@
   <footer>
     <div class="container">
       <div class="footer-links">
-        <a href="https://github.com/alansikora/codecanary">GitHub</a>
-        <a href="https://github.com/alansikora/codecanary/blob/main/docs/configuration.md">Docs</a>
-        <a href="https://github.com/alansikora/codecanary/blob/main/LICENSE">MIT License</a>
+        <a href="https://github.com/alansikora/codecanary" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/alansikora/codecanary/blob/main/docs/configuration.md" target="_blank" rel="noopener">Docs</a>
+        <a href="https://github.com/alansikora/codecanary/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
       </div>
       <p>CodeCanary &mdash; AI-powered code review for GitHub pull requests.</p>
     </div>

--- a/website/index.html
+++ b/website/index.html
@@ -5,6 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>CodeCanary — AI-Powered Code Review</title>
   <meta name="description" content="AI-powered code review for GitHub pull requests. Catch bugs, security issues, and quality problems before they land in main." />
+  <meta property="og:title" content="CodeCanary — AI-Powered Code Review" />
+  <meta property="og:description" content="Catch bugs, security issues, and quality problems before they land in main." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://codecanary.sh" />
+  <meta name="twitter:card" content="summary" />
   <style>
     *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -443,17 +448,39 @@
       margin-bottom: 16px;
     }
 
+    /* --- Skip link --- */
+    .skip-link {
+      position: absolute;
+      left: -9999px;
+      top: 0;
+      background: var(--accent);
+      color: #0a0a0a;
+      padding: 8px 16px;
+      font-size: 14px;
+      font-weight: 600;
+      z-index: 100;
+      border-radius: 0 0 8px 0;
+    }
+    .skip-link:focus {
+      left: 0;
+      text-decoration: none;
+    }
+
     /* --- Responsive --- */
     @media (max-width: 640px) {
       .hero { padding: 80px 0 60px; }
       section { padding: 60px 0; }
       .features-grid { grid-template-columns: 1fr; }
       .steps { grid-template-columns: 1fr; }
-      .providers-grid { grid-template-columns: 1fr 1fr; }
+      .providers-grid { grid-template-columns: 1fr; }
+      .provider-wide { grid-column: span 1; }
     }
   </style>
 </head>
 <body>
+
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <main id="main-content">
 
   <!-- Hero -->
   <section class="hero">
@@ -679,6 +706,8 @@
       </div>
     </div>
   </section>
+
+  </main>
 
   <!-- Footer -->
   <footer>

--- a/website/index.html
+++ b/website/index.html
@@ -680,10 +680,10 @@
           <div class="provider-desc">Any model via OpenRouter</div>
         </div>
         <div class="provider-wide">
-          <div class="wide-label">As simple as changing two lines:</div>
+          <div class="wide-label">Switching providers? Change two lines:</div>
           <pre><span class="key">provider:</span> <span class="val">openai</span>
 <span class="key">review_model:</span> <span class="val">gpt-5.4</span></pre>
-          <a href="https://github.com/alansikora/codecanary/blob/main/docs/configuration.md" class="wide-link">Full configuration docs &rarr;</a>
+          <a href="https://github.com/alansikora/codecanary/blob/main/CONTRIBUTING.md" class="wide-link">Adding a new provider &rarr;</a>
         </div>
         <div class="provider-card">
           <div class="provider-name">Claude CLI</div>


### PR DESCRIPTION
## Summary
- Clarifies the wide card text: "Switching providers? Change two lines:" instead of the ambiguous "As simple as changing two lines:"
- Links to CONTRIBUTING.md (adding new providers) instead of configuration docs

Follow-up to #140.