### PR TITLE
feat: add Grok (xAI) as an LLM provider

### DIFF
--- a/internal/review/provider_grok.go
+++ b/internal/review/provider_grok.go
@@ -12,12 +12,17 @@ func init() {
 		New:      newGrokProvider,
 		Validate: validateGrok,
 		Pricing: []PricingEntry{
-			// More-specific substrings first (grok-4-1-fast before grok-4).
+			// xAI uses two naming conventions: dot-separated for the flagship
+			// family (grok-4.20-*) and hyphen-separated for the fast tier
+			// (grok-4-1-fast-*). Both are correct per the xAI API docs.
+			// More-specific substrings must come before the grok-4 catch-all.
 			{"grok-4-1-fast", modelPricing{0.20, 0.50, 0.20, 0.05}},
+			{"grok-4.20", modelPricing{2, 6, 2, 0.20}},
 			{"grok-4", modelPricing{2, 6, 2, 0.20}},
 		},
 		MaxOutputTokens: []MaxTokensEntry{
 			{"grok-4-1-fast", 131_072},
+			{"grok-4.20", 131_072},
 			{"grok-4", 131_072},
 		},
 		SuggestedReviewModel: "grok-4.20-0309-non-reasoning",
@@ -26,8 +31,8 @@ func init() {
 }
 
 func validateGrok(mc *ModelConfig) error {
-	if mc.APIBase != "" {
-		return fmt.Errorf("api_base is not supported by the grok provider")
+	if mc.APIBase != "" && !isValidURL(mc.APIBase) {
+		return fmt.Errorf("invalid api_base %q: must be an HTTP(S) URL", mc.APIBase)
 	}
 	return nil
 }
@@ -35,17 +40,22 @@ func validateGrok(mc *ModelConfig) error {
 // grokProvider implements ModelProvider for the xAI Grok API.
 // Grok uses the OpenAI-compatible chat completions format.
 type grokProvider struct {
-	model  string
-	keyEnv string
-	env    []string
+	model   string
+	apiBase string
+	keyEnv  string
+	env     []string
 }
 
 func newGrokProvider(mc *ModelConfig, env []string) ModelProvider {
+	apiBase := "https://api.x.ai/v1"
+	if mc.APIBase != "" {
+		apiBase = mc.APIBase
+	}
 	keyEnv := credentials.EnvVar
 	if mc.APIKeyEnv != "" {
 		keyEnv = mc.APIKeyEnv
 	}
-	return &grokProvider{model: mc.Model, keyEnv: keyEnv, env: env}
+	return &grokProvider{model: mc.Model, apiBase: apiBase, keyEnv: keyEnv, env: env}
 }
 
 func (p *grokProvider) Run(ctx context.Context, prompt string, opts RunOpts) (*providerResult, error) {
@@ -54,7 +64,7 @@ func (p *grokProvider) Run(ctx context.Context, prompt string, opts RunOpts) (*p
 		return nil, fmt.Errorf("API key not found: set %s or run `codecanary setup local`", p.keyEnv)
 	}
 
-	chatResp, durationMS, truncated, err := doChat(ctx, "https://api.x.ai/v1", apiKey, p.model, prompt, opts.Timeout)
+	chatResp, durationMS, truncated, err := doChat(ctx, p.apiBase, apiKey, p.model, prompt, opts.Timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/review/provider_grok.go
+++ b/internal/review/provider_grok.go
@@ -1,0 +1,63 @@
+package review
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/alansikora/codecanary/internal/credentials"
+)
+
+func init() {
+	providers["grok"] = ProviderFactory{
+		New:      newGrokProvider,
+		Validate: validateGrok,
+		Pricing: []PricingEntry{
+			// More-specific substrings first (grok-4-1-fast before grok-4).
+			{"grok-4-1-fast", modelPricing{0.20, 0.50, 0.20, 0.05}},
+			{"grok-4", modelPricing{2, 6, 2, 0.20}},
+		},
+		MaxOutputTokens: []MaxTokensEntry{
+			{"grok-4-1-fast", 131_072},
+			{"grok-4", 131_072},
+		},
+		SuggestedReviewModel: "grok-4.20-0309-non-reasoning",
+		SuggestedTriageModel: "grok-4-1-fast-non-reasoning",
+	}
+}
+
+func validateGrok(mc *ModelConfig) error {
+	if mc.APIBase != "" {
+		return fmt.Errorf("api_base is not supported by the grok provider")
+	}
+	return nil
+}
+
+// grokProvider implements ModelProvider for the xAI Grok API.
+// Grok uses the OpenAI-compatible chat completions format.
+type grokProvider struct {
+	model  string
+	keyEnv string
+	env    []string
+}
+
+func newGrokProvider(mc *ModelConfig, env []string) ModelProvider {
+	keyEnv := credentials.EnvVar
+	if mc.APIKeyEnv != "" {
+		keyEnv = mc.APIKeyEnv
+	}
+	return &grokProvider{model: mc.Model, keyEnv: keyEnv, env: env}
+}
+
+func (p *grokProvider) Run(ctx context.Context, prompt string, opts RunOpts) (*providerResult, error) {
+	apiKey := lookupEnvVar(p.env, p.keyEnv)
+	if apiKey == "" {
+		return nil, fmt.Errorf("API key not found: set %s or run `codecanary setup local`", p.keyEnv)
+	}
+
+	chatResp, durationMS, truncated, err := doChat(ctx, "https://api.x.ai/v1", apiKey, p.model, prompt, opts.Timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	return chatResultFromResponse(p.model, chatResp, durationMS, truncated), nil
+}

--- a/internal/setup/forms.go
+++ b/internal/setup/forms.go
@@ -42,6 +42,7 @@ func SelectProvider() (string, error) {
 				Options(
 					huh.NewOption("Anthropic", "anthropic"),
 					huh.NewOption("OpenAI", "openai"),
+					huh.NewOption("Grok (xAI)", "grok"),
 					huh.NewOption("OpenRouter", "openrouter"),
 					huh.NewOption("Claude CLI", "claude"),
 				).
@@ -446,6 +447,13 @@ func triageModelOptions(provider string) []huh.Option[string] {
 			huh.NewOption("gpt-5.4-mini", "gpt-5.4-mini"),
 			huh.NewOption("gpt-5.4", "gpt-5.4"),
 		}
+	case "grok":
+		return []huh.Option[string]{
+			huh.NewOption("grok-4-1-fast-non-reasoning", "grok-4-1-fast-non-reasoning"),
+			huh.NewOption("grok-4-1-fast-reasoning", "grok-4-1-fast-reasoning"),
+			huh.NewOption("grok-4.20-0309-non-reasoning", "grok-4.20-0309-non-reasoning"),
+			huh.NewOption("grok-4.20-0309-reasoning", "grok-4.20-0309-reasoning"),
+		}
 	case "openrouter":
 		return []huh.Option[string]{
 			huh.NewOption("anthropic/claude-haiku-4-5-20251001", "anthropic/claude-haiku-4-5-20251001"),
@@ -476,6 +484,13 @@ func modelOptions(provider string) []huh.Option[string] {
 		return []huh.Option[string]{
 			huh.NewOption("gpt-5.4", "gpt-5.4"),
 			huh.NewOption("gpt-5.4-mini", "gpt-5.4-mini"),
+		}
+	case "grok":
+		return []huh.Option[string]{
+			huh.NewOption("grok-4.20-0309-non-reasoning", "grok-4.20-0309-non-reasoning"),
+			huh.NewOption("grok-4.20-0309-reasoning", "grok-4.20-0309-reasoning"),
+			huh.NewOption("grok-4-1-fast-non-reasoning", "grok-4-1-fast-non-reasoning"),
+			huh.NewOption("grok-4-1-fast-reasoning", "grok-4-1-fast-reasoning"),
 		}
 	case "openrouter":
 		return []huh.Option[string]{

--- a/internal/setup/guidance.go
+++ b/internal/setup/guidance.go
@@ -11,6 +11,8 @@ func ProviderGuidance(provider string) string {
 		return "Get your API key at console.anthropic.com"
 	case "openai":
 		return "Get your API key at platform.openai.com"
+	case "grok":
+		return "Get your API key at console.x.ai"
 	case "openrouter":
 		return "Get your API key at openrouter.ai"
 	case "claude":

--- a/internal/setup/validate.go
+++ b/internal/setup/validate.go
@@ -101,12 +101,10 @@ func validateOpenAI(apiKey string) error {
 }
 
 func validateGrokKey(apiKey string) error {
-	body := `{"model":"grok-4-1-fast-non-reasoning","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}`
-	req, err := http.NewRequest("POST", "https://api.x.ai/v1/chat/completions", strings.NewReader(body))
+	req, err := http.NewRequest("GET", "https://api.x.ai/v1/models", nil)
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 
 	resp, err := doValidationRequest(req)
@@ -115,6 +113,9 @@ func validateGrokKey(apiKey string) error {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode == 403 {
+		return fmt.Errorf("API key does not have permission (403 Forbidden)")
+	}
 	if resp.StatusCode >= 200 && resp.StatusCode < 500 {
 		return nil
 	}

--- a/internal/setup/validate.go
+++ b/internal/setup/validate.go
@@ -16,6 +16,8 @@ func ValidateAPIKey(provider, apiKey string) error {
 		return validateAnthropic(apiKey)
 	case "openai":
 		return validateOpenAI(apiKey)
+	case "grok":
+		return validateGrokKey(apiKey)
 	case "openrouter":
 		return validateOpenRouter(apiKey)
 	case "claude":
@@ -96,6 +98,27 @@ func validateOpenAI(apiKey string) error {
 		return nil
 	}
 	return fmt.Errorf("unexpected status %d from OpenAI API", resp.StatusCode)
+}
+
+func validateGrokKey(apiKey string) error {
+	body := `{"model":"grok-4-1-fast-non-reasoning","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}`
+	req, err := http.NewRequest("POST", "https://api.x.ai/v1/chat/completions", strings.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := doValidationRequest(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 500 {
+		return nil
+	}
+	return fmt.Errorf("unexpected status %d from xAI API", resp.StatusCode)
 }
 
 func validateOpenRouter(apiKey string) error {


### PR DESCRIPTION
## Summary

- Add xAI's Grok as a new provider via their OpenAI-compatible API (`https://api.x.ai/v1`)
- Reuses `doChat`/`chatResultFromResponse` from `provider_compat.go` — no new HTTP logic
- Suggested defaults: `grok-4.20-0309-non-reasoning` (review) and `grok-4-1-fast-non-reasoning` (triage), with reasoning variants available as options
- Includes pricing, max output tokens, setup wizard integration, and API key validation

## Files changed

- `internal/review/provider_grok.go` — new provider adapter with factory registration
- `internal/setup/forms.go` — add Grok to provider selector and model dropdowns
- `internal/setup/guidance.go` — add credential guidance for console.x.ai
- `internal/setup/validate.go` — add API key validation via test call

## Test plan

- [ ] `go build ./cmd/review` compiles
- [ ] `go test ./...` passes
- [ ] `golangci-lint run ./...` clean
- [ ] `codecanary setup local` shows Grok option and completes with a valid xAI key
- [ ] `codecanary review` produces a review using grok-4.20 models