### PR TITLE
fix: codecanary-loop skill must check conclusion and remove --since-commit

### DIFF
--- a/.claude/skills/codecanary-loop/SKILL.md
+++ b/.claude/skills/codecanary-loop/SKILL.md
@@ -56,7 +56,10 @@ Track two pieces of state across iterations:
    - **Local mode**: run `codecanary review --output json`. The command
      runs the review inline; its stdout is a JSON object with a
      `findings` array in the same shape.
-3. Check the `conclusion` field in the JSON output. If it is `failure`
+3. **PR mode only** — check the `conclusion` field in the JSON output.
+   Local mode does not have a check run, so skip this step and go
+   straight to the findings-empty check below.
+   If `conclusion` is `failure`
    (or any value other than `success` / `neutral` / empty), the review
    run itself broke. Tell the operator the check failed and stop. Do
    not say the review is clean, even if `findings` is empty — an empty
@@ -107,7 +110,8 @@ Track two pieces of state across iterations:
 
 Exit the loop (and tell the operator *why*) whenever any of these hold:
 
-- The findings list comes back empty — normal success.
+- The findings list comes back empty **and** `conclusion` is healthy
+  (`success`, `neutral`, or absent) — normal success.
 - The operator chose "Skip this cycle" or "Abort".
 - The CLI errors out (network failure, no PR detected, timeout on
   `--watch`). Surface the error verbatim and stop.

--- a/.claude/skills/codecanary-loop/SKILL.md
+++ b/.claude/skills/codecanary-loop/SKILL.md
@@ -56,8 +56,16 @@ Track two pieces of state across iterations:
    - **Local mode**: run `codecanary review --output json`. The command
      runs the review inline; its stdout is a JSON object with a
      `findings` array in the same shape.
-3. If the findings list is empty, tell the operator the review is clean
-   and exit. Do not loop further.
+3. Check the `conclusion` field in the JSON output. If it is `failure`
+   (or any value other than `success` / `neutral` / empty), the review
+   run itself broke. Tell the operator the check failed and stop. Do
+   not say the review is clean, even if `findings` is empty — an empty
+   list on a failed run means findings were never published, not that
+   the code is fine. Do not count this as a cycle (roll `CYCLE` back).
+   Wait for the operator to explicitly ask you to retry before
+   starting another cycle.
+   If `conclusion` is healthy and the findings list is empty, tell the
+   operator the review is clean and exit. Do not loop further.
 4. If `CYCLE > 1`, emit this reminder to the operator verbatim, before
    the triage table:
    > This is review cycle *N*. Before applying fixes, check whether the new

--- a/.claude/skills/codecanary-loop/SKILL.md
+++ b/.claude/skills/codecanary-loop/SKILL.md
@@ -39,20 +39,18 @@ If you cannot tell which mode applies, ask the operator before starting.
 
 ## The loop
 
-Track two pieces of state across iterations:
+Track one piece of state across iterations:
 - `CYCLE` — integer, starts at 0, increments at the top of every iteration.
-- `LAST_COMMIT` — the commit SHA whose findings you've already triaged.
-  Starts empty.
 
 ### Iteration
 
 1. `CYCLE = CYCLE + 1`.
 2. Fetch findings:
    - **PR mode**: run
-     `codecanary findings --watch --since-commit "$LAST_COMMIT" --output json`
-     (omit `--since-commit` on the first iteration). The command blocks
-     until the review check completes; its stdout is a single JSON object.
-     Parse it.
+     `codecanary findings --watch --output json`.
+     The command blocks until the review check completes; its stdout is
+     a single JSON object. Parse it. Deduplication is handled by GitHub
+     thread resolution — resolved threads are excluded by default.
    - **Local mode**: run `codecanary review --output json`. The command
      runs the review inline; its stdout is a JSON object with a
      `findings` array in the same shape.
@@ -101,7 +99,6 @@ Track two pieces of state across iterations:
        `fix: address codecanary review on #<PR> (cycle <N>)`
        plus a brief bullet list of which findings were addressed.
      - Push the branch.
-     - Set `LAST_COMMIT` to the SHA you just pushed.
      - Go back to step 1.
    - **Local mode**: stop. Report the summary of applied fixes to the
      operator. Do not commit, do not push, do not loop — a single pass

--- a/.claude/skills/codecanary-loop/SKILL.md
+++ b/.claude/skills/codecanary-loop/SKILL.md
@@ -72,8 +72,8 @@ Track one piece of state across iterations:
    explicitly ask you to retry before starting another cycle.
 4. If the findings list is empty (for either mode), tell the operator
    the review is clean and exit. Do not loop further.
-5. If `CYCLE > 1`, emit this reminder to the operator verbatim, before
-   the triage table:
+5. If `CYCLE > 1`, emit this reminder to the operator before the
+   triage table, substituting *N* with the current value of `CYCLE`:
    > This is review cycle *N*. Before applying fixes, check whether the new
    > findings are caused by your previous fixes or are genuinely different
    > issues. If the bot keeps re-flagging the same `fix_ref` across cycles,
@@ -112,8 +112,10 @@ Track one piece of state across iterations:
 
 Exit the loop (and tell the operator *why*) whenever any of these hold:
 
-- The findings list comes back empty **and** `conclusion` is healthy
-  (`success`, `neutral`, or absent) — normal success.
+- **PR mode**: the findings list comes back empty and `conclusion` is
+  healthy (`success` or `neutral`) — normal success.
+- **Local mode**: the findings list comes back empty — normal success.
+  (There is no `conclusion` field in local mode; its absence is expected.)
 - The operator chose "Skip this cycle" or "Abort".
 - The CLI errors out (network failure, no PR detected, timeout on
   `--watch`). Surface the error verbatim and stop.

--- a/.claude/skills/codecanary-loop/SKILL.md
+++ b/.claude/skills/codecanary-loop/SKILL.md
@@ -51,48 +51,52 @@ Track one piece of state across iterations:
      The command blocks until the review check completes; its stdout is
      a single JSON object. Parse it. Deduplication is handled by GitHub
      thread resolution — resolved threads are excluded by default.
+     Note: findings the operator previously skipped (via "Skip this
+     cycle" or "Apply some") will re-appear if their threads are still
+     open. This is intentional — skipped findings are deferred, not
+     dismissed.
    - **Local mode**: run `codecanary review --output json`. The command
      runs the review inline; its stdout is a JSON object with a
      `findings` array in the same shape.
 3. **PR mode only** — check the `conclusion` field in the JSON output.
-   Local mode does not have a check run, so skip only this conclusion
-   check and proceed to the findings-empty check at the end of this
-   step.
-   If `conclusion` is `failure`
-   (or any value other than `success` / `neutral` / empty), the review
-   run itself broke. Tell the operator the check failed and stop. Do
-   not say the review is clean, even if `findings` is empty — an empty
-   list on a failed run means findings were never published, not that
-   the code is fine. Do not count this as a cycle (roll `CYCLE` back).
-   Wait for the operator to explicitly ask you to retry before
-   starting another cycle.
-   If the findings list is empty (for either mode), tell the operator
+   (Skip this step entirely for local mode — there is no check run.)
+   If `conclusion` is `failure`, the review run itself broke. If
+   `conclusion` is `cancelled` or `timed_out`, the run was interrupted
+   (e.g. a newer push superseded it). In any of these cases — or any
+   value other than `success` / `neutral` / empty — tell the operator
+   the check failed, name the conclusion, and stop. Do not say the
+   review is clean, even if `findings` is empty — an empty list on a
+   failed run means findings were never published, not that the code
+   is fine. Roll `CYCLE` back by one (`CYCLE = CYCLE - 1`) so the
+   next retry starts at the correct count. Wait for the operator to
+   explicitly ask you to retry before starting another cycle.
+4. If the findings list is empty (for either mode), tell the operator
    the review is clean and exit. Do not loop further.
-4. If `CYCLE > 1`, emit this reminder to the operator verbatim, before
+5. If `CYCLE > 1`, emit this reminder to the operator verbatim, before
    the triage table:
    > This is review cycle *N*. Before applying fixes, check whether the new
    > findings are caused by your previous fixes or are genuinely different
    > issues. If the bot keeps re-flagging the same `fix_ref` across cycles,
    > stop and verify your fix actually addresses what the bot meant —
    > don't keep patching symptoms.
-5. Render a triage table (Markdown) summarizing the findings:
+6. Render a triage table (Markdown) summarizing the findings:
    - Columns: severity, file:line, fix_ref, title, proposed action
    - One row per finding. Keep proposed actions terse (one line each).
-6. Ask the operator to confirm. Use `AskUserQuestion` with a single
+7. Ask the operator to confirm. Use `AskUserQuestion` with a single
    question whose options are:
    - "Apply all" *(Recommended)*
    - "Apply some (I'll specify which)"
    - "Skip this cycle" — treats all findings as deferred; exits the loop
    - "Abort" — exits the loop immediately
    Wait for the response before touching any files.
-7. If the operator approved (all or some), apply the fixes. For each
+8. If the operator approved (all or some), apply the fixes. For each
    approved finding:
    - Read the file, make the minimal edit that addresses the finding,
      keeping the surrounding code intact (do not "improve" unrelated code).
    - If the suggestion in the finding is an exact code snippet and fits
      the context, prefer it verbatim; otherwise adapt it to the codebase
      conventions (existing imports, types, error-handling style).
-8. Finalize the cycle:
+9. Finalize the cycle:
    - **PR mode**:
      - Run `go build ./...` and `go test ./...` if any Go files changed.
      - Commit with a message like:
@@ -115,7 +119,7 @@ Exit the loop (and tell the operator *why*) whenever any of these hold:
   `--watch`). Surface the error verbatim and stop.
 - You detect you're in a stable disagreement loop: the same `fix_ref`
   values appear in two consecutive cycles after you applied fixes for
-  them. This is the signal from step 4 turning into a hard stop — tell
+  them. This is the signal from step 5 turning into a hard stop — tell
   the operator which fix_refs keep re-emerging and ask them to review
   whether the fix is correct before continuing.
 

--- a/.claude/skills/codecanary-loop/SKILL.md
+++ b/.claude/skills/codecanary-loop/SKILL.md
@@ -57,8 +57,9 @@ Track two pieces of state across iterations:
      runs the review inline; its stdout is a JSON object with a
      `findings` array in the same shape.
 3. **PR mode only** — check the `conclusion` field in the JSON output.
-   Local mode does not have a check run, so skip this step and go
-   straight to the findings-empty check below.
+   Local mode does not have a check run, so skip only this conclusion
+   check and proceed to the findings-empty check at the end of this
+   step.
    If `conclusion` is `failure`
    (or any value other than `success` / `neutral` / empty), the review
    run itself broke. Tell the operator the check failed and stop. Do
@@ -67,8 +68,8 @@ Track two pieces of state across iterations:
    the code is fine. Do not count this as a cycle (roll `CYCLE` back).
    Wait for the operator to explicitly ask you to retry before
    starting another cycle.
-   If `conclusion` is healthy and the findings list is empty, tell the
-   operator the review is clean and exit. Do not loop further.
+   If the findings list is empty (for either mode), tell the operator
+   the review is clean and exit. Do not loop further.
 4. If `CYCLE > 1`, emit this reminder to the operator verbatim, before
    the triage table:
    > This is review cycle *N*. Before applying fixes, check whether the new

--- a/cmd/review/cli/findings.go
+++ b/cmd/review/cli/findings.go
@@ -35,21 +35,11 @@ PR number is auto-detected from the current branch when omitted. Output
 defaults to a human-readable markdown table; use --output json for
 machine consumption (e.g. the codecanary-loop Claude skill).`,
 	Args: cobra.MaximumNArgs(1),
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		sinceCommit, _ := cmd.Flags().GetString("since-commit")
-		if sinceCommit != "" && len(sinceCommit) < minSinceCommitLen {
-			return fmt.Errorf(
-				"--since-commit requires at least %d hex characters (got %q); pass a full or abbreviated SHA",
-				minSinceCommitLen, sinceCommit)
-		}
-		return nil
-	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		repoFlagSet := cmd.Flags().Changed("repo")
 		repo, _ := cmd.Flags().GetString("repo")
 		output, _ := cmd.Flags().GetString("output")
 		watch, _ := cmd.Flags().GetBool("watch")
-		sinceCommit, _ := cmd.Flags().GetString("since-commit")
 		timeoutMinutes, _ := cmd.Flags().GetInt("timeout")
 		includeResolved, _ := cmd.Flags().GetBool("include-resolved")
 
@@ -85,10 +75,6 @@ machine consumption (e.g. the codecanary-loop Claude skill).`,
 		if err != nil {
 			return err
 		}
-		if sinceCommit != "" {
-			findings = filterSinceCommit(findings, sinceCommit)
-		}
-
 		payload := findingsOutput{
 			PR:           prNumber,
 			Repo:         repo,
@@ -137,28 +123,6 @@ func resolveFindingsPR(args []string, repoFlagSet bool) (int, error) {
 		return 0, fmt.Errorf("%w (or pass the PR number as an argument)", err)
 	}
 	return n, nil
-}
-
-// minSinceCommitLen is the minimum length of a `--since-commit` value we
-// accept. 7 chars matches the abbreviated-SHA length git ships by default
-// and is long enough to be unambiguous on any PR-sized history. Shorter
-// values are rejected at flag-parse time (see findingsCmd.PreRunE) so
-// users notice immediately instead of getting silently unfiltered results.
-const minSinceCommitLen = 7
-
-// filterSinceCommit drops findings anchored on the given commit SHA.
-// Callers pass the previous HEAD after pushing a new commit to get only
-// findings on the fresh commit. Returns a freshly-allocated slice so the
-// caller's original `findings` backing array is never mutated.
-func filterSinceCommit(findings []review.PRFinding, sinceCommit string) []review.PRFinding {
-	out := make([]review.PRFinding, 0, len(findings))
-	for _, f := range findings {
-		if strings.HasPrefix(f.CommitID, sinceCommit) {
-			continue
-		}
-		out = append(out, f)
-	}
-	return out
 }
 
 func emitFindingsJSON(p findingsOutput) error {
@@ -239,8 +203,7 @@ func init() {
 	findingsCmd.Flags().StringP("repo", "r", "", "GitHub repo (owner/name); defaults to current repo")
 	findingsCmd.Flags().StringP("output", "o", "markdown", "Output format: markdown or json")
 	findingsCmd.Flags().Bool("watch", false, "Poll until the review check completes before returning")
-	findingsCmd.Flags().String("since-commit", "", "Drop findings anchored on this commit SHA (used for loop deduplication)")
-	findingsCmd.Flags().Int("timeout", 15, "Max minutes to wait when --watch is set. Use 0 or a negative value to wait indefinitely (blocks until the review check completes or the process is interrupted)")
+findingsCmd.Flags().Int("timeout", 15, "Max minutes to wait when --watch is set. Use 0 or a negative value to wait indefinitely (blocks until the review check completes or the process is interrupted)")
 	findingsCmd.Flags().Bool("include-resolved", false, "Include findings whose GitHub review thread is already marked resolved (default: skip them)")
 	rootCmd.AddCommand(findingsCmd)
 }

--- a/cmd/review/cli/findings.go
+++ b/cmd/review/cli/findings.go
@@ -203,7 +203,7 @@ func init() {
 	findingsCmd.Flags().StringP("repo", "r", "", "GitHub repo (owner/name); defaults to current repo")
 	findingsCmd.Flags().StringP("output", "o", "markdown", "Output format: markdown or json")
 	findingsCmd.Flags().Bool("watch", false, "Poll until the review check completes before returning")
-findingsCmd.Flags().Int("timeout", 15, "Max minutes to wait when --watch is set. Use 0 or a negative value to wait indefinitely (blocks until the review check completes or the process is interrupted)")
+	findingsCmd.Flags().Int("timeout", 15, "Max minutes to wait when --watch is set. Use 0 or a negative value to wait indefinitely (blocks until the review check completes or the process is interrupted)")
 	findingsCmd.Flags().Bool("include-resolved", false, "Include findings whose GitHub review thread is already marked resolved (default: skip them)")
 	rootCmd.AddCommand(findingsCmd)
 }

--- a/internal/skills/codecanary-loop/SKILL.md
+++ b/internal/skills/codecanary-loop/SKILL.md
@@ -56,7 +56,10 @@ Track two pieces of state across iterations:
    - **Local mode**: run `codecanary review --output json`. The command
      runs the review inline; its stdout is a JSON object with a
      `findings` array in the same shape.
-3. Check the `conclusion` field in the JSON output. If it is `failure`
+3. **PR mode only** — check the `conclusion` field in the JSON output.
+   Local mode does not have a check run, so skip this step and go
+   straight to the findings-empty check below.
+   If `conclusion` is `failure`
    (or any value other than `success` / `neutral` / empty), the review
    run itself broke. Tell the operator the check failed and stop. Do
    not say the review is clean, even if `findings` is empty — an empty
@@ -107,7 +110,8 @@ Track two pieces of state across iterations:
 
 Exit the loop (and tell the operator *why*) whenever any of these hold:
 
-- The findings list comes back empty — normal success.
+- The findings list comes back empty **and** `conclusion` is healthy
+  (`success`, `neutral`, or absent) — normal success.
 - The operator chose "Skip this cycle" or "Abort".
 - The CLI errors out (network failure, no PR detected, timeout on
   `--watch`). Surface the error verbatim and stop.

--- a/internal/skills/codecanary-loop/SKILL.md
+++ b/internal/skills/codecanary-loop/SKILL.md
@@ -56,8 +56,16 @@ Track two pieces of state across iterations:
    - **Local mode**: run `codecanary review --output json`. The command
      runs the review inline; its stdout is a JSON object with a
      `findings` array in the same shape.
-3. If the findings list is empty, tell the operator the review is clean
-   and exit. Do not loop further.
+3. Check the `conclusion` field in the JSON output. If it is `failure`
+   (or any value other than `success` / `neutral` / empty), the review
+   run itself broke. Tell the operator the check failed and stop. Do
+   not say the review is clean, even if `findings` is empty — an empty
+   list on a failed run means findings were never published, not that
+   the code is fine. Do not count this as a cycle (roll `CYCLE` back).
+   Wait for the operator to explicitly ask you to retry before
+   starting another cycle.
+   If `conclusion` is healthy and the findings list is empty, tell the
+   operator the review is clean and exit. Do not loop further.
 4. If `CYCLE > 1`, emit this reminder to the operator verbatim, before
    the triage table:
    > This is review cycle *N*. Before applying fixes, check whether the new

--- a/internal/skills/codecanary-loop/SKILL.md
+++ b/internal/skills/codecanary-loop/SKILL.md
@@ -39,20 +39,18 @@ If you cannot tell which mode applies, ask the operator before starting.
 
 ## The loop
 
-Track two pieces of state across iterations:
+Track one piece of state across iterations:
 - `CYCLE` — integer, starts at 0, increments at the top of every iteration.
-- `LAST_COMMIT` — the commit SHA whose findings you've already triaged.
-  Starts empty.
 
 ### Iteration
 
 1. `CYCLE = CYCLE + 1`.
 2. Fetch findings:
    - **PR mode**: run
-     `codecanary findings --watch --since-commit "$LAST_COMMIT" --output json`
-     (omit `--since-commit` on the first iteration). The command blocks
-     until the review check completes; its stdout is a single JSON object.
-     Parse it.
+     `codecanary findings --watch --output json`.
+     The command blocks until the review check completes; its stdout is
+     a single JSON object. Parse it. Deduplication is handled by GitHub
+     thread resolution — resolved threads are excluded by default.
    - **Local mode**: run `codecanary review --output json`. The command
      runs the review inline; its stdout is a JSON object with a
      `findings` array in the same shape.
@@ -101,7 +99,6 @@ Track two pieces of state across iterations:
        `fix: address codecanary review on #<PR> (cycle <N>)`
        plus a brief bullet list of which findings were addressed.
      - Push the branch.
-     - Set `LAST_COMMIT` to the SHA you just pushed.
      - Go back to step 1.
    - **Local mode**: stop. Report the summary of applied fixes to the
      operator. Do not commit, do not push, do not loop — a single pass

--- a/internal/skills/codecanary-loop/SKILL.md
+++ b/internal/skills/codecanary-loop/SKILL.md
@@ -72,8 +72,8 @@ Track one piece of state across iterations:
    explicitly ask you to retry before starting another cycle.
 4. If the findings list is empty (for either mode), tell the operator
    the review is clean and exit. Do not loop further.
-5. If `CYCLE > 1`, emit this reminder to the operator verbatim, before
-   the triage table:
+5. If `CYCLE > 1`, emit this reminder to the operator before the
+   triage table, substituting *N* with the current value of `CYCLE`:
    > This is review cycle *N*. Before applying fixes, check whether the new
    > findings are caused by your previous fixes or are genuinely different
    > issues. If the bot keeps re-flagging the same `fix_ref` across cycles,
@@ -112,8 +112,10 @@ Track one piece of state across iterations:
 
 Exit the loop (and tell the operator *why*) whenever any of these hold:
 
-- The findings list comes back empty **and** `conclusion` is healthy
-  (`success`, `neutral`, or absent) — normal success.
+- **PR mode**: the findings list comes back empty and `conclusion` is
+  healthy (`success` or `neutral`) — normal success.
+- **Local mode**: the findings list comes back empty — normal success.
+  (There is no `conclusion` field in local mode; its absence is expected.)
 - The operator chose "Skip this cycle" or "Abort".
 - The CLI errors out (network failure, no PR detected, timeout on
   `--watch`). Surface the error verbatim and stop.

--- a/internal/skills/codecanary-loop/SKILL.md
+++ b/internal/skills/codecanary-loop/SKILL.md
@@ -51,48 +51,52 @@ Track one piece of state across iterations:
      The command blocks until the review check completes; its stdout is
      a single JSON object. Parse it. Deduplication is handled by GitHub
      thread resolution — resolved threads are excluded by default.
+     Note: findings the operator previously skipped (via "Skip this
+     cycle" or "Apply some") will re-appear if their threads are still
+     open. This is intentional — skipped findings are deferred, not
+     dismissed.
    - **Local mode**: run `codecanary review --output json`. The command
      runs the review inline; its stdout is a JSON object with a
      `findings` array in the same shape.
 3. **PR mode only** — check the `conclusion` field in the JSON output.
-   Local mode does not have a check run, so skip only this conclusion
-   check and proceed to the findings-empty check at the end of this
-   step.
-   If `conclusion` is `failure`
-   (or any value other than `success` / `neutral` / empty), the review
-   run itself broke. Tell the operator the check failed and stop. Do
-   not say the review is clean, even if `findings` is empty — an empty
-   list on a failed run means findings were never published, not that
-   the code is fine. Do not count this as a cycle (roll `CYCLE` back).
-   Wait for the operator to explicitly ask you to retry before
-   starting another cycle.
-   If the findings list is empty (for either mode), tell the operator
+   (Skip this step entirely for local mode — there is no check run.)
+   If `conclusion` is `failure`, the review run itself broke. If
+   `conclusion` is `cancelled` or `timed_out`, the run was interrupted
+   (e.g. a newer push superseded it). In any of these cases — or any
+   value other than `success` / `neutral` / empty — tell the operator
+   the check failed, name the conclusion, and stop. Do not say the
+   review is clean, even if `findings` is empty — an empty list on a
+   failed run means findings were never published, not that the code
+   is fine. Roll `CYCLE` back by one (`CYCLE = CYCLE - 1`) so the
+   next retry starts at the correct count. Wait for the operator to
+   explicitly ask you to retry before starting another cycle.
+4. If the findings list is empty (for either mode), tell the operator
    the review is clean and exit. Do not loop further.
-4. If `CYCLE > 1`, emit this reminder to the operator verbatim, before
+5. If `CYCLE > 1`, emit this reminder to the operator verbatim, before
    the triage table:
    > This is review cycle *N*. Before applying fixes, check whether the new
    > findings are caused by your previous fixes or are genuinely different
    > issues. If the bot keeps re-flagging the same `fix_ref` across cycles,
    > stop and verify your fix actually addresses what the bot meant —
    > don't keep patching symptoms.
-5. Render a triage table (Markdown) summarizing the findings:
+6. Render a triage table (Markdown) summarizing the findings:
    - Columns: severity, file:line, fix_ref, title, proposed action
    - One row per finding. Keep proposed actions terse (one line each).
-6. Ask the operator to confirm. Use `AskUserQuestion` with a single
+7. Ask the operator to confirm. Use `AskUserQuestion` with a single
    question whose options are:
    - "Apply all" *(Recommended)*
    - "Apply some (I'll specify which)"
    - "Skip this cycle" — treats all findings as deferred; exits the loop
    - "Abort" — exits the loop immediately
    Wait for the response before touching any files.
-7. If the operator approved (all or some), apply the fixes. For each
+8. If the operator approved (all or some), apply the fixes. For each
    approved finding:
    - Read the file, make the minimal edit that addresses the finding,
      keeping the surrounding code intact (do not "improve" unrelated code).
    - If the suggestion in the finding is an exact code snippet and fits
      the context, prefer it verbatim; otherwise adapt it to the codebase
      conventions (existing imports, types, error-handling style).
-8. Finalize the cycle:
+9. Finalize the cycle:
    - **PR mode**:
      - Run `go build ./...` and `go test ./...` if any Go files changed.
      - Commit with a message like:
@@ -115,7 +119,7 @@ Exit the loop (and tell the operator *why*) whenever any of these hold:
   `--watch`). Surface the error verbatim and stop.
 - You detect you're in a stable disagreement loop: the same `fix_ref`
   values appear in two consecutive cycles after you applied fixes for
-  them. This is the signal from step 4 turning into a hard stop — tell
+  them. This is the signal from step 5 turning into a hard stop — tell
   the operator which fix_refs keep re-emerging and ask them to review
   whether the fix is correct before continuing.
 

--- a/internal/skills/codecanary-loop/SKILL.md
+++ b/internal/skills/codecanary-loop/SKILL.md
@@ -57,8 +57,9 @@ Track two pieces of state across iterations:
      runs the review inline; its stdout is a JSON object with a
      `findings` array in the same shape.
 3. **PR mode only** — check the `conclusion` field in the JSON output.
-   Local mode does not have a check run, so skip this step and go
-   straight to the findings-empty check below.
+   Local mode does not have a check run, so skip only this conclusion
+   check and proceed to the findings-empty check at the end of this
+   step.
    If `conclusion` is `failure`
    (or any value other than `success` / `neutral` / empty), the review
    run itself broke. Tell the operator the check failed and stop. Do
@@ -67,8 +68,8 @@ Track two pieces of state across iterations:
    the code is fine. Do not count this as a cycle (roll `CYCLE` back).
    Wait for the operator to explicitly ask you to retry before
    starting another cycle.
-   If `conclusion` is healthy and the findings list is empty, tell the
-   operator the review is clean and exit. Do not loop further.
+   If the findings list is empty (for either mode), tell the operator
+   the review is clean and exit. Do not loop further.
 4. If `CYCLE > 1`, emit this reminder to the operator verbatim, before
    the triage table:
    > This is review cycle *N*. Before applying fixes, check whether the new


### PR DESCRIPTION
## Summary
- The codecanary-loop skill now inspects the `conclusion` field before declaring a review clean — a `failure` conclusion is reported as a failure even if `findings` is empty (findings were never published, not "no issues found")
- Failed runs don't count as a cycle and require the operator to explicitly retry
- Removed the `--since-commit` flag from `codecanary findings` (both CLI and skill) — it was actively hiding new findings by filtering out findings anchored on the just-pushed commit. Deduplication is already handled by GitHub thread resolution
- Clarified that the conclusion check applies to PR mode only (local mode has no check run)

## Test plan
- [x] `go test ./...` — all tests pass
- [x] `go build ./cmd/review` — builds cleanly
- [x] `go vet ./cmd/review/...` — no issues
- [x] Skills parity test (`go test ./internal/skills/`) — both copies identical
- [ ] Run the skill on a PR where the review check fails — verify it reports failure and waits for retry
- [ ] Run the skill on a PR with findings — verify all findings surface (no silent filtering)