### PR TITLE
feat: always emit a status review; edit in place on same SHA

### DIFF
--- a/.github/workflows/codecanary.yml
+++ b/.github/workflows/codecanary.yml
@@ -12,6 +12,13 @@ permissions:
   id-token: write
   pull-requests: write
 
+# Serialize CodeCanary runs per PR so two concurrent workflow runs never post
+# duplicate inline comments or race each other when editing the latest
+# top-level review body. Replies on the same PR queue behind the commit push.
+concurrency:
+  group: codecanary-pr-${{ github.event.pull_request.number || github.event.comment.pull_request_url }}
+  cancel-in-progress: false
+
 jobs:
   review:
     if: >-

--- a/docs/review-flow.md
+++ b/docs/review-flow.md
@@ -151,7 +151,14 @@ If the response is truncated (hit max output tokens), a warning is logged. The p
 
 ### 8. Publish results
 
-**GitHub CI**: Posts a review via the REST API with inline comments anchored to diff lines. Findings that can't be mapped to a diff position go in the review body. If all previous findings were resolved, old review comments are minimized (collapsed) for a cleaner PR. If there are no findings at all, a "clean" or "all clear" comment is posted.
+**GitHub CI**: Every cycle emits exactly one top-level CodeCanary review, decided by an edit-vs-post rule. `FetchLatestCodecanaryReview` reads the commit SHA from the most recent CodeCanary review's hidden marker:
+
+- **Same SHA** (reply-only run, or a duplicate `synchronize` webhook on the same HEAD): the existing body is updated in place with `UpdateReviewBody`. Only the status block between the `<!-- codecanary:status -->` markers is swapped — inline comments and prior findings text are untouched.
+- **Different or no SHA** (new commits, or first review on the PR): a fresh review is posted. The body variant depends on the cycle outcome — findings review, all-clear, activity summary (no new findings but cycle activity to surface), or clean review. All variants carry the same status block and baseline SHA marker. Older CodeCanary reviews are minimized (collapsed) before posting.
+
+The status block lists non-zero counts for: new findings, resolved by code, file removed, dismissed by author, acknowledged by author, rebutted by author, still unresolved. The block renders nothing when all counts are zero, so clean reviews remain copy-exact.
+
+Per-thread ack replies for dismissed/acknowledged/rebutted resolutions are posted earlier in the pipeline (`HandleResolutions`) and deduped via `<!-- codecanary:ack:<reason> -->` markers. Reply-only runs skip `SaveState` so the empty findings slice doesn't overwrite persisted state.
 
 **Local modes**: Prints the formatted result to stdout. Format depends on context: terminal (colored, human-readable), markdown, or JSON.
 

--- a/internal/review/github.go
+++ b/internal/review/github.go
@@ -238,8 +238,9 @@ func abs(x int) int {
 
 // PostReview posts a PR review with inline comments using the GitHub API.
 // Findings with file and line information become inline comments; others are
-// included in the review body.
-func PostReview(repo string, prNumber int, result *ReviewResult, diff string, commitSHA string) error {
+// included in the review body. The summary block is appended to the body so
+// the status dashboard appears on every CodeCanary top-level review.
+func PostReview(repo string, prNumber int, result *ReviewResult, diff string, commitSHA string, summary ReviewSummary) error {
 	// Sort findings by severity before formatting.
 	sortFindings(result.Findings)
 
@@ -268,7 +269,7 @@ func PostReview(repo string, prNumber int, result *ReviewResult, diff string, co
 		}
 	}
 
-	body := FormatReviewBody(result, canInline)
+	body := withSummary(FormatReviewBody(result, canInline), summary)
 
 	payload := reviewPayload{
 		Event:    "COMMENT",
@@ -573,8 +574,122 @@ func ReplyToThread(threadID, body string) error {
 
 // ghReview is the JSON shape for a PR review from the REST API.
 type ghReview struct {
+	ID     int64  `json:"id"`
 	NodeID string `json:"node_id"`
 	Body   string `json:"body"`
+}
+
+// LatestCodecanaryReview captures the identity and body of the most recent
+// CodeCanary top-level review, together with the commit SHA embedded in its
+// hidden marker. Returned by FetchLatestCodecanaryReview for the
+// "edit if same SHA, otherwise post new" publish decision.
+type LatestCodecanaryReview struct {
+	ID   int64
+	SHA  string
+	Body string
+}
+
+// FetchLatestCodecanaryReview returns the most recent top-level review on
+// the PR that carries a CodeCanary marker, along with the commit SHA
+// embedded in that marker. Returns (nil, nil) when no matching review
+// exists. A non-nil error is returned only for transport/parsing failures.
+func FetchLatestCodecanaryReview(repo string, prNumber int) (*LatestCodecanaryReview, error) {
+	owner, name, err := parseRepoSlug(repo)
+	if err != nil {
+		return nil, err
+	}
+
+	apiPath := fmt.Sprintf("repos/%s/%s/pulls/%d/reviews", owner, name, prNumber)
+	out, err := exec.Command("gh", "api", apiPath).Output()
+	if err != nil {
+		return nil, fmt.Errorf("fetching PR reviews: %w", err)
+	}
+
+	var reviews []ghReview
+	if err := json.Unmarshal(out, &reviews); err != nil {
+		return nil, fmt.Errorf("parsing PR reviews: %w", err)
+	}
+
+	// Walk newest → oldest so we return the latest CodeCanary review.
+	for i := len(reviews) - 1; i >= 0; i-- {
+		rev := reviews[i]
+		for _, prefix := range reviewMarkerPrefixes {
+			idx := strings.Index(rev.Body, prefix)
+			if idx < 0 {
+				continue
+			}
+			start := idx + len(prefix)
+			endIdx := strings.Index(rev.Body[start:], reviewMarkerSuffix)
+			if endIdx < 0 {
+				continue
+			}
+			jsonData := rev.Body[start : start+endIdx]
+			var payload struct {
+				SHA string `json:"sha"`
+			}
+			// Ignore unmarshal errors so old reviews that embed a richer
+			// ReviewResult (also containing a "sha" field) still match.
+			_ = json.Unmarshal([]byte(jsonData), &payload)
+			return &LatestCodecanaryReview{
+				ID:   rev.ID,
+				SHA:  payload.SHA,
+				Body: rev.Body,
+			}, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// UpdateReviewBody replaces the body of an existing PR review via the
+// GitHub REST API. Used when a reply-only run (or a duplicate synchronize
+// webhook on the same HEAD) needs to refresh the latest CodeCanary review's
+// counts instead of posting a new top-level comment.
+func UpdateReviewBody(repo string, prNumber int, reviewID int64, body string) error {
+	owner, name, err := parseRepoSlug(repo)
+	if err != nil {
+		return err
+	}
+
+	payload, err := json.Marshal(struct {
+		Body string `json:"body"`
+	}{Body: body})
+	if err != nil {
+		return fmt.Errorf("marshaling update payload: %w", err)
+	}
+
+	apiPath := fmt.Sprintf("repos/%s/%s/pulls/%d/reviews/%d", owner, name, prNumber, reviewID)
+	_, err = ghAPIRequest("PUT", apiPath, payload)
+	return err
+}
+
+// ghAPIRequest is a generic gh api wrapper that preserves the temp-file
+// pattern used by ghAPIPOST (avoids stdin pipe truncation on large bodies).
+func ghAPIRequest(method, apiPath string, payloadJSON []byte) ([]byte, error) {
+	dir, err := os.MkdirTemp("", "codecanary-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	tmpFile, err := os.CreateTemp(dir, "payload.json")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp file: %w", err)
+	}
+	if _, err := tmpFile.Write(payloadJSON); err != nil {
+		_ = tmpFile.Close()
+		return nil, fmt.Errorf("writing payload to temp file: %w", err)
+	}
+	_ = tmpFile.Close()
+
+	cmd := exec.Command("gh", "api", apiPath, "--method", method, "--input", tmpFile.Name())
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return stdout.Bytes(), &apiError{Err: err, Stderr: stderr.String(), Response: stdout.String()}
+	}
+	return stdout.Bytes(), nil
 }
 
 // FetchPreviousReviewSHA gets the SHA from the last review's hidden data.
@@ -707,8 +822,8 @@ func GetIncrementalDiff(baseSHA string) (string, error) {
 // commitSHA is embedded in a hidden marker so future runs treat it as the
 // baseline for incremental reviews, avoiding a redundant full re-review on the
 // next push.
-func PostCleanReview(repo string, prNumber int, commitSHA string) error {
-	return postSimpleReview(repo, prNumber, buildCleanReviewBody(commitSHA))
+func PostCleanReview(repo string, prNumber int, commitSHA string, summary ReviewSummary) error {
+	return postSimpleReview(repo, prNumber, buildCleanReviewBody(commitSHA, summary))
 }
 
 // PostAllClearReview posts a review when all previous findings have been
@@ -716,25 +831,52 @@ func PostCleanReview(repo string, prNumber int, commitSHA string) error {
 // visible old reviews. The commitSHA is embedded in a hidden marker so future
 // runs treat it as the baseline for incremental reviews; without it, the next
 // push would fall back to reviewing the entire PR again.
-func PostAllClearReview(repo string, prNumber int, commitSHA string, minimizeFailed bool) error {
-	return postSimpleReview(repo, prNumber, buildAllClearReviewBody(commitSHA, minimizeFailed))
+func PostAllClearReview(repo string, prNumber int, commitSHA string, minimizeFailed bool, summary ReviewSummary) error {
+	return postSimpleReview(repo, prNumber, buildAllClearReviewBody(commitSHA, minimizeFailed, summary))
+}
+
+// PostActivityReview posts a review when no new findings were raised but
+// there is cycle activity worth surfacing (dismissals, acknowledgments,
+// rebuttals, still-open threads). This keeps every commit push producing a
+// visible top-level status comment instead of silently logging.
+func PostActivityReview(repo string, prNumber int, commitSHA string, summary ReviewSummary) error {
+	return postSimpleReview(repo, prNumber, buildActivityReviewBody(commitSHA, summary))
 }
 
 // buildCleanReviewBody renders the full Markdown body posted by
 // PostCleanReview. Split out from the poster so tests can assert the exact
 // string that lands on GitHub without having to mock gh.
-func buildCleanReviewBody(commitSHA string) string {
-	return "CodeCanary reviewed this PR \u2014 no issues found." + embedBaselineMarker(commitSHA)
+func buildCleanReviewBody(commitSHA string, summary ReviewSummary) string {
+	return withSummary("CodeCanary reviewed this PR \u2014 no issues found.", summary) + embedBaselineMarker(commitSHA)
 }
 
 // buildAllClearReviewBody renders the full Markdown body posted by
 // PostAllClearReview. Split out for the same reason as buildCleanReviewBody.
-func buildAllClearReviewBody(commitSHA string, minimizeFailed bool) string {
+func buildAllClearReviewBody(commitSHA string, minimizeFailed bool, summary ReviewSummary) string {
 	body := "## \U0001F425 CodeCanary\n\n\u2705 All previous findings have been addressed. No new issues found. \u2728"
 	if minimizeFailed {
 		body += "\n\n> \u26A0\uFE0F Some previous review comments could not be minimized and may still be visible."
 	}
-	return body + embedBaselineMarker(commitSHA)
+	return withSummary(body, summary) + embedBaselineMarker(commitSHA)
+}
+
+// buildActivityReviewBody renders the body for a commit push that raised no
+// new findings but has cycle activity (dismissals/acknowledgments/rebuttals
+// or still-open threads carried forward).
+func buildActivityReviewBody(commitSHA string, summary ReviewSummary) string {
+	body := "## \U0001F425 CodeCanary\n\nReviewed this push \u2014 no new issues found."
+	return withSummary(body, summary) + embedBaselineMarker(commitSHA)
+}
+
+// withSummary appends the status summary block to a review body. The block
+// is skipped when the summary has no non-zero counts, so existing clean/
+// all-clear bodies render identically when nothing happened.
+func withSummary(body string, summary ReviewSummary) string {
+	block := renderSummaryBlock(summary)
+	if block == "" {
+		return body
+	}
+	return body + block
 }
 
 // embedBaselineMarker returns a hidden HTML comment containing the commitSHA

--- a/internal/review/github_test.go
+++ b/internal/review/github_test.go
@@ -51,7 +51,7 @@ func TestEmbedBaselineMarkerFormat(t *testing.T) {
 }
 
 func TestBuildCleanReviewBody(t *testing.T) {
-	got := buildCleanReviewBody("abc123")
+	got := buildCleanReviewBody("abc123", ReviewSummary{})
 	want := "CodeCanary reviewed this PR \u2014 no issues found.\n<!-- codecanary:review {\"sha\":\"abc123\"} -->\n"
 	if got != want {
 		t.Errorf("body =\n%q\nwant\n%q", got, want)
@@ -59,15 +59,31 @@ func TestBuildCleanReviewBody(t *testing.T) {
 }
 
 func TestBuildCleanReviewBodyNoSHA(t *testing.T) {
-	got := buildCleanReviewBody("")
+	got := buildCleanReviewBody("", ReviewSummary{})
 	want := "CodeCanary reviewed this PR \u2014 no issues found."
 	if got != want {
 		t.Errorf("body =\n%q\nwant\n%q", got, want)
 	}
 }
 
+func TestBuildCleanReviewBodyWithSummary(t *testing.T) {
+	got := buildCleanReviewBody("abc123", ReviewSummary{NewFindings: 2, StillOpen: 1})
+	if !strings.Contains(got, statusBlockOpen) || !strings.Contains(got, statusBlockClose) {
+		t.Errorf("body missing status markers:\n%q", got)
+	}
+	if !strings.Contains(got, "New findings: **2**") {
+		t.Errorf("body missing new findings count:\n%q", got)
+	}
+	if !strings.Contains(got, "Still unresolved: **1**") {
+		t.Errorf("body missing still-unresolved count:\n%q", got)
+	}
+	if !strings.HasSuffix(got, "\n<!-- codecanary:review {\"sha\":\"abc123\"} -->\n") {
+		t.Errorf("body missing trailing baseline marker:\n%q", got)
+	}
+}
+
 func TestBuildAllClearReviewBody(t *testing.T) {
-	got := buildAllClearReviewBody("abc123", false)
+	got := buildAllClearReviewBody("abc123", false, ReviewSummary{})
 	wantSuffix := "\n<!-- codecanary:review {\"sha\":\"abc123\"} -->\n"
 	if !strings.HasSuffix(got, wantSuffix) {
 		t.Errorf("body missing marker suffix:\n%q", got)
@@ -81,12 +97,28 @@ func TestBuildAllClearReviewBody(t *testing.T) {
 }
 
 func TestBuildAllClearReviewBodyMinimizeFailed(t *testing.T) {
-	got := buildAllClearReviewBody("abc123", true)
+	got := buildAllClearReviewBody("abc123", true, ReviewSummary{})
 	if !strings.Contains(got, "could not be minimized") {
 		t.Errorf("expected minimize-warning text, got:\n%q", got)
 	}
 	wantSuffix := "\n<!-- codecanary:review {\"sha\":\"abc123\"} -->\n"
 	if !strings.HasSuffix(got, wantSuffix) {
 		t.Errorf("body missing marker suffix:\n%q", got)
+	}
+}
+
+func TestBuildActivityReviewBody(t *testing.T) {
+	got := buildActivityReviewBody("abc123", ReviewSummary{Dismissed: 1, Rebutted: 2, StillOpen: 3})
+	if !strings.Contains(got, "no new issues found") {
+		t.Errorf("body missing activity copy:\n%q", got)
+	}
+	if !strings.Contains(got, "Dismissed by author: **1**") {
+		t.Errorf("body missing dismissed count:\n%q", got)
+	}
+	if !strings.Contains(got, "Rebutted by author: **2**") {
+		t.Errorf("body missing rebutted count:\n%q", got)
+	}
+	if !strings.HasSuffix(got, "\n<!-- codecanary:review {\"sha\":\"abc123\"} -->\n") {
+		t.Errorf("body missing trailing baseline marker:\n%q", got)
 	}
 }

--- a/internal/review/platform_github.go
+++ b/internal/review/platform_github.go
@@ -194,7 +194,30 @@ func (g *GithubPlatform) Publish(result *ReviewResult, pr *PRData, threads []Rev
 		return nil
 	}
 
-	// Minimize previous reviews before posting.
+	summary := computeReviewSummary(threads, fixed, result.Findings)
+
+	// Decide edit-vs-post: if the latest CodeCanary review on the PR carries
+	// the current HEAD SHA in its marker, this is either a reply-only run or
+	// a duplicate synchronize webhook — refresh that review in place rather
+	// than stacking another top-level comment.
+	latest, latestErr := FetchLatestCodecanaryReview(g.Repo, g.PRNumber)
+	if latestErr != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not fetch latest review for dedup: %v\n", latestErr)
+	}
+	if latest != nil && result.SHA != "" && latest.SHA == result.SHA {
+		updated := replaceSummaryBlock(latest.Body, summary)
+		if updated == latest.Body {
+			Stderrf(ansiGreen, "Latest review already current for %s — no update needed\n", shortSHA(result.SHA))
+			return nil
+		}
+		if err := UpdateReviewBody(g.Repo, g.PRNumber, latest.ID, updated); err != nil {
+			return fmt.Errorf("updating review body: %w", err)
+		}
+		Stderrf(ansiGreen, "Updated latest review on PR #%d\n", g.PRNumber)
+		return nil
+	}
+
+	// Minimize previous reviews before posting a fresh one.
 	minimizeFailed := false
 	if len(threads) > 0 {
 		if nodeIDs, err := FindReviewNodeIDs(g.Repo, g.PRNumber); err == nil {
@@ -223,28 +246,27 @@ func (g *GithubPlatform) Publish(result *ReviewResult, pr *PRData, threads []Rev
 		}
 	}
 
-	// Post one of: new findings, all-clear, clean review, or nothing.
-	if len(result.Findings) > 0 {
-		if err := PostReview(g.Repo, g.PRNumber, result, pr.ValidationDiff(), result.SHA); err != nil {
+	// POST path — pick the body shape that fits the cycle outcome. Every
+	// branch emits a top-level review so each push lands a visible status
+	// comment on the PR.
+	switch {
+	case len(result.Findings) > 0:
+		if err := PostReview(g.Repo, g.PRNumber, result, pr.ValidationDiff(), result.SHA, summary); err != nil {
 			return fmt.Errorf("posting review: %w", err)
 		}
 		Stderrf(ansiGreen, "Review posted to PR #%d\n", g.PRNumber)
-	} else if len(threads) > 0 && allResolved(threads, fixed) {
-		if err := PostAllClearReview(g.Repo, g.PRNumber, result.SHA, minimizeFailed); err != nil {
+	case len(threads) > 0 && allResolved(threads, fixed):
+		if err := PostAllClearReview(g.Repo, g.PRNumber, result.SHA, minimizeFailed, summary); err != nil {
 			return fmt.Errorf("posting all-clear review: %w", err)
 		}
 		Stderrf(ansiGreen, "All clear! No issues remaining.\n")
-	} else if len(threads) > 0 {
-		codeFixedSet := make(map[int]bool, len(fixed))
-		for _, f := range fixed {
-			if f.Index >= 0 && f.Index < len(threads) && isTrueResolution(f.Reason) {
-				codeFixedSet[f.Index] = true
-			}
+	case len(threads) > 0:
+		if err := PostActivityReview(g.Repo, g.PRNumber, result.SHA, summary); err != nil {
+			return fmt.Errorf("posting activity review: %w", err)
 		}
-		unresolvedCount := len(threads) - len(codeFixedSet)
-		fmt.Fprintf(os.Stderr, "No new findings. %d previous thread(s) still unresolved.\n", unresolvedCount)
-	} else {
-		if err := PostCleanReview(g.Repo, g.PRNumber, result.SHA); err != nil {
+		Stderrf(ansiGreen, "Posted activity summary to PR #%d\n", g.PRNumber)
+	default:
+		if err := PostCleanReview(g.Repo, g.PRNumber, result.SHA, summary); err != nil {
 			return fmt.Errorf("posting review: %w", err)
 		}
 		Stderrf(ansiGreen, "Review posted to PR #%d\n", g.PRNumber)

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -454,25 +454,13 @@ func Run(opts RunOptions) error {
 		SHA:       headSHA,
 	}
 
-	// Handle early return for "no new changes" with no open findings.
-	// This fires when the incremental diff is empty and nothing is carried
-	// forward. Skipping Publish is intentional: there is nothing new to
-	// review and nothing to acknowledge, so emitting another comment would
-	// be noise. The baseline marker stays at the previous review's SHA,
-	// which is the correct comparison point for the next push — an empty
-	// diff means the tree is unchanged, so advancing the baseline would
-	// produce the same incremental diff next time either way.
-	if prompt == "" && len(findings) == 0 && len(stillOpenFindings) == 0 && isIncremental {
-		return nil
-	}
-
 	// 9. Publish results via the platform adapter.
-	// In reply-only mode, per-thread ack replies are posted earlier;
-	// skip top-level review comments, minimization, and all-clear posts.
-	if !opts.ReplyOnly {
-		if err := platform.Publish(result, pr, reviewThreads, fixed); err != nil {
-			return err
-		}
+	// Reply-only runs still publish so the latest top-level review's status
+	// block is refreshed in place (Publish routes same-SHA runs to the edit
+	// path). Skipping here would leave the PR summary stale after author
+	// replies.
+	if err := platform.Publish(result, pr, reviewThreads, fixed); err != nil {
+		return err
 	}
 
 	// 10. Save state for future incremental reviews.

--- a/internal/review/summary.go
+++ b/internal/review/summary.go
@@ -1,0 +1,115 @@
+package review
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ReviewSummary holds per-cycle counts used to render the status block that
+// appears at the top of every CodeCanary top-level review body.
+type ReviewSummary struct {
+	NewFindings    int // new findings raised this cycle
+	ResolvedByCode int // previous findings resolved by code changes
+	FileRemoved    int // previous findings whose file was removed from the PR
+	Dismissed      int
+	Acknowledged   int
+	Rebutted       int
+	StillOpen      int // threads still open with no classification this cycle
+}
+
+// hasContent reports whether any bucket has a non-zero count.
+func (s ReviewSummary) hasContent() bool {
+	return s.NewFindings+s.ResolvedByCode+s.FileRemoved+
+		s.Dismissed+s.Acknowledged+s.Rebutted+s.StillOpen > 0
+}
+
+// Status block markers used to replace the block in place when a reply-only
+// run (or duplicate synchronize webhook) edits the latest CodeCanary review.
+const (
+	statusBlockOpen  = "<!-- codecanary:status -->"
+	statusBlockClose = "<!-- /codecanary:status -->"
+)
+
+// renderSummaryBlock returns a Markdown block listing non-zero counts.
+// Returns an empty string when all counts are zero. Callers append the
+// result to the review body. The block is wrapped in HTML-comment markers
+// so replaceSummaryBlock can find and update it on subsequent edits.
+func renderSummaryBlock(s ReviewSummary) string {
+	if !s.hasContent() {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "\n%s\n### Status\n\n", statusBlockOpen)
+	row := func(label string, n int) {
+		if n == 0 {
+			return
+		}
+		fmt.Fprintf(&b, "- %s: **%d**\n", label, n)
+	}
+	row("New findings", s.NewFindings)
+	row("Resolved by code", s.ResolvedByCode)
+	row("File removed", s.FileRemoved)
+	row("Dismissed by author", s.Dismissed)
+	row("Acknowledged by author", s.Acknowledged)
+	row("Rebutted by author", s.Rebutted)
+	row("Still unresolved", s.StillOpen)
+	fmt.Fprintf(&b, "%s\n", statusBlockClose)
+	return b.String()
+}
+
+// replaceSummaryBlock replaces an existing status block in body with the
+// block rendered from summary. If no status block exists, the new block is
+// appended. When summary is empty, any existing block is stripped.
+func replaceSummaryBlock(body string, summary ReviewSummary) string {
+	newBlock := renderSummaryBlock(summary)
+	open := strings.Index(body, statusBlockOpen)
+	if open < 0 {
+		return body + newBlock
+	}
+	// Trim one leading newline so we don't accumulate blank lines on
+	// repeated edits (renderSummaryBlock prepends "\n").
+	start := open
+	if start > 0 && body[start-1] == '\n' {
+		start--
+	}
+	closeIdx := strings.Index(body[open:], statusBlockClose)
+	if closeIdx < 0 {
+		// Malformed marker — replace from the open tag to end of body.
+		return body[:start] + newBlock
+	}
+	end := open + closeIdx + len(statusBlockClose)
+	// Consume a trailing newline from the old block so we don't double up.
+	if end < len(body) && body[end] == '\n' {
+		end++
+	}
+	return body[:start] + newBlock + body[end:]
+}
+
+// computeReviewSummary builds a ReviewSummary from the fixed thread
+// resolutions, the full prior thread list, and the new findings emitted
+// this cycle. The StillOpen bucket captures threads that were not
+// classified by this cycle (no code fix, no author activity).
+func computeReviewSummary(threads []ReviewThread, fixed []fixedThread, newFindings []Finding) ReviewSummary {
+	s := ReviewSummary{NewFindings: len(newFindings)}
+	fixedSet := make(map[int]bool, len(fixed))
+	for _, f := range fixed {
+		if f.Index < 0 || f.Index >= len(threads) {
+			continue
+		}
+		fixedSet[f.Index] = true
+		switch f.Reason {
+		case "code_change":
+			s.ResolvedByCode++
+		case "file_removed":
+			s.FileRemoved++
+		case "dismissed":
+			s.Dismissed++
+		case "acknowledged":
+			s.Acknowledged++
+		case "rebutted":
+			s.Rebutted++
+		}
+	}
+	s.StillOpen = len(threads) - len(fixedSet)
+	return s
+}

--- a/internal/review/summary_test.go
+++ b/internal/review/summary_test.go
@@ -1,0 +1,88 @@
+package review
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderSummaryBlockEmpty(t *testing.T) {
+	if got := renderSummaryBlock(ReviewSummary{}); got != "" {
+		t.Errorf("expected empty string for zero summary, got %q", got)
+	}
+}
+
+func TestRenderSummaryBlockOmitsZeroRows(t *testing.T) {
+	got := renderSummaryBlock(ReviewSummary{Dismissed: 2})
+	if !strings.Contains(got, "Dismissed by author: **2**") {
+		t.Errorf("missing dismissed row:\n%q", got)
+	}
+	if strings.Contains(got, "New findings") {
+		t.Errorf("zero-count New findings row should be omitted:\n%q", got)
+	}
+	if !strings.Contains(got, statusBlockOpen) || !strings.Contains(got, statusBlockClose) {
+		t.Errorf("status block markers missing:\n%q", got)
+	}
+}
+
+func TestComputeReviewSummary(t *testing.T) {
+	threads := []ReviewThread{{}, {}, {}, {}, {}}
+	fixed := []fixedThread{
+		{Index: 0, Reason: "code_change"},
+		{Index: 1, Reason: "dismissed"},
+		{Index: 2, Reason: "rebutted"},
+		{Index: 3, Reason: "file_removed"},
+	}
+	findings := []Finding{{ID: "a"}, {ID: "b"}}
+
+	got := computeReviewSummary(threads, fixed, findings)
+	want := ReviewSummary{
+		NewFindings:    2,
+		ResolvedByCode: 1,
+		FileRemoved:    1,
+		Dismissed:      1,
+		Rebutted:       1,
+		StillOpen:      1, // thread index 4 not in fixed
+	}
+	if got != want {
+		t.Errorf("summary = %+v, want %+v", got, want)
+	}
+}
+
+func TestReplaceSummaryBlockAppendsWhenMissing(t *testing.T) {
+	body := "hello"
+	got := replaceSummaryBlock(body, ReviewSummary{NewFindings: 1})
+	if !strings.HasPrefix(got, "hello") {
+		t.Errorf("existing body should be preserved:\n%q", got)
+	}
+	if !strings.Contains(got, statusBlockOpen) {
+		t.Errorf("new block should be appended:\n%q", got)
+	}
+}
+
+func TestReplaceSummaryBlockUpdatesInPlace(t *testing.T) {
+	original := "prefix\n" + renderSummaryBlock(ReviewSummary{NewFindings: 1}) + "suffix"
+	updated := replaceSummaryBlock(original, ReviewSummary{Dismissed: 2})
+	if strings.Contains(updated, "New findings") {
+		t.Errorf("old block should be replaced, got:\n%q", updated)
+	}
+	if !strings.Contains(updated, "Dismissed by author: **2**") {
+		t.Errorf("new block should be present, got:\n%q", updated)
+	}
+	if !strings.HasPrefix(updated, "prefix\n") {
+		t.Errorf("prefix should be preserved, got:\n%q", updated)
+	}
+	if !strings.HasSuffix(updated, "suffix") {
+		t.Errorf("suffix should be preserved, got:\n%q", updated)
+	}
+}
+
+func TestReplaceSummaryBlockStripsWhenEmpty(t *testing.T) {
+	original := "prefix\n" + renderSummaryBlock(ReviewSummary{NewFindings: 1}) + "suffix"
+	updated := replaceSummaryBlock(original, ReviewSummary{})
+	if strings.Contains(updated, statusBlockOpen) {
+		t.Errorf("status block should be stripped when empty, got:\n%q", updated)
+	}
+	if !strings.HasPrefix(updated, "prefix\n") || !strings.HasSuffix(updated, "suffix") {
+		t.Errorf("non-block content should be preserved, got:\n%q", updated)
+	}
+}

--- a/internal/setup/codecanary.yml
+++ b/internal/setup/codecanary.yml
@@ -12,6 +12,13 @@ permissions:
   id-token: write
   pull-requests: write
 
+# Serialize CodeCanary runs per PR so two concurrent workflow runs never post
+# duplicate inline comments or race each other when editing the latest
+# top-level review body. Replies on the same PR queue behind the commit push.
+concurrency:
+  group: codecanary-pr-${{ github.event.pull_request.number || github.event.comment.pull_request_url }}
+  cancel-in-progress: false
+
 jobs:
   review:
     if: >-


### PR DESCRIPTION
## Summary

Every PR event now produces exactly one visible top-level CodeCanary review, and the body is kept fresh as author activity lands.

**Decision rule** (one line): fetch the latest CodeCanary top-level review; if its embedded commit SHA equals current HEAD → edit its body in place; otherwise → post a new review.

This collapses three behaviors into one rule:

- **New commits** — previous review marker has an older SHA → POST a new top-level review (findings, all-clear, activity summary, or clean).
- **Reply-only events** (`pull_request_review_comment`) — HEAD is unchanged, so the latest review matches → EDIT the body in place (updates the status counts after dismissals / acknowledgments / rebuttals).
- **Duplicate `synchronize` webhook on same SHA** — same rule applies, EDIT wins → no more double-posts.

### What changed for users

Before: a commit push with no new findings but some previously-flagged threads still open was silent at the PR level (stderr only). Reply-only events never updated the top-level review.

After: every cycle surfaces a **Status** block listing non-zero counts:

- New findings
- Resolved by code
- File removed
- Dismissed by author
- Acknowledged by author
- Rebutted by author
- Still unresolved

### Implementation notes

- Status block is wrapped in `<!-- codecanary:status -->` / `<!-- /codecanary:status -->` HTML markers so `replaceSummaryBlock` can swap it in place without touching inline comments, findings copy, or the hidden baseline marker.
- New `FetchLatestCodecanaryReview` reads the REST `/pulls/:n/reviews` endpoint and returns the review ID + embedded SHA + body of the most recent CodeCanary top-level review.
- New `UpdateReviewBody` calls `PUT /pulls/:n/reviews/:id` to refresh the body.
- New `PostActivityReview` covers the "no new findings, but activity to surface" path (commit push where all findings were dismissed / acknowledged / rebutted instead of fixed).
- `PostReview` / `PostCleanReview` / `PostAllClearReview` now accept a `ReviewSummary` that is appended to the body. Empty summaries append nothing, so existing copy is unchanged when there's nothing to report.
- Dropped the old early-return in `runner.go` that silently skipped Publish when the incremental diff was empty — Publish's edit path handles this correctly (body stays identical → no API call).
- Workflow gains a `concurrency` group keyed on PR number so two workflow runs can never race on the same PR (belt-and-suspenders over the SHA-based edit dedup).
- `docs/review-flow.md` updated to describe the new publish flow.

## Test plan

- [x] `go test ./...` passes (including the workflow sync check in `internal/setup/`).
- [x] `go vet ./...` clean.
- [x] `golangci-lint run ./...` clean.
- [x] `go build ./cmd/review` builds.
- [ ] On a live PR: push a commit → new top-level review lands with the Status block.
- [ ] Reply to a thread with a dismissal → CodeCanary edits the latest review body in place (same commit, no duplicate post).
- [ ] Push another commit → CodeCanary posts a new top-level review and minimizes the previous one.
- [ ] Duplicate `synchronize` webhook (if reproducible) → second run edits rather than double-posts.