### PR TITLE
fix: advance incremental baseline on clean and all-clear reviews

### DIFF
--- a/docs/review-flow.md
+++ b/docs/review-flow.md
@@ -53,7 +53,7 @@ Each provider is constructed via the factory registry in `provider.go`. The prov
 
 The platform adapter loads unresolved findings from the last review:
 
-**GitHub CI**: Fetches review threads via GraphQL. Filters to CodeCanary findings only (detected by HTML marker comments). Extracts the previous review's HEAD SHA from the most recent review body. Returns unresolved threads, the SHA, and a count for fix_ref numbering.
+**GitHub CI**: Fetches review threads via GraphQL. Filters to CodeCanary findings only (detected by HTML marker comments). Extracts the previous review's HEAD SHA from the most recent review body — clean and all-clear reviews embed this marker too, so the baseline advances even when a push produced no findings. Returns unresolved threads, the SHA, and a count for fix_ref numbering.
 
 **Local modes**: Reads `~/.codecanary/state/<branch>.json`, which stores the SHA, branch name, and findings array from the previous review. Converts saved findings into `ReviewThread` shape for the triage pipeline.
 
@@ -61,7 +61,7 @@ If no previous findings exist, this is a first review.
 
 ### 5. Triage and build prompt
 
-This step diverges based on whether previous findings exist.
+This step diverges based on whether a previous review SHA exists. A previous SHA alone is enough to enter the incremental path — if previous findings were all resolved (no open threads), the incremental diff still scopes the review to commits since the last baseline, avoiding a redundant full re-review.
 
 #### First review path
 

--- a/internal/review/github.go
+++ b/internal/review/github.go
@@ -703,19 +703,43 @@ func GetIncrementalDiff(baseSHA string) (string, error) {
 	return string(out), nil
 }
 
-// PostCleanReview posts a review when the first review finds no issues.
-func PostCleanReview(repo string, prNumber int) error {
-	return postSimpleReview(repo, prNumber, "CodeCanary reviewed this PR \u2014 no issues found.")
+// PostCleanReview posts a review when the first review finds no issues. The
+// commitSHA is embedded in a hidden marker so future runs treat it as the
+// baseline for incremental reviews, avoiding a redundant full re-review on the
+// next push.
+func PostCleanReview(repo string, prNumber int, commitSHA string) error {
+	body := "CodeCanary reviewed this PR \u2014 no issues found."
+	body += embedBaselineMarker(repo, prNumber, commitSHA)
+	return postSimpleReview(repo, prNumber, body)
 }
 
-// PostAllClearReview posts a review when all previous findings have been resolved.
-// If minimizeFailed is true, a note is appended warning about visible old reviews.
-func PostAllClearReview(repo string, prNumber int, minimizeFailed bool) error {
+// PostAllClearReview posts a review when all previous findings have been
+// resolved. If minimizeFailed is true, a note is appended warning about
+// visible old reviews. The commitSHA is embedded in a hidden marker so future
+// runs treat it as the baseline for incremental reviews; without it, the next
+// push would fall back to reviewing the entire PR again.
+func PostAllClearReview(repo string, prNumber int, commitSHA string, minimizeFailed bool) error {
 	body := "## \U0001F425 CodeCanary\n\n\u2705 All previous findings have been addressed. No new issues found. \u2728"
 	if minimizeFailed {
 		body += "\n\n> \u26A0\uFE0F Some previous review comments could not be minimized and may still be visible."
 	}
+	body += embedBaselineMarker(repo, prNumber, commitSHA)
 	return postSimpleReview(repo, prNumber, body)
+}
+
+// embedBaselineMarker returns a hidden HTML comment containing the commitSHA
+// so FetchPreviousReviewSHA can use this review as the incremental baseline.
+// Returns an empty string if commitSHA is empty (local mode, dry run).
+func embedBaselineMarker(repo string, prNumber int, commitSHA string) string {
+	if commitSHA == "" {
+		return ""
+	}
+	result := ReviewResult{PRNumber: prNumber, Repo: repo, SHA: commitSHA}
+	data, err := json.Marshal(result)
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("\n\n%s%s%s\n", reviewMarkerPrefixes[0], string(data), reviewMarkerSuffix)
 }
 
 func postSimpleReview(repo string, prNumber int, body string) error {

--- a/internal/review/github.go
+++ b/internal/review/github.go
@@ -709,7 +709,7 @@ func GetIncrementalDiff(baseSHA string) (string, error) {
 // next push.
 func PostCleanReview(repo string, prNumber int, commitSHA string) error {
 	body := "CodeCanary reviewed this PR \u2014 no issues found."
-	body += embedBaselineMarker(repo, prNumber, commitSHA)
+	body += embedBaselineMarker(commitSHA)
 	return postSimpleReview(repo, prNumber, body)
 }
 
@@ -723,23 +723,26 @@ func PostAllClearReview(repo string, prNumber int, commitSHA string, minimizeFai
 	if minimizeFailed {
 		body += "\n\n> \u26A0\uFE0F Some previous review comments could not be minimized and may still be visible."
 	}
-	body += embedBaselineMarker(repo, prNumber, commitSHA)
+	body += embedBaselineMarker(commitSHA)
 	return postSimpleReview(repo, prNumber, body)
 }
 
 // embedBaselineMarker returns a hidden HTML comment containing the commitSHA
 // so FetchPreviousReviewSHA can use this review as the incremental baseline.
-// Returns an empty string if commitSHA is empty (local mode, dry run).
-func embedBaselineMarker(repo string, prNumber int, commitSHA string) string {
+// Returns an empty string if commitSHA is empty (local mode, dry run). The
+// marker carries only the SHA — FetchPreviousReviewSHA is the sole reader and
+// it only needs that field.
+func embedBaselineMarker(commitSHA string) string {
 	if commitSHA == "" {
 		return ""
 	}
-	result := ReviewResult{PRNumber: prNumber, Repo: repo, SHA: commitSHA}
-	data, err := json.Marshal(result)
+	data, err := json.Marshal(struct {
+		SHA string `json:"sha"`
+	}{SHA: commitSHA})
 	if err != nil {
 		return ""
 	}
-	return fmt.Sprintf("\n\n%s%s%s\n", reviewMarkerPrefixes[0], string(data), reviewMarkerSuffix)
+	return fmt.Sprintf("\n%s%s%s\n", reviewMarkerPrefixes[0], string(data), reviewMarkerSuffix)
 }
 
 func postSimpleReview(repo string, prNumber int, body string) error {

--- a/internal/review/github.go
+++ b/internal/review/github.go
@@ -708,9 +708,7 @@ func GetIncrementalDiff(baseSHA string) (string, error) {
 // baseline for incremental reviews, avoiding a redundant full re-review on the
 // next push.
 func PostCleanReview(repo string, prNumber int, commitSHA string) error {
-	body := "CodeCanary reviewed this PR \u2014 no issues found."
-	body += embedBaselineMarker(commitSHA)
-	return postSimpleReview(repo, prNumber, body)
+	return postSimpleReview(repo, prNumber, buildCleanReviewBody(commitSHA))
 }
 
 // PostAllClearReview posts a review when all previous findings have been
@@ -719,12 +717,24 @@ func PostCleanReview(repo string, prNumber int, commitSHA string) error {
 // runs treat it as the baseline for incremental reviews; without it, the next
 // push would fall back to reviewing the entire PR again.
 func PostAllClearReview(repo string, prNumber int, commitSHA string, minimizeFailed bool) error {
+	return postSimpleReview(repo, prNumber, buildAllClearReviewBody(commitSHA, minimizeFailed))
+}
+
+// buildCleanReviewBody renders the full Markdown body posted by
+// PostCleanReview. Split out from the poster so tests can assert the exact
+// string that lands on GitHub without having to mock gh.
+func buildCleanReviewBody(commitSHA string) string {
+	return "CodeCanary reviewed this PR \u2014 no issues found." + embedBaselineMarker(commitSHA)
+}
+
+// buildAllClearReviewBody renders the full Markdown body posted by
+// PostAllClearReview. Split out for the same reason as buildCleanReviewBody.
+func buildAllClearReviewBody(commitSHA string, minimizeFailed bool) string {
 	body := "## \U0001F425 CodeCanary\n\n\u2705 All previous findings have been addressed. No new issues found. \u2728"
 	if minimizeFailed {
 		body += "\n\n> \u26A0\uFE0F Some previous review comments could not be minimized and may still be visible."
 	}
-	body += embedBaselineMarker(commitSHA)
-	return postSimpleReview(repo, prNumber, body)
+	return body + embedBaselineMarker(commitSHA)
 }
 
 // embedBaselineMarker returns a hidden HTML comment containing the commitSHA

--- a/internal/review/github_test.go
+++ b/internal/review/github_test.go
@@ -49,3 +49,44 @@ func TestEmbedBaselineMarkerFormat(t *testing.T) {
 		t.Errorf("marker = %q, want %q", got, want)
 	}
 }
+
+func TestBuildCleanReviewBody(t *testing.T) {
+	got := buildCleanReviewBody("abc123")
+	want := "CodeCanary reviewed this PR \u2014 no issues found.\n<!-- codecanary:review {\"sha\":\"abc123\"} -->\n"
+	if got != want {
+		t.Errorf("body =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestBuildCleanReviewBodyNoSHA(t *testing.T) {
+	got := buildCleanReviewBody("")
+	want := "CodeCanary reviewed this PR \u2014 no issues found."
+	if got != want {
+		t.Errorf("body =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestBuildAllClearReviewBody(t *testing.T) {
+	got := buildAllClearReviewBody("abc123", false)
+	wantSuffix := "\n<!-- codecanary:review {\"sha\":\"abc123\"} -->\n"
+	if !strings.HasSuffix(got, wantSuffix) {
+		t.Errorf("body missing marker suffix:\n%q", got)
+	}
+	if strings.Contains(got, "could not be minimized") {
+		t.Errorf("unexpected minimize-warning text when minimizeFailed=false:\n%q", got)
+	}
+	if !strings.Contains(got, "All previous findings have been addressed") {
+		t.Errorf("body missing expected all-clear copy:\n%q", got)
+	}
+}
+
+func TestBuildAllClearReviewBodyMinimizeFailed(t *testing.T) {
+	got := buildAllClearReviewBody("abc123", true)
+	if !strings.Contains(got, "could not be minimized") {
+		t.Errorf("expected minimize-warning text, got:\n%q", got)
+	}
+	wantSuffix := "\n<!-- codecanary:review {\"sha\":\"abc123\"} -->\n"
+	if !strings.HasSuffix(got, wantSuffix) {
+		t.Errorf("body missing marker suffix:\n%q", got)
+	}
+}

--- a/internal/review/github_test.go
+++ b/internal/review/github_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestEmbedBaselineMarkerRoundTrip(t *testing.T) {
 	sha := "6971e4164c0a4df9d89aefdb874174a56df420d4"
-	marker := embedBaselineMarker("owner/repo", 1502, sha)
+	marker := embedBaselineMarker(sha)
 
 	prefix := reviewMarkerPrefixes[0]
 	idx := strings.Index(marker, prefix)
@@ -21,6 +21,8 @@ func TestEmbedBaselineMarkerRoundTrip(t *testing.T) {
 		t.Fatalf("marker missing expected suffix: %q", marker)
 	}
 
+	// FetchPreviousReviewSHA unmarshals into ReviewResult, so the minimal
+	// {sha} payload must still populate ReviewResult.SHA correctly.
 	var result ReviewResult
 	if err := json.Unmarshal([]byte(marker[start:start+endIdx]), &result); err != nil {
 		t.Fatalf("marker JSON does not round-trip: %v (raw=%q)", err, marker[start:start+endIdx])
@@ -28,16 +30,22 @@ func TestEmbedBaselineMarkerRoundTrip(t *testing.T) {
 	if result.SHA != sha {
 		t.Errorf("SHA = %q, want %q", result.SHA, sha)
 	}
-	if result.PRNumber != 1502 {
-		t.Errorf("PRNumber = %d, want 1502", result.PRNumber)
-	}
-	if result.Repo != "owner/repo" {
-		t.Errorf("Repo = %q, want owner/repo", result.Repo)
-	}
 }
 
 func TestEmbedBaselineMarkerEmptySHA(t *testing.T) {
-	if got := embedBaselineMarker("owner/repo", 1, ""); got != "" {
+	if got := embedBaselineMarker(""); got != "" {
 		t.Errorf("expected empty marker for empty SHA, got %q", got)
+	}
+}
+
+// TestEmbedBaselineMarkerFormat guards the full rendered snippet against
+// accidental extra whitespace regressions. FormatReviewBody uses a single
+// leading and trailing newline around the marker; baseline-marker bodies
+// must match that convention so the rendered PR comment doesn't drift.
+func TestEmbedBaselineMarkerFormat(t *testing.T) {
+	got := embedBaselineMarker("abc123")
+	want := "\n<!-- codecanary:review {\"sha\":\"abc123\"} -->\n"
+	if got != want {
+		t.Errorf("marker = %q, want %q", got, want)
 	}
 }

--- a/internal/review/github_test.go
+++ b/internal/review/github_test.go
@@ -1,0 +1,43 @@
+package review
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestEmbedBaselineMarkerRoundTrip(t *testing.T) {
+	sha := "6971e4164c0a4df9d89aefdb874174a56df420d4"
+	marker := embedBaselineMarker("owner/repo", 1502, sha)
+
+	prefix := reviewMarkerPrefixes[0]
+	idx := strings.Index(marker, prefix)
+	if idx < 0 {
+		t.Fatalf("marker missing expected prefix %q: %q", prefix, marker)
+	}
+	start := idx + len(prefix)
+	endIdx := strings.Index(marker[start:], reviewMarkerSuffix)
+	if endIdx < 0 {
+		t.Fatalf("marker missing expected suffix: %q", marker)
+	}
+
+	var result ReviewResult
+	if err := json.Unmarshal([]byte(marker[start:start+endIdx]), &result); err != nil {
+		t.Fatalf("marker JSON does not round-trip: %v (raw=%q)", err, marker[start:start+endIdx])
+	}
+	if result.SHA != sha {
+		t.Errorf("SHA = %q, want %q", result.SHA, sha)
+	}
+	if result.PRNumber != 1502 {
+		t.Errorf("PRNumber = %d, want 1502", result.PRNumber)
+	}
+	if result.Repo != "owner/repo" {
+		t.Errorf("Repo = %q, want owner/repo", result.Repo)
+	}
+}
+
+func TestEmbedBaselineMarkerEmptySHA(t *testing.T) {
+	if got := embedBaselineMarker("owner/repo", 1, ""); got != "" {
+		t.Errorf("expected empty marker for empty SHA, got %q", got)
+	}
+}

--- a/internal/review/platform_github.go
+++ b/internal/review/platform_github.go
@@ -230,7 +230,7 @@ func (g *GithubPlatform) Publish(result *ReviewResult, pr *PRData, threads []Rev
 		}
 		Stderrf(ansiGreen, "Review posted to PR #%d\n", g.PRNumber)
 	} else if len(threads) > 0 && allResolved(threads, fixed) {
-		if err := PostAllClearReview(g.Repo, g.PRNumber, minimizeFailed); err != nil {
+		if err := PostAllClearReview(g.Repo, g.PRNumber, result.SHA, minimizeFailed); err != nil {
 			return fmt.Errorf("posting all-clear review: %w", err)
 		}
 		Stderrf(ansiGreen, "All clear! No issues remaining.\n")
@@ -244,7 +244,7 @@ func (g *GithubPlatform) Publish(result *ReviewResult, pr *PRData, threads []Rev
 		unresolvedCount := len(threads) - len(codeFixedSet)
 		fmt.Fprintf(os.Stderr, "No new findings. %d previous thread(s) still unresolved.\n", unresolvedCount)
 	} else {
-		if err := PostCleanReview(g.Repo, g.PRNumber); err != nil {
+		if err := PostCleanReview(g.Repo, g.PRNumber, result.SHA); err != nil {
 			return fmt.Errorf("posting review: %w", err)
 		}
 		Stderrf(ansiGreen, "Review posted to PR #%d\n", g.PRNumber)

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -454,6 +454,13 @@ func Run(opts RunOptions) error {
 	}
 
 	// Handle early return for "no new changes" with no open findings.
+	// This fires when the incremental diff is empty and nothing is carried
+	// forward. Skipping Publish is intentional: there is nothing new to
+	// review and nothing to acknowledge, so emitting another comment would
+	// be noise. The baseline marker stays at the previous review's SHA,
+	// which is the correct comparison point for the next push — an empty
+	// diff means the tree is unchanged, so advancing the baseline would
+	// produce the same incremental diff next time either way.
 	if prompt == "" && len(findings) == 0 && len(stillOpenFindings) == 0 && isIncremental {
 		return nil
 	}

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -364,7 +364,11 @@ func Run(opts RunOptions) error {
 	var prompt string
 	var fixed []fixedThread
 	var stillOpenFindings []Finding
-	isIncremental := len(reviewThreads) > 0 && previousSHA != ""
+	// A previous SHA alone is enough to enter the incremental path. When
+	// previous findings were all resolved (reviewThreads empty), we still
+	// want to scope the next review to commits since that baseline instead
+	// of re-reviewing the whole PR.
+	isIncremental := previousSHA != ""
 
 	if isIncremental {
 		prompt, fixed, stillOpenFindings = runTriage(
@@ -531,7 +535,11 @@ func runTriage(
 	reviewThreads []ReviewThread, previousSHA string, startIndex int,
 	opts RunOptions,
 ) (string, []fixedThread, []Finding) {
-	Stderrf(ansiBold, "Re-evaluating %d unresolved thread(s) (base %s)...\n", len(reviewThreads), shortSHA(previousSHA))
+	if len(reviewThreads) > 0 {
+		Stderrf(ansiBold, "Re-evaluating %d unresolved thread(s) (base %s)...\n", len(reviewThreads), shortSHA(previousSHA))
+	} else {
+		Stderrf(ansiBold, "Reviewing new commits since %s...\n", shortSHA(previousSHA))
+	}
 
 	// Try to compute an incremental diff (only changes since last review).
 	// This produces a smaller prompt when available. If it fails (e.g. shallow


### PR DESCRIPTION
## Summary

When a codecanary run posts a clean ("no issues found") or all-clear ("all previous findings have been addressed") review, the body carries no `codecanary:review` marker. `FetchPreviousReviewSHA` only understands bodies with that marker, so it walks past clean reviews and uses the last findings-bearing review as the baseline. Combined with the `isIncremental` gate in `runner.go:367` also requiring `len(reviewThreads) > 0`, the next push after a PR reaches a clean state re-enters the **full PR review** branch — `BuildPrompt`, not `BuildIncrementalPrompt`.

Result: any trivial follow-up commit on a clean PR triggers a full re-review, which is expensive and prone to surfacing "unrelated" findings anchored to commits reviewed much earlier (the LLM sees the full PR diff and can flag design issues the first review didn't catch).

Observed on `thetechfx/bedrock#1502`: a 1-line refactor in commit 3 triggered a 387 KB prompt, 313 added / 94 removed lines, 8 files, $0.84. Findings anchored at lines `957` and `1204` of a file where commit 3 only touched line `857`. The run log shows `Reviewing PR #1502...` (full-review branch), not `Re-evaluating N unresolved thread(s)...`.

## Changes

- `PostCleanReview` / `PostAllClearReview` now embed a hidden `<!-- codecanary:review ... -->` marker with the current commit SHA, so the baseline advances on every successful run.
- The `isIncremental` gate in `Run()` now requires only a previous SHA, not also open threads. `runTriage` already handles an empty `reviewThreads` slice correctly — phase 1 becomes a no-op, phase 2 builds an incremental prompt with zero known issues.
- Triage log distinguishes re-evaluation from an incremental review with no prior findings.
- Added a round-trip test for the baseline marker.
- `docs/review-flow.md` updated to reflect the new baseline semantics.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`
- [x] New test `TestEmbedBaselineMarkerRoundTrip` verifies the marker round-trips via the same JSON schema `FetchPreviousReviewSHA` consumes.
- [ ] Smoke test on a PR that reaches "all clear" then gets a new push — confirm the next run says `Reviewing new commits since <sha>...` and posts findings scoped to the incremental hunks only.