### PR TITLE
fix: remove --local from docs and add --base flag to review command

### DIFF
--- a/.claude/skills/codecanary-loop/SKILL.md
+++ b/.claude/skills/codecanary-loop/SKILL.md
@@ -3,10 +3,10 @@ name: codecanary-loop
 description: |
   Drive a codecanary review → triage → fix → push feedback loop to convergence.
   Defaults to PR mode (watches the codecanary GitHub action, fetches findings,
-  applies approved fixes, commits, pushes, and re-watches). Pass `--local` to
-  run a local review against uncommitted changes instead, skipping all git
-  plumbing. Always confirms every finding with the user before applying —
-  never auto-applies.
+  applies approved fixes, commits, pushes, and re-watches). Falls back to
+  local mode automatically when no PR is detected, reviewing uncommitted
+  changes and skipping all git plumbing. Always confirms every finding with
+  the user before applying — never auto-applies.
 ---
 
 # codecanary-loop
@@ -31,8 +31,8 @@ is spent on triage judgment and fix application, not on watching CI.
 
 - **PR mode (default)**: fixes land as commits on the current branch and
   are pushed. Used when an open PR exists for the branch.
-- **Local mode** — invoked when the operator passes `--local` as an argument
-  to this skill: `codecanary review --output json` runs a review on the
+- **Local mode** — activated automatically when no PR is detected for the
+  current branch: `codecanary review --output json` runs a review on the
   current dirty working tree; fixes are applied but not committed or pushed.
 
 If you cannot tell which mode applies, ask the operator before starting.

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ This writes the embedded skill to `~/.claude/skills/codecanary-loop/SKILL.md`, w
 Then in Claude Code, ask it to handle the codecanary review on your PR — the skill is auto-discovered and matched to your request via its frontmatter description. Two modes:
 
 - **PR mode** (default) — watches the GitHub Actions review check via `codecanary findings --watch`, renders a triage table, asks you to confirm which fixes to apply, commits and pushes, then loops on the next review.
-- **Local mode** — ask for a local pass (or mention `--local`). Single pass against your dirty working tree. Applies approved fixes without committing or pushing.
+- **Local mode** — triggered automatically when no PR is detected for the current branch. Single pass against your dirty working tree. Applies approved fixes without committing or pushing.
 
 The full skill contract lives at [internal/skills/codecanary-loop/SKILL.md](internal/skills/codecanary-loop/SKILL.md).
 

--- a/cmd/review/cli/review.go
+++ b/cmd/review/cli/review.go
@@ -30,6 +30,9 @@ var reviewCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("invalid PR number %q: %w", args[0], err)
 			}
+			if baseBranch != "" {
+				review.Stderrf(review.ColorYellow, "Warning: --base ignored in PR mode\n")
+			}
 			return review.Run(review.RunOptions{
 				Repo:       repo,
 				PRNumber:   prNumber,
@@ -53,6 +56,9 @@ var reviewCmd = &cobra.Command{
 		// Try auto-detecting PR from current branch.
 		if prNumber, err := review.DetectPRNumber(repo); err == nil {
 			review.Stderrf(review.ColorCyan, "Auto-detected PR #%d from current branch\n", prNumber)
+			if baseBranch != "" {
+				review.Stderrf(review.ColorYellow, "Warning: --base ignored in PR mode\n")
+			}
 			return review.Run(review.RunOptions{
 				Repo:       repo,
 				PRNumber:   prNumber,

--- a/cmd/review/cli/review.go
+++ b/cmd/review/cli/review.go
@@ -22,6 +22,7 @@ var reviewCmd = &cobra.Command{
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		replyOnly, _ := cmd.Flags().GetBool("reply-only")
 		claudePath, _ := cmd.Flags().GetString("claude-path")
+		baseBranch, _ := cmd.Flags().GetString("base")
 
 		// Explicit PR number — GitHub mode.
 		if len(args) > 0 {
@@ -73,7 +74,7 @@ var reviewCmd = &cobra.Command{
 		}
 
 		// No PR — local mode.
-		pr, err := review.FetchLocalDiff()
+		pr, err := review.FetchLocalDiff(baseBranch)
 		if err != nil {
 			return fmt.Errorf("no PR found and local diff failed: %w", err)
 		}
@@ -112,6 +113,7 @@ func init() {
 	reviewCmd.Flags().StringP("config", "c", "", "Path to review config (auto-detected if empty)")
 	reviewCmd.Flags().Bool("reply-only", false, "Evaluate thread replies only, skip new findings")
 	reviewCmd.Flags().String("claude-path", "", "Path to the Claude CLI binary (overrides config claude_path)")
+	reviewCmd.Flags().StringP("base", "b", "", "Base branch for local review (auto-detected if empty)")
 	reviewCmd.PersistentFlags().Bool("dry-run", false, "Show prompt without running Claude")
 	rootCmd.AddCommand(reviewCmd)
 }

--- a/internal/review/local.go
+++ b/internal/review/local.go
@@ -7,12 +7,16 @@ import (
 	"strings"
 )
 
-// FetchLocalDiff computes a diff of the current branch against the default
-// branch and returns a PRData suitable for review without a GitHub PR.
-func FetchLocalDiff() (*PRData, error) {
-	base := detectDefaultBranch()
+// FetchLocalDiff computes a diff of the current branch against the given base
+// branch and returns a PRData suitable for review without a GitHub PR. If
+// baseBranch is empty, it auto-detects main or master.
+func FetchLocalDiff(baseBranch string) (*PRData, error) {
+	base := baseBranch
 	if base == "" {
-		return nil, fmt.Errorf("could not detect default branch (tried main, master)")
+		base = detectDefaultBranch()
+		if base == "" {
+			return nil, fmt.Errorf("could not detect default branch (tried main, master); use --base to specify one")
+		}
 	}
 
 	head, err := currentBranch()

--- a/internal/skills/codecanary-loop/SKILL.md
+++ b/internal/skills/codecanary-loop/SKILL.md
@@ -3,10 +3,10 @@ name: codecanary-loop
 description: |
   Drive a codecanary review → triage → fix → push feedback loop to convergence.
   Defaults to PR mode (watches the codecanary GitHub action, fetches findings,
-  applies approved fixes, commits, pushes, and re-watches). Pass `--local` to
-  run a local review against uncommitted changes instead, skipping all git
-  plumbing. Always confirms every finding with the user before applying —
-  never auto-applies.
+  applies approved fixes, commits, pushes, and re-watches). Falls back to
+  local mode automatically when no PR is detected, reviewing uncommitted
+  changes and skipping all git plumbing. Always confirms every finding with
+  the user before applying — never auto-applies.
 ---
 
 # codecanary-loop
@@ -31,8 +31,8 @@ is spent on triage judgment and fix application, not on watching CI.
 
 - **PR mode (default)**: fixes land as commits on the current branch and
   are pushed. Used when an open PR exists for the branch.
-- **Local mode** — invoked when the operator passes `--local` as an argument
-  to this skill: `codecanary review --output json` runs a review on the
+- **Local mode** — activated automatically when no PR is detected for the
+  current branch: `codecanary review --output json` runs a review on the
   current dirty working tree; fixes are applied but not committed or pushed.
 
 If you cannot tell which mode applies, ask the operator before starting.


### PR DESCRIPTION


  ---
  Summary

  - Removed references to the non-existent --local flag from documentation (README, skill files). Local mode is triggered automatically when no PR is detected — there was never a --local CLI flag.
  - Added --base / -b flag to codecanary review so users can explicitly specify which branch to diff against in local mode (e.g., codecanary review --base master). When omitted, auto-detection (main →
  master) still applies.

  Changed files

  - README.md — updated local mode description
  - internal/skills/codecanary-loop/SKILL.md — updated frontmatter and mode selection docs
  - .claude/skills/codecanary-loop/SKILL.md — synced with canonical copy
  - cmd/review/cli/review.go — added --base flag, pass it to FetchLocalDiff
  - internal/review/local.go — FetchLocalDiff accepts optional base branch parameter

  Test plan

  - go build ./cmd/review succeeds
  - go test ./... passes (including skill parity test)
  - codecanary review --help shows the new --base flag
  - codecanary review --base master runs a local review against master
  - codecanary review (no --base) still auto-detects main/master