### PR TITLE
feat: skip review when PR has merge conflicts

### DIFF
--- a/.github/workflows/codecanary.yml
+++ b/.github/workflows/codecanary.yml
@@ -51,7 +51,10 @@ jobs:
         run: |
           # GitHub computes .mergeable asynchronously; poll until it resolves.
           for i in 1 2 3 4 5 6 7 8 9 10; do
-            MERGEABLE=$(gh api "$PR_URL" --jq '.mergeable')
+            MERGEABLE=$(gh api "$PR_URL" --jq '.mergeable' 2>&1) || {
+              echo "gh api failed (attempt $i): $MERGEABLE"
+              MERGEABLE="null"
+            }
             if [ "$MERGEABLE" != "null" ]; then
               break
             fi
@@ -63,6 +66,8 @@ jobs:
             echo "skip=true" >> "$GITHUB_ENV"
           elif [ "$MERGEABLE" = "null" ]; then
             echo "mergeable still null after polling; proceeding"
+          else
+            echo "mergeable=$MERGEABLE; proceeding"
           fi
 
       - uses: actions/checkout@v6

--- a/.github/workflows/codecanary.yml
+++ b/.github/workflows/codecanary.yml
@@ -43,6 +43,28 @@ jobs:
         run: |
           echo "skip=true" >> "$GITHUB_ENV"
 
+      - name: Skip on merge conflicts
+        if: env.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.url || github.event.comment.pull_request_url }}
+        run: |
+          # GitHub computes .mergeable asynchronously; poll until it resolves.
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            MERGEABLE=$(gh api "$PR_URL" --jq '.mergeable')
+            if [ "$MERGEABLE" != "null" ]; then
+              break
+            fi
+            echo "mergeable not yet computed (attempt $i), waiting 3s..."
+            sleep 3
+          done
+          if [ "$MERGEABLE" = "false" ]; then
+            echo "Skipping: PR has merge conflicts"
+            echo "skip=true" >> "$GITHUB_ENV"
+          elif [ "$MERGEABLE" = "null" ]; then
+            echo "mergeable still null after polling; proceeding"
+          fi
+
       - uses: actions/checkout@v6
         if: env.skip != 'true'
         with:

--- a/internal/setup/codecanary.yml
+++ b/internal/setup/codecanary.yml
@@ -51,7 +51,10 @@ jobs:
         run: |
           # GitHub computes .mergeable asynchronously; poll until it resolves.
           for i in 1 2 3 4 5 6 7 8 9 10; do
-            MERGEABLE=$(gh api "$PR_URL" --jq '.mergeable')
+            MERGEABLE=$(gh api "$PR_URL" --jq '.mergeable' 2>&1) || {
+              echo "gh api failed (attempt $i): $MERGEABLE"
+              MERGEABLE="null"
+            }
             if [ "$MERGEABLE" != "null" ]; then
               break
             fi
@@ -63,6 +66,8 @@ jobs:
             echo "skip=true" >> "$GITHUB_ENV"
           elif [ "$MERGEABLE" = "null" ]; then
             echo "mergeable still null after polling; proceeding"
+          else
+            echo "mergeable=$MERGEABLE; proceeding"
           fi
 
       - uses: actions/checkout@v6

--- a/internal/setup/codecanary.yml
+++ b/internal/setup/codecanary.yml
@@ -43,6 +43,28 @@ jobs:
         run: |
           echo "skip=true" >> "$GITHUB_ENV"
 
+      - name: Skip on merge conflicts
+        if: env.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.url || github.event.comment.pull_request_url }}
+        run: |
+          # GitHub computes .mergeable asynchronously; poll until it resolves.
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            MERGEABLE=$(gh api "$PR_URL" --jq '.mergeable')
+            if [ "$MERGEABLE" != "null" ]; then
+              break
+            fi
+            echo "mergeable not yet computed (attempt $i), waiting 3s..."
+            sleep 3
+          done
+          if [ "$MERGEABLE" = "false" ]; then
+            echo "Skipping: PR has merge conflicts"
+            echo "skip=true" >> "$GITHUB_ENV"
+          elif [ "$MERGEABLE" = "null" ]; then
+            echo "mergeable still null after polling; proceeding"
+          fi
+
       - uses: actions/checkout@v6
         if: env.skip != 'true'
         with:


### PR DESCRIPTION
## Summary
- Add a preflight step in the CodeCanary workflow that polls `pull_request.mergeable` (up to 30s) and short-circuits via the existing `env.skip` pattern when GitHub reports conflicts.
- Avoids spending tokens on PRs that can't be merged until the author rebases, without touching the core review pipeline.
- Mirrored to both `internal/setup/codecanary.yml` (embedded template) and `.github/workflows/codecanary.yml` so the `TestEmbeddedWorkflowMatchesRepoFile` sync check stays green.

## Test plan
- [ ] `go test ./internal/setup/` passes (sync + round-trip tests).
- [ ] On a PR with a conflict: workflow run logs `Skipping: PR has merge conflicts` and downstream steps are gated off.
- [ ] On a clean PR: preflight logs mergeable quickly and the review step still runs.
- [ ] On a `pull_request_review_comment` reply event: PR URL resolves via `github.event.comment.pull_request_url` and the gate evaluates correctly.