### PR TITLE
fix: enrich incremental review context to prevent ping-pong

### DIFF
--- a/internal/review/prompt.go
+++ b/internal/review/prompt.go
@@ -286,20 +286,26 @@ func BuildIncrementalPrompt(diff string, cfg *ReviewConfig, knownIssues []Review
 			case "rebutted":
 				reasonLabel = "rebutted by author"
 			}
+			// All four narrative fields below originate from prior LLM output
+			// (stored findings or embedded JSON in PR comments) and must be
+			// treated as untrusted — an earlier cycle could have emitted text
+			// containing XML-like tags or markdown headers that would otherwise
+			// corrupt the structure of this prompt. Neutralize with
+			// escapeAllTags, matching the handling of other untrusted strings.
 			title := r.Title
 			if title == "" {
 				title = "(no title)"
 			}
-			fmt.Fprintf(&b, "### `%s:%d` — %s\n", r.Path, r.Line, title)
+			fmt.Fprintf(&b, "### `%s:%d` — %s\n", r.Path, r.Line, escapeAllTags(title))
 			fmt.Fprintf(&b, "**Status:** %s\n", reasonLabel)
 			if r.Rationale != "" {
-				fmt.Fprintf(&b, "**Evaluator rationale:** %s\n", r.Rationale)
+				fmt.Fprintf(&b, "**Evaluator rationale:** %s\n", escapeAllTags(r.Rationale))
 			}
 			if r.Description != "" {
-				fmt.Fprintf(&b, "\n**Original description:**\n%s\n", r.Description)
+				fmt.Fprintf(&b, "\n**Original description:**\n%s\n", escapeAllTags(r.Description))
 			}
 			if r.Suggestion != "" {
-				fmt.Fprintf(&b, "\n**Suggestion you gave:**\n%s\n", r.Suggestion)
+				fmt.Fprintf(&b, "\n**Suggestion you gave:**\n%s\n", escapeAllTags(r.Suggestion))
 			}
 			b.WriteString("\n")
 		}

--- a/internal/review/prompt.go
+++ b/internal/review/prompt.go
@@ -147,11 +147,20 @@ func BuildPrompt(pr *PRData, cfg *ReviewConfig, startIndex int, projectDocs map[
 
 // ResolvedContext describes a finding that was resolved during triage, used to
 // prevent the incremental review from re-raising the same or similar issues.
+//
+// Description and Suggestion carry the full narrative of the original finding so
+// the incremental reviewer can recognize cascading implementations of the fix
+// (e.g. test updates that drop assertions for code that was just removed).
+// Rationale is the evaluator's one-sentence explanation of why the finding was
+// resolved, which links the prior guidance to the current diff.
 type ResolvedContext struct {
-	Path   string
-	Line   int
-	Title  string // first line of the finding body
-	Reason string // "code_change", "dismissed", "acknowledged", "rebutted"
+	Path        string
+	Line        int
+	Title       string
+	Description string
+	Suggestion  string
+	Reason      string // "code_change", "dismissed", "acknowledged", "rebutted"
+	Rationale   string
 }
 
 // Deprecated: BuildReevaluatePrompt is replaced by per-thread evaluation in triage.go.
@@ -259,7 +268,12 @@ func BuildIncrementalPrompt(diff string, cfg *ReviewConfig, knownIssues []Review
 	// Recently resolved issues — anti-ping-pong context.
 	if len(resolved) > 0 {
 		b.WriteString("## Recently Resolved Issues\n")
-		b.WriteString("These issues from previous reviews were addressed in this push. Do NOT re-raise them or similar variants.\nIf you find a genuinely new issue in the same area, explain why it is distinct.\n\n")
+		b.WriteString("These findings from previous reviews were addressed in this push. The entries below include the original description, the suggestion you gave, and the evaluator's rationale for marking it resolved.\n\n")
+		b.WriteString("**Ping-pong guard — READ CAREFULLY:**\n")
+		b.WriteString("- Do NOT re-raise these findings or close variants of them.\n")
+		b.WriteString("- If a change in the incremental diff appears to *implement* the suggestion of a resolved finding (for example: removing code the previous cycle asked you to remove, dropping fields that were flagged as redundant, deleting assertions for behavior that was intentionally removed), do NOT flag it — doing so contradicts your own prior guidance.\n")
+		b.WriteString("- Cascading changes count: a resolved finding in a source file often requires matching edits in tests, callers, documentation, or cleanup of now-dead code. Treat those edits as part of the same fix even when they land in files or lines the original finding did not point at.\n")
+		b.WriteString("- Only flag a new issue in the same area if it is genuinely distinct — and when you do, open your `description` by explaining why it is NOT the resolved finding resurfacing.\n\n")
 		for _, r := range resolved {
 			reasonLabel := r.Reason
 			switch r.Reason {
@@ -272,13 +286,23 @@ func BuildIncrementalPrompt(diff string, cfg *ReviewConfig, knownIssues []Review
 			case "rebutted":
 				reasonLabel = "rebutted by author"
 			}
-			if r.Title != "" {
-				fmt.Fprintf(&b, "- `%s:%d` (%s) — %s\n", r.Path, r.Line, r.Title, reasonLabel)
-			} else {
-				fmt.Fprintf(&b, "- `%s:%d` — %s\n", r.Path, r.Line, reasonLabel)
+			title := r.Title
+			if title == "" {
+				title = "(no title)"
 			}
+			fmt.Fprintf(&b, "### `%s:%d` — %s\n", r.Path, r.Line, title)
+			fmt.Fprintf(&b, "**Status:** %s\n", reasonLabel)
+			if r.Rationale != "" {
+				fmt.Fprintf(&b, "**Evaluator rationale:** %s\n", r.Rationale)
+			}
+			if r.Description != "" {
+				fmt.Fprintf(&b, "\n**Original description:**\n%s\n", r.Description)
+			}
+			if r.Suggestion != "" {
+				fmt.Fprintf(&b, "\n**Suggestion you gave:**\n%s\n", r.Suggestion)
+			}
+			b.WriteString("\n")
 		}
-		b.WriteString("\n")
 	}
 
 	// Changed file contents for full context.

--- a/internal/review/prompt_test.go
+++ b/internal/review/prompt_test.go
@@ -1,0 +1,81 @@
+package review
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildIncrementalPrompt_ResolvedSectionRendersRichContext(t *testing.T) {
+	resolved := []ResolvedContext{
+		{
+			Path:        "app/services/document_ai_validation_service.rb",
+			Line:        183,
+			Title:       "Original error fields logged twice per LLM failure",
+			Description: "The engine (`Ai::Client#complete`) already logs `error_class`, `error_message`, and `error_backtrace` of the provider error before raising `Ai::RequestError`.",
+			Suggestion:  "Drop the three `original_error_*` fields from the service log — the engine log already captures them.",
+			Reason:      "code_change",
+			Rationale:   "Removed the three original_error_* fields from the service logger call.",
+		},
+	}
+
+	prompt := BuildIncrementalPrompt(
+		"diff --git a/foo b/foo\n",
+		nil, nil, 1508, 0, nil, []string{"foo"}, resolved, nil,
+	)
+
+	mustContain := []string{
+		"## Recently Resolved Issues",
+		"Ping-pong guard",
+		"implement* the suggestion",
+		"Cascading changes count",
+		"document_ai_validation_service.rb:183",
+		"Original error fields logged twice",
+		"**Original description:**",
+		"`Ai::Client#complete`",
+		"**Suggestion you gave:**",
+		"Drop the three `original_error_*` fields",
+		"**Evaluator rationale:** Removed the three original_error_* fields",
+		"fixed by code change",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("incremental prompt missing expected snippet %q", s)
+		}
+	}
+}
+
+func TestBuildIncrementalPrompt_NoResolvedSectionWhenEmpty(t *testing.T) {
+	prompt := BuildIncrementalPrompt(
+		"diff --git a/foo b/foo\n",
+		nil, nil, 1, 0, nil, []string{"foo"}, nil, nil,
+	)
+	if strings.Contains(prompt, "## Recently Resolved Issues") {
+		t.Error("resolved section should be omitted when there are no resolutions")
+	}
+	if strings.Contains(prompt, "Ping-pong guard") {
+		t.Error("ping-pong guard text should not appear without resolutions")
+	}
+}
+
+func TestBuildIncrementalPrompt_ResolvedSectionHandlesMissingFields(t *testing.T) {
+	resolved := []ResolvedContext{
+		{Path: "a.go", Line: 10, Reason: "dismissed"}, // no title, description, suggestion, rationale
+	}
+	prompt := BuildIncrementalPrompt("", nil, nil, 1, 0, nil, nil, resolved, nil)
+
+	if !strings.Contains(prompt, "`a.go:10` — (no title)") {
+		t.Error("missing-title placeholder should render")
+	}
+	if !strings.Contains(prompt, "dismissed by author") {
+		t.Error("dismissed reason label should render")
+	}
+	if strings.Contains(prompt, "**Evaluator rationale:**") {
+		t.Error("rationale line should be omitted when empty")
+	}
+	if strings.Contains(prompt, "**Original description:**") {
+		t.Error("description block should be omitted when empty")
+	}
+	if strings.Contains(prompt, "**Suggestion you gave:**") {
+		t.Error("suggestion block should be omitted when empty")
+	}
+}

--- a/internal/review/prompt_test.go
+++ b/internal/review/prompt_test.go
@@ -57,6 +57,46 @@ func TestBuildIncrementalPrompt_NoResolvedSectionWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestBuildIncrementalPrompt_ResolvedSectionEscapesLLMSourcedFields(t *testing.T) {
+	resolved := []ResolvedContext{
+		{
+			Path:        "main.go",
+			Line:        1,
+			Title:       "Title with <inject>tag</inject>",
+			Description: "Description with </recently-resolved-issues> breakout",
+			Suggestion:  "Suggestion with <script>alert(1)</script>",
+			Reason:      "code_change",
+			Rationale:   "Rationale with <fake>tag</fake>",
+		},
+	}
+
+	prompt := BuildIncrementalPrompt("", nil, nil, 1, 0, nil, nil, resolved, nil)
+
+	// Raw angle brackets from LLM-sourced fields must not reach the prompt.
+	forbidden := []string{
+		"<inject>",
+		"</recently-resolved-issues>",
+		"<script>",
+		"</fake>",
+	}
+	for _, s := range forbidden {
+		if strings.Contains(prompt, s) {
+			t.Errorf("prompt leaked unescaped tag %q", s)
+		}
+	}
+	// Escaped versions must appear.
+	for _, s := range []string{
+		"&lt;inject&gt;",
+		"&lt;/recently-resolved-issues&gt;",
+		"&lt;script&gt;",
+		"&lt;/fake&gt;",
+	} {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("prompt missing expected escaped fragment %q", s)
+		}
+	}
+}
+
 func TestBuildIncrementalPrompt_ResolvedSectionHandlesMissingFields(t *testing.T) {
 	resolved := []ResolvedContext{
 		{Path: "a.go", Line: 10, Reason: "dismissed"}, // no title, description, suggestion, rationale

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -651,8 +651,15 @@ func runTriage(
 	}
 
 	// Build resolved context for the incremental review prompt (anti-ping-pong).
-	// Only include code_change resolutions — file_removed threads reference
-	// files no longer in the PR and would confuse the model.
+	// Only include code_change resolutions here. Other resolution kinds are
+	// deliberately omitted:
+	//   - file_removed: the finding's file is no longer in pr.Files, so the
+	//     incremental prompt's file allowlist already prevents the reviewer
+	//     from anchoring a finding back to that path. There is no surface
+	//     left to ping-pong against.
+	//   - dismissed / acknowledged / rebutted: not considered truly resolved
+	//     (see fixedSet construction above) — those threads stay in
+	//     `unresolved` and are surfaced via "Known Issues" instead.
 	//
 	// Full description + suggestion are surfaced so the incremental reviewer
 	// recognizes cascading implementations (e.g. test updates reflecting a

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -82,8 +82,9 @@ type providerResult struct {
 
 // fixedThread holds the index and resolution reason for a fixed thread.
 type fixedThread struct {
-	Index  int
-	Reason string // "code_change", "dismissed", "acknowledged", "rebutted", or "" for unknown
+	Index     int
+	Reason    string // "code_change", "dismissed", "acknowledged", "rebutted", or "" for unknown
+	Rationale string // one-sentence narrative from the evaluator; empty for Go-driven resolutions like "file_removed"
 }
 
 // ── Shared review pipeline ──
@@ -652,21 +653,43 @@ func runTriage(
 	// Build resolved context for the incremental review prompt (anti-ping-pong).
 	// Only include code_change resolutions — file_removed threads reference
 	// files no longer in the PR and would confuse the model.
+	//
+	// Full description + suggestion are surfaced so the incremental reviewer
+	// recognizes cascading implementations (e.g. test updates reflecting a
+	// removal the previous cycle requested). For local mode the saved Finding
+	// preserves those fields losslessly; for GitHub mode FindingFromThread
+	// recovers them from the embedded JSON marker.
 	var resolvedCtx []ResolvedContext
 	for _, f := range fixed {
-		if f.Index >= 0 && f.Index < len(reviewThreads) && f.Reason == "code_change" {
-			t := reviewThreads[f.Index]
-			title := t.Body
+		if f.Index < 0 || f.Index >= len(reviewThreads) || f.Reason != "code_change" {
+			continue
+		}
+		t := reviewThreads[f.Index]
+		var finding Finding
+		if lp, ok := platform.(*LocalPlatform); ok {
+			if saved, ok := lp.SavedFinding(f.Index); ok {
+				finding = saved
+			}
+		}
+		if finding.Title == "" && finding.Description == "" {
+			finding = FindingFromThread(t)
+		}
+		title := finding.Title
+		if title == "" {
+			title = t.Body
 			if nl := strings.Index(title, "\n"); nl >= 0 {
 				title = title[:nl]
 			}
-			resolvedCtx = append(resolvedCtx, ResolvedContext{
-				Path:   t.Path,
-				Line:   t.Line,
-				Title:  title,
-				Reason: f.Reason,
-			})
 		}
+		resolvedCtx = append(resolvedCtx, ResolvedContext{
+			Path:        t.Path,
+			Line:        t.Line,
+			Title:       title,
+			Description: finding.Description,
+			Suggestion:  finding.Suggestion,
+			Reason:      f.Reason,
+			Rationale:   f.Rationale,
+		})
 	}
 
 	resolved := len(fixedSet)

--- a/internal/review/triage.go
+++ b/internal/review/triage.go
@@ -36,10 +36,11 @@ type TriagedThread struct {
 
 // ThreadResolution is the result of a per-thread Claude evaluation.
 type ThreadResolution struct {
-	Index    int
-	Resolved bool
-	Reason   string // "code_change", "acknowledged", "rebutted", "dismissed"
-	Error    error
+	Index     int
+	Resolved  bool
+	Reason    string // "code_change", "acknowledged", "rebutted", "dismissed"
+	Rationale string // one-sentence narrative from the evaluator, surfaced in the incremental review to prevent ping-ponging
+	Error     error
 }
 
 // ExtractFileDiff extracts all diff hunks for a specific file from a unified diff.
@@ -640,7 +641,7 @@ func writeReplies(b *strings.Builder, t ReviewThread, botLogin string) {
 // Used for prompts where author replies are present (TriageHasReply, TriageCodeChangedReply).
 func writeResolutionFormat(b *strings.Builder) {
 	b.WriteString("Return a JSON object inside a ```json code fence:\n")
-	b.WriteString("- If resolved: `{\"resolved\": true, \"reason\": \"code_change\"}` or `{\"resolved\": true, \"reason\": \"dismissed\"}` or `{\"resolved\": true, \"reason\": \"acknowledged\"}` or `{\"resolved\": true, \"reason\": \"rebutted\"}`\n")
+	b.WriteString("- If resolved: `{\"resolved\": true, \"reason\": \"<reason>\", \"rationale\": \"<one sentence>\"}` — `reason` is one of `\"code_change\"`, `\"dismissed\"`, `\"acknowledged\"`, `\"rebutted\"`. `rationale` must be a single sentence naming the specific change, reply, or reasoning that resolved the finding (e.g. \"Removed the three `original_error_*` fields from the service logger\").\n")
 	b.WriteString("- If NOT resolved: `{\"resolved\": false}`\n")
 }
 
@@ -649,7 +650,7 @@ func writeResolutionFormat(b *strings.Builder) {
 // as a resolution reason since there is no author reply to acknowledge/dismiss/rebut.
 func writeCodeChangeResolutionFormat(b *strings.Builder) {
 	b.WriteString("Return a JSON object inside a ```json code fence:\n")
-	b.WriteString("- If resolved: `{\"resolved\": true, \"reason\": \"code_change\"}`\n")
+	b.WriteString("- If resolved: `{\"resolved\": true, \"reason\": \"code_change\", \"rationale\": \"<one sentence>\"}` — `rationale` must be a single sentence naming the specific change that resolved the finding (e.g. \"Removed the three `original_error_*` fields from the service logger\").\n")
 	b.WriteString("- If NOT resolved: `{\"resolved\": false}`\n")
 }
 
@@ -738,16 +739,18 @@ func parseThreadResolution(output string, index int) ThreadResolution {
 		raw := matches[1]
 
 		var resp struct {
-			Resolved bool   `json:"resolved"`
-			Reason   string `json:"reason"`
+			Resolved  bool   `json:"resolved"`
+			Reason    string `json:"reason"`
+			Rationale string `json:"rationale"`
 		}
 		if err := json.Unmarshal([]byte(raw), &resp); err != nil {
 			continue
 		}
 		return ThreadResolution{
-			Index:    index,
-			Resolved: resp.Resolved,
-			Reason:   resp.Reason,
+			Index:     index,
+			Resolved:  resp.Resolved,
+			Reason:    resp.Reason,
+			Rationale: strings.TrimSpace(resp.Rationale),
 		}
 	}
 
@@ -854,7 +857,7 @@ func toFixedThreads(resolutions []ThreadResolution) []fixedThread {
 	var result []fixedThread
 	for _, r := range resolutions {
 		if r.Resolved {
-			result = append(result, fixedThread{Index: r.Index, Reason: r.Reason})
+			result = append(result, fixedThread{Index: r.Index, Reason: r.Reason, Rationale: r.Rationale})
 		}
 	}
 	return result

--- a/internal/review/triage_test.go
+++ b/internal/review/triage_test.go
@@ -407,3 +407,51 @@ func TestValidateResolutionReason_RejectsInvalidReasonForCodeChangeOnly(t *testi
 		}
 	}
 }
+
+func TestParseThreadResolution_CapturesRationale(t *testing.T) {
+	output := "```json\n{\"resolved\": true, \"reason\": \"code_change\", \"rationale\": \"  Removed the three original_error_* fields  \"}\n```"
+	parsed := parseThreadResolution(output, 7)
+
+	if !parsed.Resolved || parsed.Reason != "code_change" {
+		t.Fatalf("expected resolved code_change, got %+v", parsed)
+	}
+	if parsed.Rationale != "Removed the three original_error_* fields" {
+		t.Errorf("rationale should be trimmed, got %q", parsed.Rationale)
+	}
+	if parsed.Index != 7 {
+		t.Errorf("index should be preserved, got %d", parsed.Index)
+	}
+}
+
+func TestToFixedThreads_PropagatesRationale(t *testing.T) {
+	resolutions := []ThreadResolution{
+		{Index: 0, Resolved: true, Reason: "code_change", Rationale: "dropped dead fields"},
+		{Index: 1, Resolved: false},
+		{Index: 2, Resolved: true, Reason: "dismissed"},
+	}
+	fixed := toFixedThreads(resolutions)
+
+	if len(fixed) != 2 {
+		t.Fatalf("expected 2 fixed threads, got %d", len(fixed))
+	}
+	if fixed[0].Rationale != "dropped dead fields" {
+		t.Errorf("first rationale should carry over, got %q", fixed[0].Rationale)
+	}
+	if fixed[1].Rationale != "" {
+		t.Errorf("empty rationale should stay empty, got %q", fixed[1].Rationale)
+	}
+}
+
+func TestResolutionFormat_RequestsRationale(t *testing.T) {
+	for _, fn := range map[string]func(*strings.Builder){
+		"writeResolutionFormat":           writeResolutionFormat,
+		"writeCodeChangeResolutionFormat": writeCodeChangeResolutionFormat,
+	} {
+		var b strings.Builder
+		fn(&b)
+		out := b.String()
+		if !strings.Contains(out, `"rationale"`) {
+			t.Errorf("prompt format should request a rationale field, got:\n%s", out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Incremental reviews could flag cascading edits that implemented a prior resolved suggestion — observed on [thetechfx/bedrock#1508](https://github.com/thetechfx/bedrock/pull/1508), where cycle 0 asked to drop three `original_error_*` fields from a service logger and cycle 1 flagged the matching test update as an observability regression. The incremental prompt only knew the path/line/title of resolved findings, so the link between the old guidance and the new diff was missing.

Three changes land together:

- **Fatten `ResolvedContext`** — carries the finding's full `Description`, `Suggestion`, and evaluator `Rationale`. Populated via `LocalPlatform.SavedFinding` in local mode and `FindingFromThread` (embedded JSON) in GitHub mode.
- **Explicit ping-pong guard** — the "Recently Resolved Issues" section now opens with a guard block: do not flag changes that *implement* the prior suggestion, cascading test/caller/cleanup edits count as part of the same fix, and any genuinely-new finding in the same area must open with why it is distinct.
- **Triage rationale** — triage prompts now request a one-sentence rationale in the JSON response. `ThreadResolution` and `fixedThread` carry it through to `ResolvedContext`, surfacing the narrative link (e.g. "Removed the three `original_error_*` fields from the service logger") in the incremental prompt as **Evaluator rationale:**.

## Test plan

- [x] `go test ./...` — green (incl. new `prompt_test.go` and three new triage tests covering rationale parsing, propagation, and both format writers)
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Dogfood on a PR where cycle 1 removes code/assertions per cycle 0's suggestion — confirm the incremental review does not re-raise it