### PR TITLE
feat: add codecanary findings command and codecanary-loop Claude skill

### DIFF
--- a/.claude/skills/codecanary-loop/SKILL.md
+++ b/.claude/skills/codecanary-loop/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: codecanary-loop
+description: |
+  Drive a codecanary review → triage → fix → push feedback loop to convergence.
+  Defaults to PR mode (watches the codecanary GitHub action, fetches findings,
+  applies approved fixes, commits, pushes, and re-watches). Pass `--local` to
+  run a local review against uncommitted changes instead, skipping all git
+  plumbing. Always confirms every finding with the user before applying —
+  never auto-applies.
+---
+
+# codecanary-loop
+
+You are driving the CodeCanary review-fix loop. The operator runs this skill
+when they want you to iterate against CodeCanary's findings until the review
+is clean. Stay disciplined: you are the glue between the CLI and the
+operator's decisions, not the reviewer.
+
+## Heavy lifting lives in the CLI
+
+All polling, fetching, parsing, and PR/repo autodetection happens in
+`codecanary findings` and `codecanary review`. You never shell out to `gh`
+directly from this skill. You never parse HTML comment markers. You never
+poll for CI status. The CLI emits structured JSON; you consume it.
+
+This is intentional for token-efficiency: the loop machinery runs in
+subprocesses whose output is small and structured. Your conversation budget
+is spent on triage judgment and fix application, not on watching CI.
+
+## Mode selection
+
+- **PR mode (default)**: fixes land as commits on the current branch and
+  are pushed. Used when an open PR exists for the branch.
+- **Local mode** — invoked when the operator passes `--local` as an argument
+  to this skill: `codecanary review --output json` runs a review on the
+  current dirty working tree; fixes are applied but not committed or pushed.
+
+If you cannot tell which mode applies, ask the operator before starting.
+
+## The loop
+
+Track two pieces of state across iterations:
+- `CYCLE` — integer, starts at 0, increments at the top of every iteration.
+- `LAST_COMMIT` — the commit SHA whose findings you've already triaged.
+  Starts empty.
+
+### Iteration
+
+1. `CYCLE = CYCLE + 1`.
+2. Fetch findings:
+   - **PR mode**: run
+     `codecanary findings --watch --since-commit "$LAST_COMMIT" --output json`
+     (omit `--since-commit` on the first iteration). The command blocks
+     until the review check completes; its stdout is a single JSON object.
+     Parse it.
+   - **Local mode**: run `codecanary review --output json`. The command
+     runs the review inline; its stdout is a JSON object with a
+     `findings` array in the same shape.
+3. If the findings list is empty, tell the operator the review is clean
+   and exit. Do not loop further.
+4. If `CYCLE > 1`, emit this reminder to the operator verbatim, before
+   the triage table:
+   > This is review cycle *N*. Before applying fixes, check whether the new
+   > findings are caused by your previous fixes or are genuinely different
+   > issues. If the bot keeps re-flagging the same `fix_ref` across cycles,
+   > stop and verify your fix actually addresses what the bot meant —
+   > don't keep patching symptoms.
+5. Render a triage table (Markdown) summarizing the findings:
+   - Columns: severity, file:line, fix_ref, title, proposed action
+   - One row per finding. Keep proposed actions terse (one line each).
+6. Ask the operator to confirm. Use `AskUserQuestion` with a single
+   question whose options are:
+   - "Apply all" *(Recommended)*
+   - "Apply some (I'll specify which)"
+   - "Skip this cycle" — treats all findings as deferred; exits the loop
+   - "Abort" — exits the loop immediately
+   Wait for the response before touching any files.
+7. If the operator approved (all or some), apply the fixes. For each
+   approved finding:
+   - Read the file, make the minimal edit that addresses the finding,
+     keeping the surrounding code intact (do not "improve" unrelated code).
+   - If the suggestion in the finding is an exact code snippet and fits
+     the context, prefer it verbatim; otherwise adapt it to the codebase
+     conventions (existing imports, types, error-handling style).
+8. Finalize the cycle:
+   - **PR mode**:
+     - Run `go build ./...` and `go test ./...` if any Go files changed.
+     - Commit with a message like:
+       `fix: address codecanary review on #<PR> (cycle <N>)`
+       plus a brief bullet list of which findings were addressed.
+     - Push the branch.
+     - Set `LAST_COMMIT` to the SHA you just pushed.
+     - Go back to step 1.
+   - **Local mode**: stop. Report the summary of applied fixes to the
+     operator. Do not commit, do not push, do not loop — a single pass
+     is the contract for local mode.
+
+## Stopping conditions
+
+Exit the loop (and tell the operator *why*) whenever any of these hold:
+
+- The findings list comes back empty — normal success.
+- The operator chose "Skip this cycle" or "Abort".
+- The CLI errors out (network failure, no PR detected, timeout on
+  `--watch`). Surface the error verbatim and stop.
+- You detect you're in a stable disagreement loop: the same `fix_ref`
+  values appear in two consecutive cycles after you applied fixes for
+  them. This is the signal from step 4 turning into a hard stop — tell
+  the operator which fix_refs keep re-emerging and ask them to review
+  whether the fix is correct before continuing.
+
+## What not to do
+
+- Don't iterate without operator confirmation.
+- Don't auto-apply nitpicks or "obvious" fixes.
+- Don't write your own logic to parse `<!-- codecanary:finding ... -->`
+  markers — the CLI already returns structured Findings.
+- Don't `gh api` or `gh pr view` yourself — the CLI handles that.
+- Don't attempt concurrent PR work. One branch at a time.
+- Don't commit to `main` or an unrelated branch; always stay on the PR's
+  feature branch.
+- Don't force-push. The loop only appends commits.
+
+## Example operator turn
+
+```
+user: Run codecanary-loop on this PR
+
+assistant: (invokes `codecanary findings --watch --output json`,
+            parses JSON, renders triage table, asks for confirmation,
+            applies approved fixes, commits, pushes, loops)
+```

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,7 @@ dist/
 # Wrangler local state
 **/.wrangler/
 
-# Claude Code local worktrees / settings
-.claude/
+# Claude Code local worktrees / settings — ignore everything under .claude/
+# EXCEPT the checked-in skills directory (intentional shared tooling).
+.claude/*
+!.claude/skills/

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,8 @@ dist/
 
 # Claude Code local worktrees / settings — ignore everything under .claude/
 # EXCEPT the checked-in skills directory (intentional shared tooling).
+# Both the directory itself AND its contents need explicit negation, since
+# Git's ignore-then-re-include rules apply per pathname component.
 .claude/*
 !.claude/skills/
+!.claude/skills/**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ cmd/
     cli/           # Cobra commands
       root.go      # Root "codecanary" command
       review.go    # codecanary review <pr>
+      findings.go  # codecanary findings <pr> — fetch bot findings for the loop skill
       setup.go     # codecanary setup [local|github]
       auth.go      # codecanary auth [status|delete]
 internal/
@@ -36,6 +37,7 @@ internal/
     formatter.go         # JSON/Markdown/Terminal output formatting
     usage.go             # Token tracking, budget checking
     github.go            # GitHub API calls (fetch threads, post reviews)
+    comments.go          # PR review comment fetch + finding marker parser + review-check watcher
     local.go             # Local diff & git operations
     state.go             # Local state persistence
     docs.go              # Project doc discovery
@@ -56,6 +58,9 @@ oidc/              # OIDC domain
   worker/          # Cloudflare Worker — OIDC token exchange proxy (TypeScript)
 action.yml         # GitHub Action definition (composite action)
 install.sh         # Downloads and installs codecanary binary permanently
+.claude/
+  skills/
+    codecanary-loop/ # Claude Code skill — drives review→fix→push loop using `codecanary findings`
 ```
 
 ## Binary

--- a/cmd/review/cli/breaking.go
+++ b/cmd/review/cli/breaking.go
@@ -35,6 +35,7 @@ var breakingManifest = []breakingSurface{
 	{"cmd/review/cli/review.go", "CLI Flags", "CLI flag names or defaults may have changed"},
 	{"cmd/review/cli/root.go", "CLI Flags", "CLI flag names or defaults may have changed"},
 	{"cmd/review/cli/costs.go", "CLI Costs", "`codecanary review costs` behavior may have changed"},
+	{"cmd/review/cli/findings.go", "Findings Command", "`codecanary findings` output schema or flags changed; the codecanary-loop skill may need updating"},
 	{"cmd/review/cli/setup.go", "Setup Command", "`codecanary setup` behavior may have changed"},
 	{"cmd/review/cli/auth.go", "Auth Command", "`codecanary auth` behavior may have changed"},
 	{"cmd/review/cli/upgrade.go", "Upgrade Command", "`codecanary upgrade` behavior may have changed"},

--- a/cmd/review/cli/findings.go
+++ b/cmd/review/cli/findings.go
@@ -1,0 +1,213 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/alansikora/codecanary/internal/review"
+	"github.com/spf13/cobra"
+)
+
+// findingsOutput is the JSON envelope emitted by `codecanary findings --output json`.
+// Keeps the shape stable across CLI versions so the codecanary-loop skill
+// (and any other automation) can rely on it.
+type findingsOutput struct {
+	PR           int                `json:"pr"`
+	Repo         string             `json:"repo"`
+	Commit       string             `json:"commit"`
+	ReviewStatus string             `json:"review_status"`
+	Conclusion   string             `json:"conclusion,omitempty"`
+	Findings     []review.PRFinding `json:"findings"`
+}
+
+var findingsCmd = &cobra.Command{
+	Use:   "findings [pr-number]",
+	Short: "Fetch codecanary review findings from a PR",
+	Long: `Fetch codecanary-bot review comments posted on a PR and emit them as
+structured output. With --watch, blocks until the in-flight review check
+completes before returning.
+
+PR number is auto-detected from the current branch when omitted. Output
+defaults to a human-readable markdown table; use --output json for
+machine consumption (e.g. the codecanary-loop Claude skill).`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		repo, _ := cmd.Flags().GetString("repo")
+		output, _ := cmd.Flags().GetString("output")
+		watch, _ := cmd.Flags().GetBool("watch")
+		sinceCommit, _ := cmd.Flags().GetString("since-commit")
+		timeoutMinutes, _ := cmd.Flags().GetInt("timeout")
+
+		if repo == "" {
+			detected, err := review.DetectRepo()
+			if err != nil {
+				return fmt.Errorf("could not detect repo (pass --repo owner/name): %w", err)
+			}
+			repo = detected
+		}
+
+		prNumber, err := resolveFindingsPR(args, repo)
+		if err != nil {
+			return err
+		}
+
+		var status review.ReviewStatus
+		if watch {
+			timeout := time.Duration(timeoutMinutes) * time.Minute
+			status, err = review.WaitForReview(repo, prNumber, timeout)
+		} else {
+			status, err = review.FetchReviewStatus(repo, prNumber)
+		}
+		if err != nil {
+			return err
+		}
+
+		comments, err := review.FetchPRComments(repo, prNumber)
+		if err != nil {
+			return err
+		}
+
+		findings := review.ParseFindingMarkers(comments)
+		if sinceCommit != "" {
+			findings = filterSinceCommit(findings, sinceCommit)
+		}
+
+		payload := findingsOutput{
+			PR:           prNumber,
+			Repo:         repo,
+			Commit:       status.HeadSHA,
+			ReviewStatus: status.Status,
+			Conclusion:   status.Conclusion,
+			Findings:     findings,
+		}
+
+		switch output {
+		case "json":
+			return emitFindingsJSON(payload)
+		default:
+			return emitFindingsMarkdown(payload)
+		}
+	},
+}
+
+// resolveFindingsPR returns the PR number from the positional arg or by
+// auto-detecting from the current branch via gh.
+func resolveFindingsPR(args []string, repo string) (int, error) {
+	if len(args) > 0 {
+		n, err := strconv.Atoi(args[0])
+		if err != nil {
+			return 0, fmt.Errorf("invalid PR number %q: %w", args[0], err)
+		}
+		return n, nil
+	}
+	n, err := review.DetectPRNumber(repo)
+	if err != nil {
+		return 0, fmt.Errorf("%w (or pass the PR number as an argument)", err)
+	}
+	return n, nil
+}
+
+// filterSinceCommit drops findings anchored on the given commit SHA.
+// Callers pass the previous HEAD after pushing a new commit to get
+// only findings on the fresh commit. Prefix match (7+ chars) so short
+// hashes are accepted.
+func filterSinceCommit(findings []review.PRFinding, sinceCommit string) []review.PRFinding {
+	if len(sinceCommit) < 7 {
+		return findings
+	}
+	out := findings[:0]
+	for _, f := range findings {
+		if strings.HasPrefix(f.CommitID, sinceCommit) {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+func emitFindingsJSON(p findingsOutput) error {
+	// Ensure findings is `[]` not `null` in the JSON output.
+	if p.Findings == nil {
+		p.Findings = []review.PRFinding{}
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(p)
+}
+
+func emitFindingsMarkdown(p findingsOutput) error {
+	fmt.Printf("# CodeCanary findings — %s PR #%d\n\n", p.Repo, p.PR)
+	fmt.Printf("Commit: `%s`  •  Review: `%s`", shortSHA(p.Commit), p.ReviewStatus)
+	if p.Conclusion != "" {
+		fmt.Printf(" (%s)", p.Conclusion)
+	}
+	fmt.Println()
+	fmt.Println()
+
+	if len(p.Findings) == 0 {
+		fmt.Println("No findings.")
+		return nil
+	}
+
+	fmt.Println("| Severity | File:Line | Fix ref | Title |")
+	fmt.Println("|---|---|---|---|")
+	for _, f := range p.Findings {
+		fmt.Printf("| %s | `%s:%d` | `%s` | %s |\n",
+			severityIcon(f.Severity)+" "+f.Severity,
+			f.File, f.Line, f.FixRef, f.Title)
+	}
+	fmt.Println()
+	for _, f := range p.Findings {
+		fmt.Printf("## %s %s — `%s`\n\n",
+			severityIcon(f.Severity), f.Severity, f.ID)
+		fmt.Printf("**%s**  (`%s:%d`, fix_ref `%s`)\n\n",
+			f.Title, f.File, f.Line, f.FixRef)
+		fmt.Println(f.Description)
+		if f.Suggestion != "" {
+			fmt.Println()
+			fmt.Println("> " + strings.ReplaceAll(f.Suggestion, "\n", "\n> "))
+		}
+		if f.CommentURL != "" {
+			fmt.Printf("\n[view comment](%s)\n", f.CommentURL)
+		}
+		fmt.Println()
+	}
+	return nil
+}
+
+func shortSHA(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
+}
+
+func severityIcon(sev string) string {
+	switch strings.ToLower(sev) {
+	case "critical":
+		return "🔴"
+	case "bug":
+		return "🟠"
+	case "warning":
+		return "🟡"
+	case "suggestion":
+		return "🔵"
+	case "nitpick":
+		return "⚪"
+	default:
+		return "·"
+	}
+}
+
+func init() {
+	findingsCmd.Flags().StringP("repo", "r", "", "GitHub repo (owner/name); defaults to current repo")
+	findingsCmd.Flags().StringP("output", "o", "markdown", "Output format: markdown or json")
+	findingsCmd.Flags().Bool("watch", false, "Poll until the review check completes before returning")
+	findingsCmd.Flags().String("since-commit", "", "Drop findings anchored on this commit SHA (used for loop deduplication)")
+	findingsCmd.Flags().Int("timeout", 15, "Max minutes to wait when --watch is set (0 = no timeout)")
+	rootCmd.AddCommand(findingsCmd)
+}

--- a/cmd/review/cli/findings.go
+++ b/cmd/review/cli/findings.go
@@ -45,11 +45,18 @@ machine consumption (e.g. the codecanary-loop Claude skill).`,
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		repoFlagSet := cmd.Flags().Changed("repo")
 		repo, _ := cmd.Flags().GetString("repo")
 		output, _ := cmd.Flags().GetString("output")
 		watch, _ := cmd.Flags().GetBool("watch")
 		sinceCommit, _ := cmd.Flags().GetString("since-commit")
 		timeoutMinutes, _ := cmd.Flags().GetInt("timeout")
+		includeResolved, _ := cmd.Flags().GetBool("include-resolved")
+
+		prNumber, err := resolveFindingsPR(args, repoFlagSet)
+		if err != nil {
+			return err
+		}
 
 		if repo == "" {
 			detected, err := review.DetectRepo()
@@ -57,11 +64,6 @@ machine consumption (e.g. the codecanary-loop Claude skill).`,
 				return fmt.Errorf("could not detect repo (pass --repo owner/name): %w", err)
 			}
 			repo = detected
-		}
-
-		prNumber, err := resolveFindingsPR(args, repo)
-		if err != nil {
-			return err
 		}
 
 		var status review.ReviewStatus
@@ -75,12 +77,14 @@ machine consumption (e.g. the codecanary-loop Claude skill).`,
 			return err
 		}
 
-		comments, err := review.FetchPRComments(repo, prNumber)
+		// Fetch via GraphQL reviewThreads so we can honour GitHub's
+		// thread resolution state. The REST comments endpoint doesn't
+		// expose isResolved, which meant earlier iterations of this
+		// command re-reported findings the bot had already closed.
+		findings, err := review.FetchPRFindings(repo, prNumber, includeResolved)
 		if err != nil {
 			return err
 		}
-
-		findings := review.ParseFindingMarkers(comments)
 		if sinceCommit != "" {
 			findings = filterSinceCommit(findings, sinceCommit)
 		}
@@ -106,17 +110,27 @@ machine consumption (e.g. the codecanary-loop Claude skill).`,
 // resolveFindingsPR returns the PR number from the positional arg or by
 // auto-detecting from the current branch via gh.
 //
-// Note: `gh pr view --repo X` requires an explicit PR number, so we always
-// call DetectPRNumber with an empty repo (which lets gh auto-detect from
-// the current remote + branch). The repo argument to this function is
-// unused but kept in the signature for clarity at the call site.
-func resolveFindingsPR(args []string, _ string) (int, error) {
+// `gh pr view --repo X` requires an explicit PR number — it can't
+// auto-detect when scoped to a different repo. When --repo is set and
+// no PR number is given, fail loudly instead of silently falling back
+// to current-branch detection in the local repo (which almost
+// certainly isn't what the user meant).
+//
+// `repoFlagSet` tells us whether the user passed --repo explicitly,
+// since we auto-detect the repo via DetectRepo() for other purposes
+// and a non-empty repo alone doesn't distinguish the two cases.
+func resolveFindingsPR(args []string, repoFlagSet bool) (int, error) {
 	if len(args) > 0 {
 		n, err := strconv.Atoi(args[0])
 		if err != nil {
 			return 0, fmt.Errorf("invalid PR number %q: %w", args[0], err)
 		}
 		return n, nil
+	}
+	if repoFlagSet {
+		return 0, fmt.Errorf(
+			"--repo requires an explicit PR number argument; " +
+				"omit --repo to auto-detect from the current branch")
 	}
 	n, err := review.DetectPRNumber("")
 	if err != nil {
@@ -227,5 +241,6 @@ func init() {
 	findingsCmd.Flags().Bool("watch", false, "Poll until the review check completes before returning")
 	findingsCmd.Flags().String("since-commit", "", "Drop findings anchored on this commit SHA (used for loop deduplication)")
 	findingsCmd.Flags().Int("timeout", 15, "Max minutes to wait when --watch is set. Use 0 or a negative value to wait indefinitely (blocks until the review check completes or the process is interrupted)")
+	findingsCmd.Flags().Bool("include-resolved", false, "Include findings whose GitHub review thread is already marked resolved (default: skip them)")
 	rootCmd.AddCommand(findingsCmd)
 }

--- a/cmd/review/cli/findings.go
+++ b/cmd/review/cli/findings.go
@@ -35,6 +35,15 @@ PR number is auto-detected from the current branch when omitted. Output
 defaults to a human-readable markdown table; use --output json for
 machine consumption (e.g. the codecanary-loop Claude skill).`,
 	Args: cobra.MaximumNArgs(1),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		sinceCommit, _ := cmd.Flags().GetString("since-commit")
+		if sinceCommit != "" && len(sinceCommit) < minSinceCommitLen {
+			return fmt.Errorf(
+				"--since-commit requires at least %d hex characters (got %q); pass a full or abbreviated SHA",
+				minSinceCommitLen, sinceCommit)
+		}
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		repo, _ := cmd.Flags().GetString("repo")
 		output, _ := cmd.Flags().GetString("output")
@@ -96,7 +105,12 @@ machine consumption (e.g. the codecanary-loop Claude skill).`,
 
 // resolveFindingsPR returns the PR number from the positional arg or by
 // auto-detecting from the current branch via gh.
-func resolveFindingsPR(args []string, repo string) (int, error) {
+//
+// Note: `gh pr view --repo X` requires an explicit PR number, so we always
+// call DetectPRNumber with an empty repo (which lets gh auto-detect from
+// the current remote + branch). The repo argument to this function is
+// unused but kept in the signature for clarity at the call site.
+func resolveFindingsPR(args []string, _ string) (int, error) {
 	if len(args) > 0 {
 		n, err := strconv.Atoi(args[0])
 		if err != nil {
@@ -104,22 +118,26 @@ func resolveFindingsPR(args []string, repo string) (int, error) {
 		}
 		return n, nil
 	}
-	n, err := review.DetectPRNumber(repo)
+	n, err := review.DetectPRNumber("")
 	if err != nil {
 		return 0, fmt.Errorf("%w (or pass the PR number as an argument)", err)
 	}
 	return n, nil
 }
 
+// minSinceCommitLen is the minimum length of a `--since-commit` value we
+// accept. 7 chars matches the abbreviated-SHA length git ships by default
+// and is long enough to be unambiguous on any PR-sized history. Shorter
+// values are rejected at flag-parse time (see findingsCmd.PreRunE) so
+// users notice immediately instead of getting silently unfiltered results.
+const minSinceCommitLen = 7
+
 // filterSinceCommit drops findings anchored on the given commit SHA.
-// Callers pass the previous HEAD after pushing a new commit to get
-// only findings on the fresh commit. Prefix match (7+ chars) so short
-// hashes are accepted.
+// Callers pass the previous HEAD after pushing a new commit to get only
+// findings on the fresh commit. Returns a freshly-allocated slice so the
+// caller's original `findings` backing array is never mutated.
 func filterSinceCommit(findings []review.PRFinding, sinceCommit string) []review.PRFinding {
-	if len(sinceCommit) < 7 {
-		return findings
-	}
-	out := findings[:0]
+	out := make([]review.PRFinding, 0, len(findings))
 	for _, f := range findings {
 		if strings.HasPrefix(f.CommitID, sinceCommit) {
 			continue
@@ -208,6 +226,6 @@ func init() {
 	findingsCmd.Flags().StringP("output", "o", "markdown", "Output format: markdown or json")
 	findingsCmd.Flags().Bool("watch", false, "Poll until the review check completes before returning")
 	findingsCmd.Flags().String("since-commit", "", "Drop findings anchored on this commit SHA (used for loop deduplication)")
-	findingsCmd.Flags().Int("timeout", 15, "Max minutes to wait when --watch is set (0 = no timeout)")
+	findingsCmd.Flags().Int("timeout", 15, "Max minutes to wait when --watch is set. Use 0 or a negative value to wait indefinitely (blocks until the review check completes or the process is interrupted)")
 	rootCmd.AddCommand(findingsCmd)
 }

--- a/internal/review/comments.go
+++ b/internal/review/comments.go
@@ -29,10 +29,21 @@ func runGhJSON(args ...string) ([]byte, error) {
 	return out, nil
 }
 
-// BotLogin is the GitHub login of the codecanary review bot that posts
-// findings on PRs. Comments from any other author are ignored when
-// collecting findings.
+// BotLogin is the REST-API form of the codecanary review bot's login
+// (includes the `[bot]` suffix). GraphQL returns the same principal as
+// plain `codecanary-bot` — use isBotAuthor to compare against either.
 const BotLogin = "codecanary-bot[bot]"
+
+// botLoginPrefix matches both the REST (`codecanary-bot[bot]`) and
+// GraphQL (`codecanary-bot`) author forms returned by the GitHub API
+// for the review bot.
+const botLoginPrefix = "codecanary-bot"
+
+// isBotAuthor reports whether the given login refers to the codecanary
+// review bot, normalising over the REST/GraphQL spelling difference.
+func isBotAuthor(login string) bool {
+	return login == botLoginPrefix || login == BotLogin
+}
 
 // reviewCheckName is the name of the GitHub check emitted by the codecanary
 // action. WaitForReview polls for this check to reach COMPLETED.
@@ -62,6 +73,10 @@ type PRFinding struct {
 	CommentURL string `json:"comment_url,omitempty"`
 	CommitID   string `json:"commit_id,omitempty"`
 	CreatedAt  string `json:"created_at,omitempty"`
+	// Resolved reports whether the enclosing GitHub review thread has
+	// been marked resolved (by the bot's own triage or by a human).
+	// FetchPRFindings omits resolved findings by default.
+	Resolved bool `json:"resolved,omitempty"`
 }
 
 // FetchPRComments returns all line-anchored review comments on the given
@@ -100,7 +115,7 @@ func FetchPRComments(repo string, prNumber int) ([]PRReviewComment, error) {
 func ParseFindingMarkers(comments []PRReviewComment) []PRFinding {
 	var out []PRFinding
 	for _, c := range comments {
-		if c.User.Login != BotLogin {
+		if !isBotAuthor(c.User.Login) {
 			continue
 		}
 		idx := strings.Index(c.Body, findingMarkerPrefix)
@@ -171,6 +186,138 @@ func FetchReviewStatus(repo string, prNumber int) (ReviewStatus, error) {
 		}
 	}
 	return rs, nil
+}
+
+// graphQLFindingsResponse is the JSON shape of the reviewThreads query
+// used by FetchPRFindings. It carries enough per-comment metadata to
+// build a PRFinding without a second REST round-trip.
+type graphQLFindingsResponse struct {
+	Data struct {
+		Repository struct {
+			PullRequest struct {
+				ReviewThreads struct {
+					Nodes []struct {
+						IsResolved bool `json:"isResolved"`
+						IsOutdated bool `json:"isOutdated"`
+						Comments   struct {
+							Nodes []struct {
+								Body         string `json:"body"`
+								Path         string `json:"path"`
+								Line         int    `json:"line"`
+								OriginalLine int    `json:"originalLine"`
+								URL          string `json:"url"`
+								CreatedAt    string `json:"createdAt"`
+								Commit       struct {
+									Oid string `json:"oid"`
+								} `json:"commit"`
+								Author struct {
+									Login string `json:"login"`
+								} `json:"author"`
+							} `json:"nodes"`
+						} `json:"comments"`
+					} `json:"nodes"`
+				} `json:"reviewThreads"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+// FetchPRFindings returns the findings posted by the codecanary bot on
+// the given PR, keyed off GitHub's reviewThreads GraphQL endpoint so we
+// can honour per-thread resolution state. Resolved threads are omitted
+// by default; pass includeResolved=true to keep them.
+//
+// Uses GraphQL (not the REST comments endpoint) because isResolved
+// isn't exposed via REST. That's what caused the first iteration of
+// this command to re-report findings the bot had already closed.
+func FetchPRFindings(repo string, prNumber int, includeResolved bool) ([]PRFinding, error) {
+	owner, name, err := parseRepoSlug(repo)
+	if err != nil {
+		return nil, err
+	}
+	// Note: first:100 for both threads and comments is the GitHub page
+	// size. A PR with more than 100 review threads would be truncated
+	// — fine for now, revisit with cursor-based pagination if the cap
+	// is ever hit in practice.
+	query := `query($owner:String!,$name:String!,$pr:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$pr){
+      reviewThreads(first:100){
+        nodes{
+          isResolved
+          isOutdated
+          comments(first:100){
+            nodes{
+              body path line originalLine url createdAt
+              commit{oid}
+              author{login}
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+	out, err := runGhJSON("api", "graphql",
+		"-f", "query="+query,
+		"-f", "owner="+owner,
+		"-f", "name="+name,
+		"-F", fmt.Sprintf("pr=%d", prNumber),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("gh api graphql (reviewThreads): %w", err)
+	}
+
+	var resp graphQLFindingsResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return nil, fmt.Errorf("parsing graphql response: %w", err)
+	}
+
+	var findings []PRFinding
+	for _, thread := range resp.Data.Repository.PullRequest.ReviewThreads.Nodes {
+		if thread.IsResolved && !includeResolved {
+			continue
+		}
+		if len(thread.Comments.Nodes) == 0 {
+			continue
+		}
+		head := thread.Comments.Nodes[0]
+		if !isBotAuthor(head.Author.Login) {
+			continue
+		}
+		// Extract the finding marker from the body.
+		idx := strings.Index(head.Body, findingMarkerPrefix)
+		if idx < 0 {
+			continue
+		}
+		start := idx + len(findingMarkerPrefix)
+		endIdx := strings.Index(head.Body[start:], reviewMarkerSuffix)
+		if endIdx < 0 {
+			continue
+		}
+		var f Finding
+		if err := json.Unmarshal([]byte(head.Body[start:start+endIdx]), &f); err != nil {
+			continue
+		}
+		// Prefer the live line; fall back to originalLine if the thread
+		// has become outdated (code shifted out from under the anchor).
+		if f.Line == 0 {
+			if head.Line > 0 {
+				f.Line = head.Line
+			} else {
+				f.Line = head.OriginalLine
+			}
+		}
+		findings = append(findings, PRFinding{
+			Finding:    f,
+			CommentURL: head.URL,
+			CommitID:   head.Commit.Oid,
+			CreatedAt:  head.CreatedAt,
+			Resolved:   thread.IsResolved,
+		})
+	}
+	return findings, nil
 }
 
 // WaitForReview polls until the `review` check reaches the COMPLETED state

--- a/internal/review/comments.go
+++ b/internal/review/comments.go
@@ -282,19 +282,27 @@ func FetchPRFindings(repo string, prNumber int, includeResolved bool) ([]PRFindi
 	if err := json.Unmarshal(out, &resp); err != nil {
 		return nil, fmt.Errorf("parsing graphql response: %w", err)
 	}
-	// GraphQL may return a partial response (http 200 with `errors` set
-	// and `data` null-or-incomplete). Treat any error message as fatal
-	// rather than silently returning zero findings.
+	// GraphQL may return a partial response: http 200 with `errors` set
+	// and `data` either null or only populated for the fields the token
+	// had access to. Fail only when the returned data is empty (nothing
+	// usable to work with); otherwise log the errors and carry on with
+	// what we got.
+	threadNodes := resp.Data.Repository.PullRequest.ReviewThreads.Nodes
 	if len(resp.Errors) > 0 {
 		msgs := make([]string, 0, len(resp.Errors))
 		for _, e := range resp.Errors {
 			msgs = append(msgs, e.Message)
 		}
-		return nil, fmt.Errorf("graphql error: %s", strings.Join(msgs, "; "))
+		joined := strings.Join(msgs, "; ")
+		if len(threadNodes) == 0 {
+			return nil, fmt.Errorf("graphql error: %s", joined)
+		}
+		_, _ = fmt.Fprintf(os.Stderr,
+			"warning: partial graphql response: %s\n", joined)
 	}
 
 	var findings []PRFinding
-	for _, thread := range resp.Data.Repository.PullRequest.ReviewThreads.Nodes {
+	for _, thread := range threadNodes {
 		if thread.IsResolved && !includeResolved {
 			continue
 		}

--- a/internal/review/comments.go
+++ b/internal/review/comments.go
@@ -1,0 +1,187 @@
+package review
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// BotLogin is the GitHub login of the codecanary review bot that posts
+// findings on PRs. Comments from any other author are ignored when
+// collecting findings.
+const BotLogin = "codecanary-bot[bot]"
+
+// reviewCheckName is the name of the GitHub check emitted by the codecanary
+// action. WaitForReview polls for this check to reach COMPLETED.
+const reviewCheckName = "review"
+
+// PRReviewComment mirrors the subset of the GitHub review comment payload
+// we care about. Fields follow the `gh api repos/.../pulls/N/comments`
+// response shape.
+type PRReviewComment struct {
+	ID   int64 `json:"id"`
+	User struct {
+		Login string `json:"login"`
+	} `json:"user"`
+	Body         string `json:"body"`
+	Path         string `json:"path"`
+	Line         int    `json:"line"`
+	OriginalLine int    `json:"original_line"`
+	CommitID     string `json:"commit_id"`
+	CreatedAt    string `json:"created_at"`
+	HTMLURL      string `json:"html_url"`
+}
+
+// PRFinding is a Finding augmented with the GitHub comment context it was
+// posted from. Used by the `codecanary findings` command.
+type PRFinding struct {
+	Finding
+	CommentURL string `json:"comment_url,omitempty"`
+	CommitID   string `json:"commit_id,omitempty"`
+	CreatedAt  string `json:"created_at,omitempty"`
+}
+
+// FetchPRComments returns all line-anchored review comments on the given
+// PR, oldest first. Uses gh API pagination (`--paginate`) so large PRs
+// return every page in a single JSON array.
+func FetchPRComments(repo string, prNumber int) ([]PRReviewComment, error) {
+	owner, name, err := parseRepoSlug(repo)
+	if err != nil {
+		return nil, err
+	}
+	apiPath := fmt.Sprintf("repos/%s/%s/pulls/%d/comments", owner, name, prNumber)
+	out, err := exec.Command("gh", "api", "--paginate", apiPath).Output()
+	if err != nil {
+		return nil, fmt.Errorf("fetching PR comments: %w", err)
+	}
+	// `gh api --paginate` concatenates JSON arrays as `][` between pages.
+	// Normalize to a single array before unmarshaling.
+	normalized := strings.ReplaceAll(string(out), "][", ",")
+	var comments []PRReviewComment
+	if err := json.Unmarshal([]byte(normalized), &comments); err != nil {
+		return nil, fmt.Errorf("parsing PR comments: %w", err)
+	}
+	return comments, nil
+}
+
+// ParseFindingMarkers filters to bot-authored comments and extracts the
+// embedded `<!-- codecanary:finding {...} -->` JSON marker from each body.
+// Comments without a finding marker are silently skipped.
+func ParseFindingMarkers(comments []PRReviewComment) []PRFinding {
+	var out []PRFinding
+	for _, c := range comments {
+		if c.User.Login != BotLogin {
+			continue
+		}
+		idx := strings.Index(c.Body, findingMarkerPrefix)
+		if idx < 0 {
+			continue
+		}
+		start := idx + len(findingMarkerPrefix)
+		endIdx := strings.Index(c.Body[start:], reviewMarkerSuffix)
+		if endIdx < 0 {
+			continue
+		}
+		jsonData := c.Body[start : start+endIdx]
+		var f Finding
+		if err := json.Unmarshal([]byte(jsonData), &f); err != nil {
+			continue
+		}
+		out = append(out, PRFinding{
+			Finding:    f,
+			CommentURL: c.HTMLURL,
+			CommitID:   c.CommitID,
+			CreatedAt:  c.CreatedAt,
+		})
+	}
+	return out
+}
+
+// ReviewStatus captures the state of the codecanary `review` check on a PR,
+// along with the PR's current head SHA for convenience.
+type ReviewStatus struct {
+	Status     string `json:"status"`     // queued | in_progress | completed | ""
+	Conclusion string `json:"conclusion"` // success | failure | cancelled | ""
+	HeadSHA    string `json:"head_sha"`
+}
+
+// ghStatusRollup is the subset of `gh pr view --json ...` we parse.
+type ghStatusRollup struct {
+	HeadRefOid       string `json:"headRefOid"`
+	StatusCheckRollup []struct {
+		Name       string `json:"name"`
+		Status     string `json:"status"`
+		Conclusion string `json:"conclusion"`
+	} `json:"statusCheckRollup"`
+}
+
+// FetchReviewStatus queries the current state of the `review` check for
+// the given PR. Returns a ReviewStatus with empty Status/Conclusion if
+// the check isn't present (e.g. the action hasn't started yet).
+func FetchReviewStatus(repo string, prNumber int) (ReviewStatus, error) {
+	args := []string{"pr", "view", fmt.Sprintf("%d", prNumber),
+		"--json", "headRefOid,statusCheckRollup"}
+	if repo != "" {
+		args = append(args, "--repo", repo)
+	}
+	out, err := exec.Command("gh", args...).Output()
+	if err != nil {
+		return ReviewStatus{}, fmt.Errorf("gh pr view: %w", err)
+	}
+	var rollup ghStatusRollup
+	if err := json.Unmarshal(out, &rollup); err != nil {
+		return ReviewStatus{}, fmt.Errorf("parsing pr view: %w", err)
+	}
+	rs := ReviewStatus{HeadSHA: rollup.HeadRefOid}
+	for _, c := range rollup.StatusCheckRollup {
+		if strings.EqualFold(c.Name, reviewCheckName) {
+			rs.Status = strings.ToLower(c.Status)
+			rs.Conclusion = strings.ToLower(c.Conclusion)
+			break
+		}
+	}
+	return rs, nil
+}
+
+// WaitForReview polls until the `review` check reaches the COMPLETED state
+// for the given PR. Progress is printed to stderr as a dot per poll so
+// stdout stays clean for JSON consumption. If timeout is zero, waits
+// indefinitely.
+func WaitForReview(repo string, prNumber int, timeout time.Duration) (ReviewStatus, error) {
+	return waitForReview(repo, prNumber, timeout, 15*time.Second, os.Stderr)
+}
+
+// waitForReview is the testable inner loop — injectable poll interval and
+// progress sink so tests don't actually sleep or write to stderr.
+func waitForReview(
+	repo string,
+	prNumber int,
+	timeout, pollInterval time.Duration,
+	progress io.Writer,
+) (ReviewStatus, error) {
+	deadline := time.Time{}
+	if timeout > 0 {
+		deadline = time.Now().Add(timeout)
+	}
+	for {
+		status, err := FetchReviewStatus(repo, prNumber)
+		if err != nil {
+			return status, err
+		}
+		if status.Status == "completed" {
+			_, _ = fmt.Fprintln(progress)
+			return status, nil
+		}
+		if !deadline.IsZero() && time.Now().After(deadline) {
+			return status, fmt.Errorf(
+				"timed out after %s waiting for review check on PR #%d (last status=%q)",
+				timeout, prNumber, status.Status)
+		}
+		_, _ = fmt.Fprint(progress, ".")
+		time.Sleep(pollInterval)
+	}
+}

--- a/internal/review/comments.go
+++ b/internal/review/comments.go
@@ -191,6 +191,10 @@ func FetchReviewStatus(repo string, prNumber int) (ReviewStatus, error) {
 // graphQLFindingsResponse is the JSON shape of the reviewThreads query
 // used by FetchPRFindings. It carries enough per-comment metadata to
 // build a PRFinding without a second REST round-trip.
+//
+// Errors is populated on partial GraphQL failures (insufficient scope,
+// resource not found, etc.); when `data` is null or incomplete, those
+// errors are the only signal of what went wrong.
 type graphQLFindingsResponse struct {
 	Data struct {
 		Repository struct {
@@ -220,6 +224,11 @@ type graphQLFindingsResponse struct {
 			} `json:"pullRequest"`
 		} `json:"repository"`
 	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+		Path    []any  `json:"path,omitempty"`
+		Type    string `json:"type,omitempty"`
+	} `json:"errors"`
 }
 
 // FetchPRFindings returns the findings posted by the codecanary bot on
@@ -272,6 +281,16 @@ func FetchPRFindings(repo string, prNumber int, includeResolved bool) ([]PRFindi
 	var resp graphQLFindingsResponse
 	if err := json.Unmarshal(out, &resp); err != nil {
 		return nil, fmt.Errorf("parsing graphql response: %w", err)
+	}
+	// GraphQL may return a partial response (http 200 with `errors` set
+	// and `data` null-or-incomplete). Treat any error message as fatal
+	// rather than silently returning zero findings.
+	if len(resp.Errors) > 0 {
+		msgs := make([]string, 0, len(resp.Errors))
+		for _, e := range resp.Errors {
+			msgs = append(msgs, e.Message)
+		}
+		return nil, fmt.Errorf("graphql error: %s", strings.Join(msgs, "; "))
 	}
 
 	var findings []PRFinding

--- a/internal/review/comments.go
+++ b/internal/review/comments.go
@@ -1,7 +1,9 @@
 package review
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -9,6 +11,23 @@ import (
 	"strings"
 	"time"
 )
+
+// runGhJSON runs `gh <args...>` capturing stdout and — on failure —
+// surfacing gh's stderr in the returned error. Plain `exec.Output()`
+// drops stderr, making gh auth / rate-limit failures opaque.
+func runGhJSON(args ...string) ([]byte, error) {
+	cmd := exec.Command("gh", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			return nil, fmt.Errorf("%w: %s",
+				err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return nil, err
+	}
+	return out, nil
+}
 
 // BotLogin is the GitHub login of the codecanary review bot that posts
 // findings on PRs. Comments from any other author are ignored when
@@ -46,26 +65,33 @@ type PRFinding struct {
 }
 
 // FetchPRComments returns all line-anchored review comments on the given
-// PR, oldest first. Uses gh API pagination (`--paginate`) so large PRs
-// return every page in a single JSON array.
+// PR, oldest first. Uses gh API pagination (`--paginate`) which emits one
+// JSON array per page concatenated back-to-back; we decode them as a
+// stream rather than string-splicing, so comment bodies that legitimately
+// contain a "][" sequence survive unscathed.
 func FetchPRComments(repo string, prNumber int) ([]PRReviewComment, error) {
 	owner, name, err := parseRepoSlug(repo)
 	if err != nil {
 		return nil, err
 	}
 	apiPath := fmt.Sprintf("repos/%s/%s/pulls/%d/comments", owner, name, prNumber)
-	out, err := exec.Command("gh", "api", "--paginate", apiPath).Output()
+	out, err := runGhJSON("api", "--paginate", apiPath)
 	if err != nil {
 		return nil, fmt.Errorf("fetching PR comments: %w", err)
 	}
-	// `gh api --paginate` concatenates JSON arrays as `][` between pages.
-	// Normalize to a single array before unmarshaling.
-	normalized := strings.ReplaceAll(string(out), "][", ",")
-	var comments []PRReviewComment
-	if err := json.Unmarshal([]byte(normalized), &comments); err != nil {
-		return nil, fmt.Errorf("parsing PR comments: %w", err)
+	dec := json.NewDecoder(bytes.NewReader(out))
+	var all []PRReviewComment
+	for {
+		var page []PRReviewComment
+		if err := dec.Decode(&page); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("parsing PR comments page: %w", err)
+		}
+		all = append(all, page...)
 	}
-	return comments, nil
+	return all, nil
 }
 
 // ParseFindingMarkers filters to bot-authored comments and extracts the
@@ -128,7 +154,7 @@ func FetchReviewStatus(repo string, prNumber int) (ReviewStatus, error) {
 	if repo != "" {
 		args = append(args, "--repo", repo)
 	}
-	out, err := exec.Command("gh", args...).Output()
+	out, err := runGhJSON(args...)
 	if err != nil {
 		return ReviewStatus{}, fmt.Errorf("gh pr view: %w", err)
 	}

--- a/internal/review/comments_test.go
+++ b/internal/review/comments_test.go
@@ -1,0 +1,87 @@
+package review
+
+import "testing"
+
+func TestParseFindingMarkersFiltersByAuthor(t *testing.T) {
+	comments := []PRReviewComment{
+		{
+			// Not authored by the bot — should be ignored even if a
+			// marker somehow appears in the body.
+			User: struct {
+				Login string `json:"login"`
+			}{Login: "someuser"},
+			Body: `<!-- codecanary:finding {"id":"x","file":"a.go","line":1,"severity":"bug","title":"t","description":"d","fix_ref":"1-1"} -->`,
+		},
+	}
+	got := ParseFindingMarkers(comments)
+	if len(got) != 0 {
+		t.Fatalf("expected 0 findings from non-bot author, got %d", len(got))
+	}
+}
+
+func TestParseFindingMarkersExtractsJSON(t *testing.T) {
+	marker := `<!-- codecanary:finding {"id":"sql","file":"x.ts","line":42,"severity":"critical","title":"SQL injection","description":"desc","fix_ref":"123-1","actionable":true} -->`
+	body := "🔴 **critical** — `sql`\n\nprose here\n\n" + marker
+
+	comments := []PRReviewComment{
+		{
+			User: struct {
+				Login string `json:"login"`
+			}{Login: BotLogin},
+			Body:      body,
+			HTMLURL:   "https://github.com/owner/repo/pull/123#discussion_r1",
+			CommitID:  "abc1234",
+			CreatedAt: "2026-04-13T10:00:00Z",
+			Path:      "x.ts",
+			Line:      42,
+		},
+	}
+
+	got := ParseFindingMarkers(comments)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(got))
+	}
+	f := got[0]
+	if f.ID != "sql" || f.File != "x.ts" || f.Line != 42 || f.Severity != "critical" {
+		t.Errorf("unexpected finding fields: %+v", f)
+	}
+	if f.FixRef != "123-1" {
+		t.Errorf("expected fix_ref=123-1, got %q", f.FixRef)
+	}
+	if f.CommentURL != "https://github.com/owner/repo/pull/123#discussion_r1" {
+		t.Errorf("missing comment URL: %+v", f)
+	}
+	if f.CommitID != "abc1234" {
+		t.Errorf("missing commit id: %+v", f)
+	}
+}
+
+func TestParseFindingMarkersSkipsCommentsWithoutMarker(t *testing.T) {
+	comments := []PRReviewComment{
+		{
+			User: struct {
+				Login string `json:"login"`
+			}{Login: BotLogin},
+			Body: "just a plain bot comment with no finding marker",
+		},
+	}
+	got := ParseFindingMarkers(comments)
+	if len(got) != 0 {
+		t.Fatalf("expected 0 findings, got %d", len(got))
+	}
+}
+
+func TestParseFindingMarkersHandlesMalformedJSON(t *testing.T) {
+	comments := []PRReviewComment{
+		{
+			User: struct {
+				Login string `json:"login"`
+			}{Login: BotLogin},
+			Body: `prose <!-- codecanary:finding {not valid json} -->`,
+		},
+	}
+	got := ParseFindingMarkers(comments)
+	if len(got) != 0 {
+		t.Fatalf("expected 0 findings from malformed marker, got %d", len(got))
+	}
+}


### PR DESCRIPTION
## Summary

Extracts the review→triage→fix→push loop we walked manually on alansikora/codecanary#143 into a reproducible CLI command + Claude skill. The mechanical parts (polling CI, fetching bot comments, parsing marker JSON) move into the binary so they don't burn conversation tokens; the conversation only sees structured findings and handles triage + code edits.

## What's new

### CLI: \`codecanary findings\`
- Auto-detects PR and repo via \`gh\`; \`--repo\` / positional \`pr-number\` override
- \`--watch\` polls the \`review\` check to COMPLETED (dots to stderr, clean JSON on stdout)
- \`--since-commit <sha>\` drops findings on that commit for cross-iteration dedup
- \`--output markdown\` (default, human) \| \`json\` (for the loop skill)
- JSON envelope wraps the existing \`Finding\` struct with \`commit_id\`, \`comment_url\`, \`created_at\` for traceability

### Supporting pkg: \`internal/review/comments.go\`
- \`FetchPRComments\`: \`gh api --paginate repos/.../pulls/N/comments\`, normalizes \`][\` between pages
- \`ParseFindingMarkers\`: filters by \`BotLogin\`, extracts the existing \`<!-- codecanary:finding {...} -->\` JSON (reuses prefix/suffix constants from \`github.go\`)
- \`FetchReviewStatus\` / \`WaitForReview\`: parses \`headRefOid\` + \`statusCheckRollup\`; inner \`waitForReview\` has injectable poll interval + progress writer for tests
- \`comments_test.go\` covers the marker parser happy path, non-bot filtering, missing marker, and malformed JSON

### Claude skill: \`.claude/skills/codecanary-loop/SKILL.md\`
Drives the loop: fetch → triage → confirm → apply → commit → push → repeat.
- Delegates all network / polling / parsing to the CLI; conversation only handles triage decisions and fix edits
- Always asks the operator to confirm via \`AskUserQuestion\` (no auto-apply of nitpicks)
- No hard iteration cap, but emits a reflection reminder from cycle 2 onward warning against patching symptoms when the same \`fix_ref\` keeps re-emerging
- Supports \`--local\` mode that reuses \`codecanary review --output json\` and skips git plumbing (single-pass)

## Housekeeping
- \`.gitignore\` carves out \`.claude/skills/\` so the skill is tracked while worktrees and runtime state stay ignored
- \`CLAUDE.md\` documents \`findings.go\`, \`comments.go\`, and the skills dir
- Breaking-change manifest registers \`findings.go\` so the loop skill's contract is covered

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` passes (new \`comments_test.go\` + existing suites)
- [x] \`golangci-lint run ./...\` clean
- [x] \`codecanary findings 143 --repo alansikora/codecanary --output json\` returns structured payload matching the merged PR's history
- [x] \`codecanary findings 143 ... --since-commit efbefd7 --output json\` correctly drops findings on that commit
- [x] \`codecanary findings 143 ...\` (no \`--output\`) renders a human-readable markdown table
- [ ] End-to-end: invoke the \`codecanary-loop\` skill on a throwaway PR, confirm triage flow + cycle-N reminder