### PR TITLE
fix: disallow /install in robots.txt to prevent GSC redirect warning

### DIFF
--- a/website/robots.txt
+++ b/website/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
+Disallow: /install
 
 Sitemap: https://codecanary.sh/sitemap.xml


### PR DESCRIPTION
## Summary
- Google Search Console flagged `/install` as "Page with redirect" because it's a 302 redirect to the raw install script on GitHub
- Added `Disallow: /install` to `robots.txt` so Google stops trying to index the redirect path

## Test plan
- [ ] Verify robots.txt is served correctly after deploy (`curl https://codecanary.sh/robots.txt`)
- [ ] Request re-validation in Google Search Console after deploy