### PR TITLE
docs: advertise Grok (xAI) provider in README and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ That's it. CodeCanary diffs your branch against main and reviews the changes loc
 ## Why CodeCanary?
 
 - **Fully automated** — runs as a GitHub Action on every push, or locally from the terminal.
-- **Multi-provider** — bring your own LLM: Anthropic, OpenAI, OpenRouter, or Claude CLI. No vendor lock-in.
+- **Multi-provider** — bring your own LLM: Anthropic, OpenAI, OpenRouter, Grok (xAI), or Claude CLI. No vendor lock-in.
 - **Incremental reviews** — on re-push, Go-driven triage classifies existing threads at zero LLM cost. Only changed code gets re-evaluated.
 - **Conversational** — when authors reply to a finding, CodeCanary re-evaluates in context. It distinguishes code fixes, dismissals, acknowledgments, and rebuttals.
 - **Native PR integration** — posts inline comments on exact diff lines, auto-resolves threads when code is fixed, and minimizes stale reviews.
@@ -164,6 +164,14 @@ review_model: anthropic/claude-sonnet-4-6
 triage_model: anthropic/claude-haiku-4-5-20251001
 ```
 
+**Grok (xAI)**:
+```yaml
+version: 1
+provider: grok
+review_model: grok-4.20-0309-non-reasoning
+triage_model: grok-4-1-fast-non-reasoning
+```
+
 **Claude CLI** (uses your logged-in `claude` session, no API key needed):
 ```yaml
 version: 1
@@ -191,6 +199,7 @@ Keys are stored in your system keychain (macOS Keychain, GNOME Keyring, KDE Wall
 | Anthropic | API key | [console.anthropic.com](https://console.anthropic.com) |
 | OpenAI | API key | [platform.openai.com](https://platform.openai.com) |
 | OpenRouter | API key | [openrouter.ai](https://openrouter.ai) |
+| Grok (xAI) | API key | [console.x.ai](https://console.x.ai) |
 | Claude CLI | Logged-in `claude` binary | Run `claude` and complete the login flow |
 
 ## How It Works

--- a/website/index.html
+++ b/website/index.html
@@ -482,29 +482,21 @@
       font-size: 12px;
       color: var(--text-muted);
     }
-    .provider-wide {
-      grid-column: span 2;
+    .provider-cta {
       background: var(--bg-card);
-      border: 1px solid var(--border);
+      border: 1px dashed var(--border);
       border-radius: 10px;
-      padding: 24px 28px;
-      text-align: left;
+      padding: 24px;
+      text-align: center;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       transition: border-color 0.2s ease;
-    }
-    .provider-wide:hover { border-color: var(--border-hover); }
-    .provider-wide .wide-label {
+      text-decoration: none;
+      color: var(--accent);
       font-size: 14px;
-      color: var(--text-muted);
-      margin-bottom: 12px;
     }
-    .provider-wide pre {
-      font-size: 13px;
-      line-height: 1.6;
-      margin-bottom: 12px;
-    }
-    .provider-wide .wide-link {
-      font-size: 13px;
-    }
+    .provider-cta:hover { border-color: var(--border-hover); text-decoration: none; }
 
     /* --- CTA --- */
     .cta-section {
@@ -576,7 +568,6 @@
       .features-grid { grid-template-columns: 1fr; }
       .steps { grid-template-columns: 1fr; }
       .providers-grid { grid-template-columns: 1fr; }
-      .provider-wide { grid-column: span 1; }
     }
   </style>
 </head>
@@ -678,7 +669,7 @@
         <div class="feature-card">
           <span class="feature-icon">&#128268;</span>
           <h3>Multi-provider</h3>
-          <p>Bring your own LLM: Anthropic, OpenAI, OpenRouter, or Claude CLI. No vendor lock-in. New providers are easy to add.</p>
+          <p>Bring your own LLM: Anthropic, OpenAI, OpenRouter, Grok (xAI), or Claude CLI. No vendor lock-in. New providers are easy to add.</p>
         </div>
         <div class="feature-card">
           <span class="feature-icon">&#10003;</span>
@@ -806,16 +797,15 @@
           <div class="provider-name">OpenRouter</div>
           <div class="provider-desc">Any model via OpenRouter</div>
         </div>
-        <div class="provider-wide">
-          <div class="wide-label">Switching providers? Change two lines:</div>
-          <pre><span class="key">provider:</span> <span class="val">openai</span>
-<span class="key">review_model:</span> <span class="val">gpt-5.4</span></pre>
-          <a href="https://github.com/alansikora/codecanary/blob/main/CONTRIBUTING.md" class="wide-link" target="_blank" rel="noopener">Adding a new provider &rarr;</a>
+        <div class="provider-card">
+          <div class="provider-name">Grok (xAI)</div>
+          <div class="provider-desc">Grok 4.20, Grok 4.1 Fast</div>
         </div>
         <div class="provider-card">
           <div class="provider-name">Claude CLI</div>
           <div class="provider-desc">Use your logged-in session, no API key needed</div>
         </div>
+        <a href="https://github.com/alansikora/codecanary/blob/main/CONTRIBUTING.md" class="provider-cta" target="_blank" rel="noopener">Adding a new provider &rarr;</a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary

- Add Grok (xAI) to the README provider list, config examples, and the credential table (points to `console.x.ai`).
- Add a Grok card to the website providers grid and update the multi-provider feature blurb.
- Replace the wide "Switching providers? Change two lines" block with a dashed-border "Adding a new provider →" CTA card in the empty 6th grid slot — simpler layout, clearer invite to contribute a new provider.

Context: #150 added Grok as a provider but left the public-facing docs (README + marketing site) advertising only Anthropic, OpenAI, OpenRouter, and Claude CLI.

## Test plan

- [ ] Open `website/index.html` locally and verify the providers section shows 6 cards in a 3×2 grid: Anthropic, OpenAI, OpenRouter / Grok (xAI), Claude CLI, Adding a new provider →
- [ ] Verify the CTA card has a dashed border and links to CONTRIBUTING.md
- [ ] Verify mobile layout (< 640px) collapses the grid to a single column
- [ ] Verify the README renders correctly on GitHub and the new Grok config example / credential-table row are present