### PR TITLE
fix: strip Claude CLI stdout noise before JSON parsing

### DIFF
--- a/internal/review/provider_claude.go
+++ b/internal/review/provider_claude.go
@@ -1,6 +1,7 @@
 package review
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -132,6 +133,14 @@ func (p *claudeCLIProvider) Run(ctx context.Context, prompt string, opts RunOpts
 			return nil, fmt.Errorf("claude failed: %s\n%s", string(exitErr.Stderr), string(output))
 		}
 		return nil, fmt.Errorf("running claude: %w", err)
+	}
+
+	// The Claude CLI may print non-JSON status lines (e.g. status-line UI) to
+	// stdout before the JSON envelope. Strip any leading lines that don't start
+	// the JSON object so json.Unmarshal sees only the JSON payload.
+	jsonStart := bytes.IndexByte(output, '{')
+	if jsonStart > 0 {
+		output = output[jsonStart:]
 	}
 
 	var resp claudeJSONResponse

--- a/internal/review/provider_claude.go
+++ b/internal/review/provider_claude.go
@@ -136,16 +136,18 @@ func (p *claudeCLIProvider) Run(ctx context.Context, prompt string, opts RunOpts
 	}
 
 	// The Claude CLI may print non-JSON status lines (e.g. status-line UI) to
-	// stdout before the JSON envelope. Strip any leading lines that don't start
-	// the JSON object so json.Unmarshal sees only the JSON payload.
-	jsonStart := bytes.IndexByte(output, '{')
-	if jsonStart > 0 {
-		output = output[jsonStart:]
+	// stdout before or after the JSON envelope. Seek to the first '{' to skip
+	// any leading noise, then use a json.Decoder which stops after the first
+	// complete value — tolerating any trailing noise as well.
+	// Preserve the original output for the plain-text fallback.
+	jsonOutput := output
+	if i := bytes.IndexByte(output, '{'); i > 0 {
+		jsonOutput = output[i:]
 	}
 
 	var resp claudeJSONResponse
-	if err := json.Unmarshal(output, &resp); err != nil {
-		// Fallback: treat entire output as plain text (e.g. older CLI version).
+	if err := json.NewDecoder(bytes.NewReader(jsonOutput)).Decode(&resp); err != nil {
+		// Fallback: treat entire original output as plain text (e.g. older CLI version).
 		return &providerResult{Text: string(output)}, nil
 	}
 


### PR DESCRIPTION
## Summary

- The Claude CLI (or a custom status-line helper) can print UI text to stdout (e.g. workspace name, last session info) before the JSON response payload when invoked with `--print`
- This caused `json.Unmarshal` to fail on the prefixed output, triggering the plain-text fallback — which passed the entire raw blob (status lines + JSON envelope) to `ParseFindings`
- `ParseFindings` then couldn't find the expected ` ```json ` fence (it's inside `resp.result`, not at the top level), returning: `parsing findings: no ```json code fence found in output`
- Fix: seek to the first `{` in stdout before unmarshaling, stripping any non-JSON prefix
  
## Files changed

- `internal/review/provider_claude.go` — skip leading non-JSON bytes before unmarshaling the Claude CLI response

## Test plan

- [x] `go build ./cmd/review` compiles
- [x] `go vet ./...` clean
- [ ] `codecanary review --output terminal` on a branch with local changes produces findings instead of a parse error
