### PR TITLE
feat: add codecanary install-skill command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ cmd/
       root.go      # Root "codecanary" command
       review.go    # codecanary review <pr>
       findings.go  # codecanary findings <pr> — fetch bot findings for the loop skill
+      install_skill.go # codecanary install-skill — write embedded Claude skill to disk
       setup.go     # codecanary setup [local|github]
       auth.go      # codecanary auth [status|delete]
 internal/
@@ -43,6 +44,9 @@ internal/
     docs.go              # Project doc discovery
   credentials/     # Credential storage (keychain with file fallback)
     keyring.go     # Store/Retrieve/Delete — keychain first, ~/.codecanary/credentials.json fallback
+  skills/          # Claude Code skills embedded in the binary via //go:embed
+    skills.go      # Exports CodecanaryLoop() returning the skill body
+    codecanary-loop/SKILL.md  # Canonical skill source (duplicated at .claude/skills/codecanary-loop/SKILL.md; parity enforced by skills_test.go)
   setup/           # Setup wizard logic (huh forms)
     forms.go       # Shared huh form components
     validate.go    # API key validation via test calls
@@ -151,6 +155,7 @@ There is a **single `Run()` function** — not separate paths for GitHub vs. loc
 - **Canonical provider registration points.** Provider names live in the factory map in `provider.go`. All providers use `CODECANARY_PROVIDER_SECRET` for credentials (defined in `internal/credentials/keyring.go`). When adding a new provider, register a `ProviderFactory` in `provider.go` and add config validation in `config.go`.
 - **Minimize shell code.** `install.sh` and the GitHub Action (`action.yml`) should be kept as thin as possible. All logic must live in Go.
 - **Workflow template is embedded.** `internal/setup/codecanary.yml` is the single source of truth for the GitHub Actions workflow, embedded via `//go:embed`. `.github/workflows/codecanary.yml` must be identical — `go test ./internal/setup/` enforces this. When changing the workflow, edit either file and copy to the other.
+- **Claude skills are embedded.** `internal/skills/codecanary-loop/SKILL.md` is the single source of truth for the codecanary-loop skill, embedded via `//go:embed` and materialized by `codecanary install-skill`. `.claude/skills/codecanary-loop/SKILL.md` must be identical so Claude Code's project-mode discovery finds it when working in this repo — `go test ./internal/skills/` enforces this. When changing the skill, edit either file and copy to the other.
 - **Keep the breaking-change manifest in sync.** `.github/workflows/breaking-change-check.yml` contains a manifest of user-facing files. When adding new user-facing surfaces (config fields, CLI flags, public endpoints, etc.), add them to the manifest.
 - **Keep `docs/review-flow.md` in sync.** This document describes the full review pipeline — every step, the triage flow, platform differences, and key design decisions. When changing `runner.go`, `triage.go`, `prompt.go`, `findings.go`, `github.go`, `local.go`, `platform.go`, or the `ReviewPlatform` implementations, update the doc to reflect the new behavior.
 - Tests exist for config, findings, formatting, and triage. Be careful with refactors — run `go test ./...` and `go vet ./...`.

--- a/cmd/review/cli/breaking.go
+++ b/cmd/review/cli/breaking.go
@@ -36,6 +36,8 @@ var breakingManifest = []breakingSurface{
 	{"cmd/review/cli/root.go", "CLI Flags", "CLI flag names or defaults may have changed"},
 	{"cmd/review/cli/costs.go", "CLI Costs", "`codecanary review costs` behavior may have changed"},
 	{"cmd/review/cli/findings.go", "Findings Command", "`codecanary findings` output schema or flags changed; the codecanary-loop skill may need updating"},
+	{"cmd/review/cli/install_skill.go", "Install-Skill Command", "`codecanary install-skill` behavior, destination path, or flags changed"},
+	{"internal/skills/codecanary-loop/SKILL.md", "Embedded Skill Content", "The codecanary-loop Claude skill body changed; users on older binaries will need to re-run `codecanary install-skill` to pick up the new version"},
 	{"cmd/review/cli/setup.go", "Setup Command", "`codecanary setup` behavior may have changed"},
 	{"cmd/review/cli/auth.go", "Auth Command", "`codecanary auth` behavior may have changed"},
 	{"cmd/review/cli/upgrade.go", "Upgrade Command", "`codecanary upgrade` behavior may have changed"},

--- a/cmd/review/cli/install_skill.go
+++ b/cmd/review/cli/install_skill.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/alansikora/codecanary/internal/skills"
+	"github.com/spf13/cobra"
+)
+
+var installSkillCmd = &cobra.Command{
+	Use:   "install-skill",
+	Short: "Install the codecanary-loop Claude Code skill onto your machine",
+	Long: `Writes the embedded codecanary-loop skill to disk so Claude Code can
+discover and invoke it. The skill drives a review → triage → fix → push
+feedback loop against a PR and converges to zero findings.
+
+Default destination is ~/.claude/skills/codecanary-loop/SKILL.md, which
+makes the skill available in every Claude Code session regardless of
+working directory. Use --dest for a custom path (e.g. project-local),
+--print to dump the content to stdout without writing, or --force to
+overwrite an existing file.
+
+The skill content is embedded in the codecanary binary; re-run this
+command after upgrading codecanary to pick up any updates.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dest, _ := cmd.Flags().GetString("dest")
+		printOnly, _ := cmd.Flags().GetBool("print")
+		force, _ := cmd.Flags().GetBool("force")
+
+		content := skills.CodecanaryLoop()
+
+		if printOnly {
+			_, err := fmt.Print(content)
+			return err
+		}
+
+		if dest == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("locating home directory: %w", err)
+			}
+			dest = filepath.Join(home, ".claude", "skills", "codecanary-loop", "SKILL.md")
+		}
+
+		if _, err := os.Stat(dest); err == nil && !force {
+			return fmt.Errorf(
+				"file already exists at %s — pass --force to overwrite", dest)
+		}
+
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return fmt.Errorf("creating parent directory: %w", err)
+		}
+		if err := os.WriteFile(dest, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("writing skill file: %w", err)
+		}
+
+		fmt.Fprintf(os.Stderr, "✓ installed codecanary-loop skill to %s\n", dest)
+		fmt.Fprintln(os.Stderr, "  Restart Claude Code to pick it up.")
+		return nil
+	},
+}
+
+func init() {
+	installSkillCmd.Flags().String("dest", "",
+		"Destination file path (default: ~/.claude/skills/codecanary-loop/SKILL.md)")
+	installSkillCmd.Flags().Bool("print", false,
+		"Print the skill content to stdout instead of writing to disk")
+	installSkillCmd.Flags().Bool("force", false,
+		"Overwrite the destination file if it already exists")
+	rootCmd.AddCommand(installSkillCmd)
+}

--- a/cmd/review/cli/install_skill.go
+++ b/cmd/review/cli/install_skill.go
@@ -25,9 +25,18 @@ overwrite an existing file.
 The skill content is embedded in the codecanary binary; re-run this
 command after upgrading codecanary to pick up any updates.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		dest, _ := cmd.Flags().GetString("dest")
-		printOnly, _ := cmd.Flags().GetBool("print")
-		force, _ := cmd.Flags().GetBool("force")
+		dest, err := cmd.Flags().GetString("dest")
+		if err != nil {
+			return fmt.Errorf("flag --dest: %w", err)
+		}
+		printOnly, err := cmd.Flags().GetBool("print")
+		if err != nil {
+			return fmt.Errorf("flag --print: %w", err)
+		}
+		force, err := cmd.Flags().GetBool("force")
+		if err != nil {
+			return fmt.Errorf("flag --force: %w", err)
+		}
 
 		content := skills.CodecanaryLoop()
 
@@ -44,9 +53,17 @@ command after upgrading codecanary to pick up any updates.`,
 			dest = filepath.Join(home, ".claude", "skills", "codecanary-loop", "SKILL.md")
 		}
 
-		if _, err := os.Stat(dest); err == nil && !force {
-			return fmt.Errorf(
-				"file already exists at %s — pass --force to overwrite", dest)
+		// Distinguish "file exists" from other Stat errors (e.g.
+		// permission denied on the parent) so we don't silently fall
+		// through to writing in a genuinely inaccessible directory.
+		switch _, statErr := os.Stat(dest); {
+		case statErr == nil:
+			if !force {
+				return fmt.Errorf(
+					"file already exists at %s — pass --force to overwrite", dest)
+			}
+		case !os.IsNotExist(statErr):
+			return fmt.Errorf("checking destination %s: %w", dest, statErr)
 		}
 
 		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {

--- a/internal/skills/codecanary-loop/SKILL.md
+++ b/internal/skills/codecanary-loop/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: codecanary-loop
+description: |
+  Drive a codecanary review → triage → fix → push feedback loop to convergence.
+  Defaults to PR mode (watches the codecanary GitHub action, fetches findings,
+  applies approved fixes, commits, pushes, and re-watches). Pass `--local` to
+  run a local review against uncommitted changes instead, skipping all git
+  plumbing. Always confirms every finding with the user before applying —
+  never auto-applies.
+---
+
+# codecanary-loop
+
+You are driving the CodeCanary review-fix loop. The operator runs this skill
+when they want you to iterate against CodeCanary's findings until the review
+is clean. Stay disciplined: you are the glue between the CLI and the
+operator's decisions, not the reviewer.
+
+## Heavy lifting lives in the CLI
+
+All polling, fetching, parsing, and PR/repo autodetection happens in
+`codecanary findings` and `codecanary review`. You never shell out to `gh`
+directly from this skill. You never parse HTML comment markers. You never
+poll for CI status. The CLI emits structured JSON; you consume it.
+
+This is intentional for token-efficiency: the loop machinery runs in
+subprocesses whose output is small and structured. Your conversation budget
+is spent on triage judgment and fix application, not on watching CI.
+
+## Mode selection
+
+- **PR mode (default)**: fixes land as commits on the current branch and
+  are pushed. Used when an open PR exists for the branch.
+- **Local mode** — invoked when the operator passes `--local` as an argument
+  to this skill: `codecanary review --output json` runs a review on the
+  current dirty working tree; fixes are applied but not committed or pushed.
+
+If you cannot tell which mode applies, ask the operator before starting.
+
+## The loop
+
+Track two pieces of state across iterations:
+- `CYCLE` — integer, starts at 0, increments at the top of every iteration.
+- `LAST_COMMIT` — the commit SHA whose findings you've already triaged.
+  Starts empty.
+
+### Iteration
+
+1. `CYCLE = CYCLE + 1`.
+2. Fetch findings:
+   - **PR mode**: run
+     `codecanary findings --watch --since-commit "$LAST_COMMIT" --output json`
+     (omit `--since-commit` on the first iteration). The command blocks
+     until the review check completes; its stdout is a single JSON object.
+     Parse it.
+   - **Local mode**: run `codecanary review --output json`. The command
+     runs the review inline; its stdout is a JSON object with a
+     `findings` array in the same shape.
+3. If the findings list is empty, tell the operator the review is clean
+   and exit. Do not loop further.
+4. If `CYCLE > 1`, emit this reminder to the operator verbatim, before
+   the triage table:
+   > This is review cycle *N*. Before applying fixes, check whether the new
+   > findings are caused by your previous fixes or are genuinely different
+   > issues. If the bot keeps re-flagging the same `fix_ref` across cycles,
+   > stop and verify your fix actually addresses what the bot meant —
+   > don't keep patching symptoms.
+5. Render a triage table (Markdown) summarizing the findings:
+   - Columns: severity, file:line, fix_ref, title, proposed action
+   - One row per finding. Keep proposed actions terse (one line each).
+6. Ask the operator to confirm. Use `AskUserQuestion` with a single
+   question whose options are:
+   - "Apply all" *(Recommended)*
+   - "Apply some (I'll specify which)"
+   - "Skip this cycle" — treats all findings as deferred; exits the loop
+   - "Abort" — exits the loop immediately
+   Wait for the response before touching any files.
+7. If the operator approved (all or some), apply the fixes. For each
+   approved finding:
+   - Read the file, make the minimal edit that addresses the finding,
+     keeping the surrounding code intact (do not "improve" unrelated code).
+   - If the suggestion in the finding is an exact code snippet and fits
+     the context, prefer it verbatim; otherwise adapt it to the codebase
+     conventions (existing imports, types, error-handling style).
+8. Finalize the cycle:
+   - **PR mode**:
+     - Run `go build ./...` and `go test ./...` if any Go files changed.
+     - Commit with a message like:
+       `fix: address codecanary review on #<PR> (cycle <N>)`
+       plus a brief bullet list of which findings were addressed.
+     - Push the branch.
+     - Set `LAST_COMMIT` to the SHA you just pushed.
+     - Go back to step 1.
+   - **Local mode**: stop. Report the summary of applied fixes to the
+     operator. Do not commit, do not push, do not loop — a single pass
+     is the contract for local mode.
+
+## Stopping conditions
+
+Exit the loop (and tell the operator *why*) whenever any of these hold:
+
+- The findings list comes back empty — normal success.
+- The operator chose "Skip this cycle" or "Abort".
+- The CLI errors out (network failure, no PR detected, timeout on
+  `--watch`). Surface the error verbatim and stop.
+- You detect you're in a stable disagreement loop: the same `fix_ref`
+  values appear in two consecutive cycles after you applied fixes for
+  them. This is the signal from step 4 turning into a hard stop — tell
+  the operator which fix_refs keep re-emerging and ask them to review
+  whether the fix is correct before continuing.
+
+## What not to do
+
+- Don't iterate without operator confirmation.
+- Don't auto-apply nitpicks or "obvious" fixes.
+- Don't write your own logic to parse `<!-- codecanary:finding ... -->`
+  markers — the CLI already returns structured Findings.
+- Don't `gh api` or `gh pr view` yourself — the CLI handles that.
+- Don't attempt concurrent PR work. One branch at a time.
+- Don't commit to `main` or an unrelated branch; always stay on the PR's
+  feature branch.
+- Don't force-push. The loop only appends commits.
+
+## Example operator turn
+
+```
+user: Run codecanary-loop on this PR
+
+assistant: (invokes `codecanary findings --watch --output json`,
+            parses JSON, renders triage table, asks for confirmation,
+            applies approved fixes, commits, pushes, loops)
+```

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -1,0 +1,30 @@
+// Package skills exposes the Claude Code skills that ship inside the
+// codecanary binary. Each skill is authored as a normal SKILL.md file
+// (so editors / linters / Claude Code itself can read it directly) and
+// embedded at build time via //go:embed so `codecanary install-skill`
+// can materialize it onto a user's machine without a network round-trip.
+//
+// Source-of-truth layout:
+//
+//	internal/skills/codecanary-loop/SKILL.md   ← canonical (embedded)
+//	.claude/skills/codecanary-loop/SKILL.md    ← identical copy, for
+//	                                             project-local Claude
+//	                                             Code discovery when
+//	                                             the repo itself is the
+//	                                             working directory.
+//
+// Go's //go:embed can't use ".." in patterns, so it cannot reach up to
+// the repo-level .claude/skills/ directory. The duplicate is kept in
+// sync by a parity test (see skills_test.go), the same convention this
+// project already uses for internal/setup/codecanary.yml vs.
+// .github/workflows/codecanary.yml.
+package skills
+
+import _ "embed"
+
+//go:embed codecanary-loop/SKILL.md
+var codecanaryLoopSkill string
+
+// CodecanaryLoop returns the body of the codecanary-loop SKILL.md file
+// embedded at build time.
+func CodecanaryLoop() string { return codecanaryLoopSkill }

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -1,0 +1,30 @@
+package skills_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/alansikora/codecanary/internal/skills"
+)
+
+// TestCodecanaryLoopSkillSynced asserts the embedded skill matches the
+// repo-level project-local copy under .claude/skills/. Both paths must
+// stay identical — the embed is for `codecanary install-skill` (ships
+// in the binary), the .claude/skills/ copy is for Claude Code's
+// project-mode discovery when a session starts in this repo.
+//
+// Same pattern as internal/setup/TestCodecanaryWorkflowSynced for the
+// workflow template at .github/workflows/codecanary.yml.
+func TestCodecanaryLoopSkillSynced(t *testing.T) {
+	const repoCopy = "../../.claude/skills/codecanary-loop/SKILL.md"
+
+	b, err := os.ReadFile(repoCopy)
+	if err != nil {
+		t.Fatalf("reading %s: %v", repoCopy, err)
+	}
+	if string(b) != skills.CodecanaryLoop() {
+		t.Fatalf("%s differs from internal/skills/codecanary-loop/SKILL.md\n"+
+			"edit either file and copy the change to the other; "+
+			"both must stay identical", repoCopy)
+	}
+}


### PR DESCRIPTION
## Summary

Users installing codecanary via `install.sh` only get the binary — the `codecanary-loop` Claude skill shipped in #144 only lives inside the repo checkout. This adds a `codecanary install-skill` command that writes the embedded skill directly to a user's machine, no clone required.

## New surface

```
codecanary install-skill [flags]

  --dest PATH   destination file path (default: ~/.claude/skills/codecanary-loop/SKILL.md)
  --print       dump skill content to stdout instead of writing
  --force       overwrite existing file
```

Writes to `~/.claude/skills/` by default (globally available across all Claude Code sessions). Overridable with `--dest` for project-local installs.

## Source-of-truth layout

Same convention already established for the GitHub Actions workflow template:

- `internal/skills/codecanary-loop/SKILL.md` — canonical, embedded via `//go:embed`
- `.claude/skills/codecanary-loop/SKILL.md` — identical duplicate, for Claude Code's project-mode discovery when a session starts in this repo

Parity enforced by `internal/skills/skills_test.go` so the two can't drift silently. When editing the skill, update either file and copy to the other (the test will fail if you miss one).

## Files

**New:**
- `internal/skills/skills.go` — package with `//go:embed` + public `CodecanaryLoop()`
- `internal/skills/codecanary-loop/SKILL.md` — canonical skill source
- `internal/skills/skills_test.go` — parity test
- `cmd/review/cli/install_skill.go` — the subcommand

**Modified:**
- `CLAUDE.md` — document the new tree + parity rule
- `cmd/review/cli/breaking.go` — register the command + SKILL.md under the breaking-change check

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` passes (new `internal/skills` suite)
- [x] `golangci-lint run ./...` clean
- [x] `codecanary install-skill --print | head` shows the skill body
- [x] `codecanary install-skill --dest /tmp/x.md --force` writes, content is byte-identical to `.claude/skills/codecanary-loop/SKILL.md`
- [ ] End-to-end: `codecanary install-skill`, restart Claude Code, invoke the loop skill