### PR TITLE
feat: discover CLAUDE.md at every ancestor of a changed file

### DIFF
--- a/docs/review-flow.md
+++ b/docs/review-flow.md
@@ -36,7 +36,7 @@ If the PR is a setup PR (only adds workflow files with no real code changes), th
 `prepareReview()` loads everything the review needs:
 
 - **Config**: Reads `config.yml` (provider, models, budgets, timeouts). If a `review.yml` exists alongside it, its rules/context/ignore fields override the config. If a `review.local.yml` also exists, its fields are appended (not replaced) on top of `review.yml`.
-- **Project docs**: Discovers CLAUDE.md files (root, `.claude/`, top-level directories). Up to 5 files, 4KB each, 12KB total.
+- **Project docs**: Discovers CLAUDE.md files at the repo root and in every ancestor directory of a changed PR file. Skips `vendor/`, `node_modules/`, hidden dirs, and other build artifacts. Up to 10 files, 16 KB each, 48 KB total. Monorepos commonly keep per-app conventions (e.g. `apps/exchange-api/CLAUDE.md`) — those load automatically when a PR touches files under that directory, so the reviewer sees the conventions specific to the code being changed rather than only the repo-root overview.
 - **File contents**: Reads changed files from disk with size limits (default 100KB per file, 500KB total). Skips binary files, ignored patterns, and files exceeding limits. When files are skipped, the diff is also filtered to remove their hunks (via `ScopeDiffToFiles`) and they are removed from the file list. The original unfiltered diff is preserved in `FullDiff` for finding validation.
 - **Environment**: Builds a filtered env for LLM subprocesses (only allowed prefixes like `CODECANARY_`, `GITHUB_`, plus essential vars like `PATH`). Injects keychain credentials if not already set.
 

--- a/internal/review/docs.go
+++ b/internal/review/docs.go
@@ -3,6 +3,7 @@ package review
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -15,36 +16,51 @@ var skipDirs = map[string]bool{
 }
 
 // maxDocBytes caps the size of a single CLAUDE.md file included in the prompt.
-const maxDocBytes = 4096
+const maxDocBytes = 16384
 
 // maxTotalDocBytes caps the total size of all CLAUDE.md files combined.
-const maxTotalDocBytes = 12288
+const maxTotalDocBytes = 49152
 
-// ReadProjectDocs reads CLAUDE.md files from known locations in the working directory.
-// It returns a map of path → content, respecting per-file and total size limits.
-func ReadProjectDocs() map[string]string {
+// maxDocs caps the number of CLAUDE.md files loaded per review.
+const maxDocs = 10
+
+// ReadProjectDocs reads CLAUDE.md files from the repo root and every ancestor
+// directory of the PR's changed files. Root docs come first; more-specific
+// ancestor docs come later so LLM recency bias favors the most relevant
+// guidance. Per-file and overall size caps apply. When prFiles is empty only
+// root docs are loaded.
+func ReadProjectDocs(prFiles []string) map[string]string {
+	root, err := os.Getwd()
+	if err != nil {
+		return map[string]string{}
+	}
+	return readProjectDocsFrom(root, prFiles)
+}
+
+// readProjectDocsFrom is the testable core of ReadProjectDocs. It resolves all
+// candidate paths relative to root, which must be an absolute path.
+func readProjectDocsFrom(root string, prFiles []string) map[string]string {
 	docs := make(map[string]string)
 
-	// Check root and .claude/ first.
-	docPaths := []string{"CLAUDE.md", ".claude/CLAUDE.md"}
-
-	// Check top-level subdirectories.
-	entries, err := os.ReadDir(".")
-	if err == nil {
-		for _, e := range entries {
-			if !e.IsDir() || skipDirs[e.Name()] || strings.HasPrefix(e.Name(), ".") {
-				continue
-			}
-			docPaths = append(docPaths, filepath.Join(e.Name(), "CLAUDE.md"))
-		}
+	// Candidate paths in load order: repo root first, then ancestors from
+	// shallowest to deepest. writeProjectDocs ultimately sorts docs
+	// alphabetically before emitting them to the prompt, which coincidentally
+	// preserves this root-then-deeper order for typical repo layouts.
+	paths := []string{"CLAUDE.md", filepath.Join(".claude", "CLAUDE.md")}
+	for _, dir := range ancestorDirs(prFiles) {
+		paths = append(paths, filepath.Join(dir, "CLAUDE.md"))
+		paths = append(paths, filepath.Join(dir, ".claude", "CLAUDE.md"))
 	}
 
 	totalBytes := 0
-	for _, p := range docPaths {
-		if len(docs) >= 5 {
+	for _, relPath := range paths {
+		if _, exists := docs[relPath]; exists {
+			continue
+		}
+		if len(docs) >= maxDocs {
 			break
 		}
-		data, err := os.ReadFile(p)
+		data, err := os.ReadFile(filepath.Join(root, relPath))
 		if err != nil {
 			continue
 		}
@@ -55,9 +71,57 @@ func ReadProjectDocs() map[string]string {
 		if totalBytes+len(content) > maxTotalDocBytes {
 			continue
 		}
-		docs[p] = content
+		docs[relPath] = content
 		totalBytes += len(content)
 	}
 
 	return docs
+}
+
+// ancestorDirs returns the unique set of ancestor directories for the given
+// files, sorted shallowest-first. Files inside skipDirs (node_modules, vendor,
+// .git, dotfile dirs, etc.) are excluded — no CLAUDE.md lookup happens for
+// their ancestors. The repo root itself is excluded; root docs are handled
+// separately by the caller.
+func ancestorDirs(files []string) []string {
+	seen := make(map[string]bool)
+	for _, f := range files {
+		dir := filepath.Dir(filepath.Clean(f))
+		if dir == "." || dir == "/" || dir == "" {
+			continue
+		}
+		if pathHasSkippedComponent(dir) {
+			continue
+		}
+		for dir != "." && dir != "/" && dir != "" {
+			seen[dir] = true
+			dir = filepath.Dir(dir)
+		}
+	}
+
+	out := make([]string, 0, len(seen))
+	for d := range seen {
+		out = append(out, d)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		di := strings.Count(out[i], string(filepath.Separator))
+		dj := strings.Count(out[j], string(filepath.Separator))
+		if di != dj {
+			return di < dj
+		}
+		return out[i] < out[j]
+	})
+	return out
+}
+
+// pathHasSkippedComponent reports whether any component of dir is in skipDirs
+// or starts with a dot. Used to exclude build artifacts, VCS metadata, and
+// hidden config directories from the ancestor walk.
+func pathHasSkippedComponent(dir string) bool {
+	for _, p := range strings.Split(filepath.Clean(dir), string(filepath.Separator)) {
+		if skipDirs[p] || strings.HasPrefix(p, ".") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/review/docs.go
+++ b/internal/review/docs.go
@@ -69,6 +69,9 @@ func readProjectDocsFrom(root string, prFiles []string) map[string]string {
 			content = content[:maxDocBytes] + "\n... (truncated)"
 		}
 		if totalBytes+len(content) > maxTotalDocBytes {
+			// `continue`, not `break`: a later, smaller doc may still fit in
+			// the remaining budget. Stopping on the first overflow would
+			// leave more bytes on the table than skipping this one file.
 			continue
 		}
 		docs[relPath] = content

--- a/internal/review/docs_test.go
+++ b/internal/review/docs_test.go
@@ -1,0 +1,181 @@
+package review
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// writeFile creates dir and writes a file under root with the given relative
+// path and content. Fails the test on any error.
+func writeFile(t *testing.T, root, relPath, content string) {
+	t.Helper()
+	abs := filepath.Join(root, relPath)
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir %q: %v", abs, err)
+	}
+	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %q: %v", abs, err)
+	}
+}
+
+func TestReadProjectDocs_RootOnlyWhenNoPRFiles(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "CLAUDE.md", "root guidance")
+	writeFile(t, root, "apps/exchange-api/CLAUDE.md", "exchange-api guidance")
+
+	docs := readProjectDocsFrom(root, nil)
+
+	if _, ok := docs["CLAUDE.md"]; !ok {
+		t.Errorf("expected root CLAUDE.md, got: %v", keys(docs))
+	}
+	if _, ok := docs[filepath.Join("apps", "exchange-api", "CLAUDE.md")]; ok {
+		t.Errorf("did not expect nested CLAUDE.md when prFiles empty: %v", keys(docs))
+	}
+}
+
+func TestReadProjectDocs_LoadsAncestorsOfChangedFiles(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "CLAUDE.md", "root guidance")
+	writeFile(t, root, "apps/exchange-api/CLAUDE.md", "exchange-api vanilla rails")
+	writeFile(t, root, "apps/backoffice-frontend/CLAUDE.md", "react conventions")
+	writeFile(t, root, "engines/exchange/CLAUDE.md", "exchange engine conventions")
+
+	// A PR that only touches exchange-api.
+	prFiles := []string{
+		"apps/exchange-api/app/services/document_update_request_service.rb",
+		"apps/exchange-api/test/services/document_update_request_service_test.rb",
+	}
+
+	docs := readProjectDocsFrom(root, prFiles)
+
+	want := map[string]bool{
+		"CLAUDE.md": true,
+		filepath.Join("apps", "exchange-api", "CLAUDE.md"): true,
+	}
+	for path := range want {
+		if _, ok := docs[path]; !ok {
+			t.Errorf("expected %q, got: %v", path, keys(docs))
+		}
+	}
+
+	// Sibling app docs must not leak in.
+	for _, unwanted := range []string{
+		filepath.Join("apps", "backoffice-frontend", "CLAUDE.md"),
+		filepath.Join("engines", "exchange", "CLAUDE.md"),
+	} {
+		if _, ok := docs[unwanted]; ok {
+			t.Errorf("did not expect %q (sibling/unrelated) in: %v", unwanted, keys(docs))
+		}
+	}
+}
+
+func TestReadProjectDocs_FallsBackToShallowerCLAUDEmd(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "CLAUDE.md", "root")
+	writeFile(t, root, "apps/CLAUDE.md", "all apps share this")
+	// No apps/exchange-api/CLAUDE.md — discovery should still pick up apps/.
+
+	docs := readProjectDocsFrom(root, []string{"apps/exchange-api/foo.rb"})
+
+	if _, ok := docs[filepath.Join("apps", "CLAUDE.md")]; !ok {
+		t.Errorf("expected apps/CLAUDE.md as ancestor fallback, got: %v", keys(docs))
+	}
+}
+
+func TestReadProjectDocs_SkipsVendoredOrHiddenAncestors(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "CLAUDE.md", "root")
+	writeFile(t, root, "vendor/lib/CLAUDE.md", "vendored, should be ignored")
+	writeFile(t, root, ".github/workflows/CLAUDE.md", "dotfile, should be ignored")
+	writeFile(t, root, "node_modules/foo/CLAUDE.md", "deps, should be ignored")
+
+	prFiles := []string{
+		"vendor/lib/bar.go",
+		".github/workflows/ci.yml",
+		"node_modules/foo/index.js",
+	}
+
+	docs := readProjectDocsFrom(root, prFiles)
+
+	if len(docs) != 1 {
+		t.Errorf("expected only root CLAUDE.md, got: %v", keys(docs))
+	}
+	if _, ok := docs["CLAUDE.md"]; !ok {
+		t.Errorf("root CLAUDE.md missing: %v", keys(docs))
+	}
+}
+
+func TestReadProjectDocs_RespectsPerFileCap(t *testing.T) {
+	root := t.TempDir()
+	large := strings.Repeat("x", maxDocBytes*2) // 32 KB, double the cap.
+	writeFile(t, root, "CLAUDE.md", large)
+
+	docs := readProjectDocsFrom(root, nil)
+
+	got := docs["CLAUDE.md"]
+	if len(got) > maxDocBytes+len("\n... (truncated)") {
+		t.Errorf("expected truncation to %d bytes + marker, got %d", maxDocBytes, len(got))
+	}
+	if !strings.HasSuffix(got, "(truncated)") {
+		t.Errorf("expected truncation marker, got tail: %q", tail(got, 40))
+	}
+}
+
+func TestReadProjectDocs_RespectsTotalCap(t *testing.T) {
+	root := t.TempDir()
+	// Four docs at 16 KB each = 64 KB total; total cap is 48 KB, so the
+	// fourth should be dropped once the budget is exhausted.
+	content := strings.Repeat("x", maxDocBytes)
+	writeFile(t, root, "CLAUDE.md", content)
+	writeFile(t, root, "apps/CLAUDE.md", content)
+	writeFile(t, root, "apps/a/CLAUDE.md", content)
+	writeFile(t, root, "apps/a/b/CLAUDE.md", content)
+
+	docs := readProjectDocsFrom(root, []string{"apps/a/b/c.rb"})
+
+	total := 0
+	for _, v := range docs {
+		total += len(v)
+	}
+	if total > maxTotalDocBytes {
+		t.Errorf("total bytes %d exceeds cap %d: loaded %v", total, maxTotalDocBytes, keys(docs))
+	}
+}
+
+func TestAncestorDirs_ShallowestFirstWithStableOrder(t *testing.T) {
+	got := ancestorDirs([]string{
+		"apps/exchange-api/app/services/foo.rb",
+		"engines/exchange/lib/bar.rb",
+		"apps/exchange-api/app/services/baz.rb", // same chain as first
+	})
+	want := []string{
+		"apps",
+		"engines",
+		"apps/exchange-api",
+		"engines/exchange",
+		"apps/exchange-api/app",
+		"engines/exchange/lib",
+		"apps/exchange-api/app/services",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ancestor order mismatch\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func keys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func tail(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[len(s)-n:]
+}

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -104,7 +104,7 @@ func prepareReview(pr *PRData, configPath string) (*reviewContext, error) {
 		return nil, err
 	}
 
-	projectDocs := ReadProjectDocs()
+	projectDocs := ReadProjectDocs(pr.Files)
 	if len(projectDocs) > 0 {
 		fmt.Fprintf(os.Stderr, "Loaded %d project doc(s) for review context\n", len(projectDocs))
 	}


### PR DESCRIPTION
## Summary

Monorepos typically place per-app conventions in nested CLAUDE.md files (e.g. `apps/exchange-api/CLAUDE.md`). The previous discovery algorithm scanned only repo-root and top-level subdirectories, so those nested docs were invisible to the reviewer — the run log consistently read *"Loaded 1 project doc(s) for review context"* on a repo that has 13.

On `thetechfx/bedrock` specifically: root `CLAUDE.md` = 19,344 bytes (truncated to 4 KB by the old per-file cap, losing ~79 %), and none of the 12 per-app / per-engine CLAUDE.md files reached the prompt. This almost certainly contributed to cycle-0 LLM misses like `no-service-objects` on PR 1502, where the Vanilla Rails anti-pattern lived in `apps/exchange-api/CLAUDE.md` that the reviewer never saw.

## Changes

- `ReadProjectDocs` now takes the list of PR files and walks every ancestor directory, probing `CLAUDE.md` / `.claude/CLAUDE.md` at each level.
- Paths inside `vendor/`, `node_modules/`, dotfile dirs, and other build artifacts are excluded from the walk.
- Size caps raised: **10 files × 16 KB each × 48 KB total** (was 5 × 4 KB × 12 KB). Comfortably under any supported model's context window and closer to what Claude Code itself loads.
- Internal helper `readProjectDocsFrom(root, prFiles)` makes the logic unit-testable with a tempdir fixture — no `os.Chdir` in tests.
- `docs/review-flow.md` updated to describe the new behavior.

## Practical effect

A PR touching `apps/exchange-api/app/services/foo.rb` now loads both `CLAUDE.md` and `apps/exchange-api/CLAUDE.md`. Sibling apps' CLAUDE.md files are **not** pulled in, keeping context targeted.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`
- [x] New tests cover: root-only when prFiles empty, ancestor loading for nested files, shallower-ancestor fallback, vendored/hidden-dir exclusion, per-file truncation, total-budget cap, ancestor ordering stability.
- [ ] Smoke test on a bedrock-style monorepo PR: confirm the log reports multiple docs loaded and that app-specific rules fire on cycle 0.