### PR TITLE
feat: support Anthropic advisor tool for review calls

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,8 @@ provider: anthropic             # required: anthropic, openai, openrouter, or cl
 
 review_model: claude-sonnet-4-6 # model for main review (provider-specific default)
 triage_model: claude-haiku-4-5-20251001  # required: model for thread re-evaluation
+advisor_model: claude-opus-4-7  # optional: enables the Anthropic advisor tool for the review call
+                                # (anthropic + claude providers only)
 
 api_key_env: ANTHROPIC_API_KEY  # env var holding the API key (default per provider)
 api_base: https://...           # override base URL (openai provider only)
@@ -132,6 +134,23 @@ claude_path: /usr/local/bin/claude-beta
 | `openai` | `gpt-5.4` | `gpt-5.4-mini` |
 | `openrouter` | `anthropic/claude-sonnet-4-6` | `anthropic/claude-haiku-4-5-20251001` |
 | `claude` | `claude-sonnet-4-6` | `haiku` |
+
+## Advisor tool (optional)
+
+When `advisor_model` is set, the review call uses Anthropic's [advisor tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool): a faster executor (your `review_model`) consults a stronger advisor model mid-generation. Only the review call uses it — triage stays on `triage_model` because advisor adds cost that is hard to justify on short classifier prompts.
+
+Supported on `anthropic` and `claude` providers only. Executor must be one of `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6`, or `claude-opus-4-7`. The advisor must be `claude-opus-4-7` (CLI aliases `opus` accepted for the `claude` provider).
+
+- On the `anthropic` provider, codecanary sends the `advisor-tool-2026-03-01` beta header and the `advisor_20260301` tool entry. The response's `usage.iterations[]` is split so advisor tokens bill at the advisor model's rate.
+- On the `claude` provider, codecanary sets `CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL=1` and injects `{"advisorModel": "…"}` via `--settings`. The feature is flagged as experimental in the Claude CLI; the env gate is required.
+
+```yaml
+version: 1
+provider: anthropic
+review_model: claude-sonnet-4-6
+triage_model: claude-haiku-4-5-20251001
+advisor_model: claude-opus-4-7
+```
 
 ## Budget enforcement
 

--- a/docs/review-flow.md
+++ b/docs/review-flow.md
@@ -44,7 +44,7 @@ If the PR is a setup PR (only adds workflow files with no real code changes), th
 
 Two `ModelProvider` instances are created from config:
 
-- **Review provider**: The main model that reviews code (configured via `review_model` in config).
+- **Review provider**: The main model that reviews code (configured via `review_model` in config). When `advisor_model` is set (anthropic or claude provider only), the review provider also enables Anthropic's server-side advisor tool so a stronger advisor model can weigh in mid-generation — the triage provider never uses advisor, since its classifier turns are too short to benefit.
 - **Triage provider**: A cheaper model for re-evaluating previous findings (configured via `triage_model` in config).
 
 Each provider is constructed via the factory registry in `provider.go`. The provider name determines which adapter handles the API call (Anthropic, OpenAI, OpenRouter, or Claude CLI).

--- a/internal/review/advisor.go
+++ b/internal/review/advisor.go
@@ -1,0 +1,64 @@
+package review
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Anthropic advisor tool constants.
+//
+// The advisor tool lets a faster executor model consult a higher-intelligence
+// advisor model mid-generation for strategic guidance. Anthropic exposes it as
+// a server-side tool; the executor emits a server_tool_use block with empty
+// input and the server runs a separate sub-inference on the advisor model.
+//
+// See: https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool
+const (
+	advisorBetaHeader = "advisor-tool-2026-03-01"
+	advisorToolType   = "advisor_20260301"
+	advisorToolName   = "advisor"
+)
+
+// advisorValidExecutors lists executor model substrings supported by the
+// advisor tool. The advisor model itself must be at least as capable as the
+// executor; Anthropic's documented pairings use claude-opus-4-7 as the advisor.
+var advisorValidExecutors = []string{
+	"claude-haiku-4-5",
+	"claude-sonnet-4-6",
+	"claude-opus-4-6",
+	"claude-opus-4-7",
+	// CLI aliases — the Claude CLI resolves these server-side.
+	"haiku", "sonnet", "opus",
+}
+
+// advisorValidAdvisors lists advisor model substrings supported by the tool.
+// Anthropic's beta currently only ships claude-opus-4-7 as a valid advisor.
+var advisorValidAdvisors = []string{
+	"claude-opus-4-7",
+	"opus",
+}
+
+// validateAdvisorPairing checks whether the given executor/advisor pair is
+// supported by the advisor tool. Matches by substring so provider-specific
+// aliases (e.g. "sonnet") and dated IDs both work.
+func validateAdvisorPairing(provider, executor, advisor string) error {
+	execOK := matchesAdvisorModel(executor, advisorValidExecutors)
+	advOK := matchesAdvisorModel(advisor, advisorValidAdvisors)
+	if !execOK {
+		return fmt.Errorf("advisor_model not supported for review_model %q — executor must be one of %s", executor, strings.Join(advisorValidExecutors, ", "))
+	}
+	if !advOK {
+		return fmt.Errorf("advisor_model %q is not a supported advisor — advisor must be one of %s", advisor, strings.Join(advisorValidAdvisors, ", "))
+	}
+	return nil
+}
+
+func matchesAdvisorModel(model string, candidates []string) bool {
+	lower := strings.ToLower(strings.TrimSpace(model))
+	for _, c := range candidates {
+		if lower == c || strings.Contains(lower, c) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/review/advisor.go
+++ b/internal/review/advisor.go
@@ -19,44 +19,79 @@ const (
 	advisorToolName   = "advisor"
 )
 
-// advisorValidExecutors lists executor model substrings supported by the
-// advisor tool. The advisor model itself must be at least as capable as the
-// executor; Anthropic's documented pairings use claude-opus-4-7 as the advisor.
-var advisorValidExecutors = []string{
+// advisorValidExecutorIDs lists full model IDs supported as the executor for
+// the advisor tool, matched by exact substring (so dated variants like
+// claude-haiku-4-5-20251001 are accepted).
+var advisorValidExecutorIDs = []string{
 	"claude-haiku-4-5",
 	"claude-sonnet-4-6",
 	"claude-opus-4-6",
 	"claude-opus-4-7",
-	// CLI aliases — the Claude CLI resolves these server-side.
+}
+
+// advisorValidAdvisorIDs lists full model IDs supported as the advisor.
+// Anthropic's beta currently only ships claude-opus-4-7 as a valid advisor.
+var advisorValidAdvisorIDs = []string{
+	"claude-opus-4-7",
+}
+
+// advisorValidCLIAliases lists Claude CLI short aliases the user may type for
+// either executor or advisor. The CLI resolves these server-side, so we can't
+// know the exact model without querying — but we can at least accept the
+// documented short names.
+var advisorValidCLIAliases = []string{
 	"haiku", "sonnet", "opus",
 }
 
-// advisorValidAdvisors lists advisor model substrings supported by the tool.
-// Anthropic's beta currently only ships claude-opus-4-7 as a valid advisor.
-var advisorValidAdvisors = []string{
-	"claude-opus-4-7",
-	"opus",
-}
-
 // validateAdvisorPairing checks whether the given executor/advisor pair is
-// supported by the advisor tool. Matches by substring so provider-specific
-// aliases (e.g. "sonnet") and dated IDs both work.
-func validateAdvisorPairing(provider, executor, advisor string) error {
-	execOK := matchesAdvisorModel(executor, advisorValidExecutors)
-	advOK := matchesAdvisorModel(advisor, advisorValidAdvisors)
-	if !execOK {
-		return fmt.Errorf("advisor_model not supported for review_model %q — executor must be one of %s", executor, strings.Join(advisorValidExecutors, ", "))
+// supported. Full model IDs are matched by substring; short CLI aliases are
+// matched by exact equality so `"opus"` does not match `"claude-opus-4-7"`.
+func validateAdvisorPairing(executor, advisor string) error {
+	if !isValidAdvisorExecutor(executor) {
+		return fmt.Errorf("advisor_model not supported for review_model %q — executor must be one of %s (or CLI aliases %s)",
+			executor,
+			strings.Join(advisorValidExecutorIDs, ", "),
+			strings.Join(advisorValidCLIAliases, ", "))
 	}
-	if !advOK {
-		return fmt.Errorf("advisor_model %q is not a supported advisor — advisor must be one of %s", advisor, strings.Join(advisorValidAdvisors, ", "))
+	if !isValidAdvisor(advisor) {
+		return fmt.Errorf("advisor_model %q is not a supported advisor — advisor must be %s (or CLI alias %q)",
+			advisor,
+			strings.Join(advisorValidAdvisorIDs, ", "),
+			"opus")
 	}
 	return nil
 }
 
-func matchesAdvisorModel(model string, candidates []string) bool {
-	lower := strings.ToLower(strings.TrimSpace(model))
-	for _, c := range candidates {
-		if lower == c || strings.Contains(lower, c) {
+func isValidAdvisorExecutor(model string) bool {
+	trimmed := strings.ToLower(strings.TrimSpace(model))
+	if matchesAlias(trimmed, advisorValidCLIAliases) {
+		return true
+	}
+	return containsAny(trimmed, advisorValidExecutorIDs)
+}
+
+func isValidAdvisor(model string) bool {
+	trimmed := strings.ToLower(strings.TrimSpace(model))
+	// Only `opus` is a valid advisor alias — the other CLI aliases (haiku,
+	// sonnet) are not documented as advisors.
+	if trimmed == "opus" {
+		return true
+	}
+	return containsAny(trimmed, advisorValidAdvisorIDs)
+}
+
+func matchesAlias(model string, aliases []string) bool {
+	for _, a := range aliases {
+		if model == a {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAny(model string, ids []string) bool {
+	for _, id := range ids {
+		if strings.Contains(model, id) {
 			return true
 		}
 	}

--- a/internal/review/advisor.go
+++ b/internal/review/advisor.go
@@ -67,7 +67,7 @@ func isValidAdvisorExecutor(model string) bool {
 	if matchesAlias(trimmed, advisorValidCLIAliases) {
 		return true
 	}
-	return containsAny(trimmed, advisorValidExecutorIDs)
+	return matchesFullID(trimmed, advisorValidExecutorIDs)
 }
 
 func isValidAdvisor(model string) bool {
@@ -77,7 +77,7 @@ func isValidAdvisor(model string) bool {
 	if trimmed == "opus" {
 		return true
 	}
-	return containsAny(trimmed, advisorValidAdvisorIDs)
+	return matchesFullID(trimmed, advisorValidAdvisorIDs)
 }
 
 func matchesAlias(model string, aliases []string) bool {
@@ -89,9 +89,12 @@ func matchesAlias(model string, aliases []string) bool {
 	return false
 }
 
-func containsAny(model string, ids []string) bool {
+// matchesFullID reports whether model equals a known full ID or is a dated
+// variant (e.g. claude-opus-4-7-20251001). Arbitrary strings that merely
+// contain the ID substring (e.g. my-claude-opus-4-7-fork) are rejected.
+func matchesFullID(model string, ids []string) bool {
 	for _, id := range ids {
-		if strings.Contains(model, id) {
+		if model == id || strings.HasPrefix(model, id+"-") {
 			return true
 		}
 	}

--- a/internal/review/advisor_test.go
+++ b/internal/review/advisor_test.go
@@ -60,6 +60,33 @@ func TestValidate_AdvisorModel_ClaudeAliasAccepted(t *testing.T) {
 	}
 }
 
+func TestValidate_AdvisorModel_UnknownCustomModelRejected(t *testing.T) {
+	// Substring match must not accept arbitrary fork names that happen to
+	// embed a known ID — see PR #161 finding 161-3.
+	cfg := &ReviewConfig{
+		Provider:     "anthropic",
+		ReviewModel:  "claude-sonnet-4-6",
+		TriageModel:  "claude-haiku-4-5-20251001",
+		AdvisorModel: "opus-tuned-fork", // contains "opus" but is not a CLI alias and not a full ID
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for non-alias, non-full-ID advisor")
+	}
+}
+
+func TestValidate_AdvisorModel_SonnetAliasRejectedAsAdvisor(t *testing.T) {
+	// Only `opus` is a valid CLI advisor alias. `sonnet`/`haiku` must not pass.
+	cfg := &ReviewConfig{
+		Provider:     "claude",
+		ReviewModel:  "sonnet",
+		TriageModel:  "haiku",
+		AdvisorModel: "sonnet",
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for sonnet as advisor alias")
+	}
+}
+
 func TestValidate_AdvisorModel_InvalidAdvisor(t *testing.T) {
 	cfg := &ReviewConfig{
 		Provider:     "anthropic",
@@ -159,7 +186,7 @@ func TestAnthropicProvider_AdvisorTool_Wiring(t *testing.T) {
 	if gotModel != "claude-sonnet-4-6" {
 		t.Errorf("request model = %q, want claude-sonnet-4-6", gotModel)
 	}
-	if len(gotTools) != 1 || gotTools[0].Type != advisorToolType || gotTools[0].Model != "claude-opus-4-7" {
+	if len(gotTools) != 1 || gotTools[0].Type != advisorToolType || gotTools[0].Name != advisorToolName || gotTools[0].Model != "claude-opus-4-7" {
 		t.Errorf("advisor tool not wired correctly: %+v", gotTools)
 	}
 	if !strings.Contains(result.Text, "pre-advisor") || !strings.Contains(result.Text, "post-advisor") {

--- a/internal/review/advisor_test.go
+++ b/internal/review/advisor_test.go
@@ -1,0 +1,279 @@
+package review
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestValidate_AdvisorModel_OpenAIRejected(t *testing.T) {
+	cfg := &ReviewConfig{
+		Provider:     "openai",
+		ReviewModel:  "gpt-5",
+		TriageModel:  "gpt-5-mini",
+		AdvisorModel: "claude-opus-4-7",
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for advisor_model on openai provider")
+	}
+	if !strings.Contains(err.Error(), "anthropic and claude") {
+		t.Errorf("error should mention supported providers, got: %v", err)
+	}
+}
+
+func TestValidate_AdvisorModel_OpenRouterRejected(t *testing.T) {
+	cfg := &ReviewConfig{
+		Provider:     "openrouter",
+		ReviewModel:  "anthropic/claude-sonnet-4-6",
+		TriageModel:  "anthropic/claude-haiku-4-5",
+		AdvisorModel: "claude-opus-4-7",
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for advisor_model on openrouter provider")
+	}
+}
+
+func TestValidate_AdvisorModel_AnthropicAccepted(t *testing.T) {
+	cfg := &ReviewConfig{
+		Provider:     "anthropic",
+		ReviewModel:  "claude-sonnet-4-6",
+		TriageModel:  "claude-haiku-4-5-20251001",
+		AdvisorModel: "claude-opus-4-7",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_AdvisorModel_ClaudeAliasAccepted(t *testing.T) {
+	cfg := &ReviewConfig{
+		Provider:     "claude",
+		ReviewModel:  "sonnet",
+		TriageModel:  "haiku",
+		AdvisorModel: "opus",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_AdvisorModel_InvalidAdvisor(t *testing.T) {
+	cfg := &ReviewConfig{
+		Provider:     "anthropic",
+		ReviewModel:  "claude-sonnet-4-6",
+		TriageModel:  "claude-haiku-4-5-20251001",
+		AdvisorModel: "claude-sonnet-4-6", // Sonnet is not a valid advisor
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for Sonnet as advisor")
+	}
+	if !strings.Contains(err.Error(), "supported advisor") {
+		t.Errorf("error should mention invalid advisor, got: %v", err)
+	}
+}
+
+func TestValidate_AdvisorModel_Empty_NoValidation(t *testing.T) {
+	cfg := &ReviewConfig{
+		Provider:    "openai", // advisor validation skipped entirely when unset
+		ReviewModel: "gpt-5",
+		TriageModel: "gpt-5-mini",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("unexpected error when advisor_model is empty: %v", err)
+	}
+}
+
+// TestAnthropicProvider_AdvisorTool_Wiring spins up a fake Anthropic endpoint
+// and verifies the provider sends the beta header, the advisor tool entry,
+// and parses the usage.iterations[] breakdown into per-model ModelUsages.
+// Also confirms server_tool_use and advisor_tool_result blocks are filtered
+// out of the response text so they don't contaminate findings parsing.
+func TestAnthropicProvider_AdvisorTool_Wiring(t *testing.T) {
+	var gotBeta string
+	var gotTools []anthropicTool
+	var gotModel string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBeta = r.Header.Get("anthropic-beta")
+		var body anthropicRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		gotTools = body.Tools
+		gotModel = body.Model
+
+		resp := map[string]any{
+			"id":    "msg_test",
+			"type":  "message",
+			"role":  "assistant",
+			"model": body.Model,
+			"content": []map[string]any{
+				{"type": "text", "text": "pre-advisor"},
+				{"type": "server_tool_use", "id": "srvtoolu_1", "name": "advisor", "input": map[string]any{}},
+				{"type": "advisor_tool_result", "tool_use_id": "srvtoolu_1"},
+				{"type": "text", "text": "post-advisor"},
+			},
+			"stop_reason": "end_turn",
+			"usage": map[string]any{
+				"input_tokens":                100,
+				"output_tokens":               200,
+				"cache_read_input_tokens":     0,
+				"cache_creation_input_tokens": 0,
+				"iterations": []map[string]any{
+					{"type": "message", "input_tokens": 100, "output_tokens": 50},
+					{"type": "advisor_message", "model": "claude-opus-4-7", "input_tokens": 500, "output_tokens": 800},
+					{"type": "message", "input_tokens": 600, "output_tokens": 150, "cache_read_input_tokens": 100},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := &anthropicProvider{
+		model:        "claude-sonnet-4-6",
+		advisorModel: "claude-opus-4-7",
+		keyEnv:       "TEST_KEY",
+		env:          []string{"TEST_KEY=sk-test"},
+	}
+	// Redirect the Anthropic URL by swapping the HTTP client. Since the
+	// provider hard-codes the URL, run the request against the httptest
+	// server by temporarily pointing DefaultTransport at its URL.
+	prevURL := anthropicAPIURL
+	anthropicAPIURL = server.URL
+	defer func() { anthropicAPIURL = prevURL }()
+
+	result, err := p.Run(t.Context(), "prompt", RunOpts{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if gotBeta != advisorBetaHeader {
+		t.Errorf("beta header = %q, want %q", gotBeta, advisorBetaHeader)
+	}
+	if gotModel != "claude-sonnet-4-6" {
+		t.Errorf("request model = %q, want claude-sonnet-4-6", gotModel)
+	}
+	if len(gotTools) != 1 || gotTools[0].Type != advisorToolType || gotTools[0].Model != "claude-opus-4-7" {
+		t.Errorf("advisor tool not wired correctly: %+v", gotTools)
+	}
+	if !strings.Contains(result.Text, "pre-advisor") || !strings.Contains(result.Text, "post-advisor") {
+		t.Errorf("expected text from both text blocks, got %q", result.Text)
+	}
+	if strings.Contains(result.Text, "server_tool_use") || strings.Contains(result.Text, "advisor_tool_result") {
+		t.Errorf("advisor metadata leaked into text: %q", result.Text)
+	}
+	if len(result.ModelUsages) != 3 {
+		t.Fatalf("expected 3 ModelUsages iterations, got %d", len(result.ModelUsages))
+	}
+	var sawAdvisor bool
+	for _, mu := range result.ModelUsages {
+		if mu.Model == "claude-opus-4-7" {
+			sawAdvisor = true
+			if mu.InputTokens != 500 || mu.OutputTokens != 800 {
+				t.Errorf("advisor usage wrong: %+v", mu)
+			}
+		}
+	}
+	if !sawAdvisor {
+		t.Errorf("no advisor iteration captured in ModelUsages: %+v", result.ModelUsages)
+	}
+}
+
+// TestAnthropicProvider_NoAdvisor_NoBetaHeader confirms we do not send the
+// advisor beta header or the advisor tool when advisorModel is empty.
+func TestAnthropicProvider_NoAdvisor_NoBetaHeader(t *testing.T) {
+	var gotBeta string
+	var gotTools []anthropicTool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBeta = r.Header.Get("anthropic-beta")
+		var body anthropicRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotTools = body.Tools
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":      "msg",
+			"type":    "message",
+			"role":    "assistant",
+			"model":   "claude-sonnet-4-6",
+			"content": []map[string]any{{"type": "text", "text": "ok"}},
+			"usage":   map[string]any{"input_tokens": 1, "output_tokens": 1},
+		})
+	}))
+	defer server.Close()
+
+	p := &anthropicProvider{
+		model:  "claude-sonnet-4-6",
+		keyEnv: "TEST_KEY",
+		env:    []string{"TEST_KEY=sk-test"},
+	}
+	prevURL := anthropicAPIURL
+	anthropicAPIURL = server.URL
+	defer func() { anthropicAPIURL = prevURL }()
+
+	if _, err := p.Run(t.Context(), "prompt", RunOpts{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if gotBeta != "" {
+		t.Errorf("beta header should be empty when advisor disabled, got %q", gotBeta)
+	}
+	if len(gotTools) != 0 {
+		t.Errorf("tools should be empty when advisor disabled, got %+v", gotTools)
+	}
+}
+
+func TestClaudeProvider_AdvisorGateInjected(t *testing.T) {
+	mc := &ModelConfig{
+		Provider:     "claude",
+		Model:        "sonnet",
+		AdvisorModel: "opus",
+	}
+	p := newClaudeCLIProvider(mc, []string{"PATH=/usr/bin"}).(*claudeCLIProvider)
+	var found bool
+	for _, e := range p.env {
+		if e == claudeAdvisorEnableEnvVar+"=1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("advisor gate env var not injected: %v", p.env)
+	}
+	if p.advisorModel != "opus" {
+		t.Errorf("advisorModel not stored on provider: %q", p.advisorModel)
+	}
+}
+
+func TestClaudeProvider_NoAdvisor_NoGate(t *testing.T) {
+	mc := &ModelConfig{Provider: "claude", Model: "sonnet"}
+	p := newClaudeCLIProvider(mc, []string{"PATH=/usr/bin"}).(*claudeCLIProvider)
+	for _, e := range p.env {
+		if strings.HasPrefix(e, claudeAdvisorEnableEnvVar+"=") {
+			t.Errorf("advisor gate set without advisor_model: %q", e)
+		}
+	}
+}
+
+func TestHasFlag(t *testing.T) {
+	cases := []struct {
+		args []string
+		flag string
+		want bool
+	}{
+		{[]string{"--foo", "bar"}, "--foo", true},
+		{[]string{"--foo=bar"}, "--foo", true},
+		{[]string{"--foobar"}, "--foo", false},
+		{[]string{}, "--foo", false},
+		{[]string{"--settings", "{}"}, "--settings", true},
+	}
+	for _, c := range cases {
+		if got := hasFlag(c.args, c.flag); got != c.want {
+			t.Errorf("hasFlag(%v, %q) = %v, want %v", c.args, c.flag, got, c.want)
+		}
+	}
+}

--- a/internal/review/advisor_test.go
+++ b/internal/review/advisor_test.go
@@ -62,7 +62,7 @@ func TestValidate_AdvisorModel_ClaudeAliasAccepted(t *testing.T) {
 
 func TestValidate_AdvisorModel_UnknownCustomModelRejected(t *testing.T) {
 	// Substring match must not accept arbitrary fork names that happen to
-	// embed a known ID — see PR #161 finding 161-3.
+	// embed a known ID — see PR #161 findings 161-3 and 161-7.
 	cfg := &ReviewConfig{
 		Provider:     "anthropic",
 		ReviewModel:  "claude-sonnet-4-6",
@@ -71,6 +71,33 @@ func TestValidate_AdvisorModel_UnknownCustomModelRejected(t *testing.T) {
 	}
 	if err := cfg.Validate(); err == nil {
 		t.Fatal("expected error for non-alias, non-full-ID advisor")
+	}
+}
+
+func TestValidate_AdvisorModel_ForkNameWithEmbeddedIDRejected(t *testing.T) {
+	// A fork whose name embeds a known full ID as substring must not pass —
+	// this is the specific case called out in 161-7.
+	cfg := &ReviewConfig{
+		Provider:     "anthropic",
+		ReviewModel:  "claude-sonnet-4-6",
+		TriageModel:  "claude-haiku-4-5-20251001",
+		AdvisorModel: "my-claude-opus-4-7-fork",
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for fork name embedding claude-opus-4-7")
+	}
+}
+
+func TestValidate_AdvisorModel_DatedVariantAccepted(t *testing.T) {
+	// Dated variants like claude-opus-4-7-20251001 must still be accepted.
+	cfg := &ReviewConfig{
+		Provider:     "anthropic",
+		ReviewModel:  "claude-sonnet-4-6-20251001",
+		TriageModel:  "claude-haiku-4-5-20251001",
+		AdvisorModel: "claude-opus-4-7-20251001",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("unexpected error for dated variant: %v", err)
 	}
 }
 

--- a/internal/review/config.go
+++ b/internal/review/config.go
@@ -215,7 +215,7 @@ func (c *ReviewConfig) Validate() error {
 		if c.Provider != "anthropic" && c.Provider != "claude" {
 			return fmt.Errorf("advisor_model is only supported by the anthropic and claude providers, not %q", c.Provider)
 		}
-		if err := validateAdvisorPairing(c.Provider, c.ReviewModel, c.AdvisorModel); err != nil {
+		if err := validateAdvisorPairing(c.ReviewModel, c.AdvisorModel); err != nil {
 			return err
 		}
 	}

--- a/internal/review/config.go
+++ b/internal/review/config.go
@@ -29,6 +29,7 @@ type ReviewConfig struct {
 	TimeoutMins  int               `yaml:"timeout_minutes"` // per-invocation timeout in minutes (default 5)
 	ReviewModel  string            `yaml:"review_model"`    // model for main review (required)
 	TriageModel  string            `yaml:"triage_model"`    // model for thread re-evaluation (required)
+	AdvisorModel string            `yaml:"advisor_model"`   // optional advisor model for mid-generation strategic guidance (anthropic & claude providers only)
 	Provider     string            `yaml:"provider"`        // "anthropic", "openai", "openrouter", or "claude"
 	APIBase      string            `yaml:"api_base"`        // override base URL (openai provider only)
 	APIKeyEnv    string            `yaml:"api_key_env"`     // env var name for API key (default depends on provider)
@@ -41,12 +42,13 @@ type ReviewConfig struct {
 // single ModelProvider instance. Used internally to build review and triage
 // providers from the flat ReviewConfig fields.
 type ModelConfig struct {
-	Provider   string
-	Model      string
-	APIBase    string
-	APIKeyEnv  string
-	ClaudeArgs []string // forwarded to claudeCLIProvider; ignored by other providers
-	ClaudePath string   // forwarded to claudeCLIProvider; empty means "claude"
+	Provider     string
+	Model        string
+	AdvisorModel string // optional advisor model; when set, enables the server-side advisor tool (anthropic & claude providers only)
+	APIBase      string
+	APIKeyEnv    string
+	ClaudeArgs   []string // forwarded to claudeCLIProvider; ignored by other providers
+	ClaudePath   string   // forwarded to claudeCLIProvider; empty means "claude"
 }
 
 // EvaluationConfig holds per-evaluation-type settings for re-evaluation prompts.
@@ -206,6 +208,14 @@ func (c *ReviewConfig) Validate() error {
 		// Also validate the triage model.
 		triageMC := &ModelConfig{Provider: c.Provider, Model: c.TriageModel, APIBase: c.APIBase, APIKeyEnv: c.APIKeyEnv}
 		if err := pf.Validate(triageMC); err != nil {
+			return err
+		}
+	}
+	if c.AdvisorModel != "" {
+		if c.Provider != "anthropic" && c.Provider != "claude" {
+			return fmt.Errorf("advisor_model is only supported by the anthropic and claude providers, not %q", c.Provider)
+		}
+		if err := validateAdvisorPairing(c.Provider, c.ReviewModel, c.AdvisorModel); err != nil {
 			return err
 		}
 	}

--- a/internal/review/provider_anthropic.go
+++ b/internal/review/provider_anthropic.go
@@ -18,6 +18,8 @@ func init() {
 		New:      newAnthropicProvider,
 		Validate: validateAnthropic,
 		Pricing: []PricingEntry{
+			// Opus 4.7
+			{"claude-opus-4-7", modelPricing{15, 75, 18.75, 1.50}},
 			// Opus 4.6 / 4.5
 			{"claude-opus-4-6", modelPricing{5, 25, 6.25, 0.50}},
 			{"claude-opus-4-5", modelPricing{5, 25, 6.25, 0.50}},
@@ -34,7 +36,8 @@ func init() {
 			{"claude-haiku-3", modelPricing{0.25, 1.25, 0.30, 0.03}},
 		},
 		MaxOutputTokens: []MaxTokensEntry{
-			// Opus 4.6 / 4.5: 128k output
+			// Opus 4.7 / 4.6 / 4.5: 128k output
+			{"claude-opus-4-7", 128_000},
 			{"claude-opus-4-6", 128_000},
 			{"claude-opus-4-5", 128_000},
 			// Opus 4.1 / 4: 32k output
@@ -61,12 +64,17 @@ func validateAnthropic(mc *ModelConfig) error {
 	return nil
 }
 
+// anthropicAPIURL is the Messages endpoint. Exposed as a variable so tests
+// can point the provider at an httptest server.
+var anthropicAPIURL = "https://api.anthropic.com/v1/messages"
+
 // anthropicProvider implements ModelProvider using the native Anthropic Messages API.
 // Supports prompt caching for significant cost savings on repeated calls.
 type anthropicProvider struct {
-	model  string   // model to use for every call
-	keyEnv string   // env var name holding the API key
-	env    []string // filtered environment
+	model        string   // executor model used for every call
+	advisorModel string   // optional advisor model — enables the server-side advisor tool when non-empty
+	keyEnv       string   // env var name holding the API key
+	env          []string // filtered environment
 }
 
 func newAnthropicProvider(mc *ModelConfig, env []string) ModelProvider {
@@ -74,7 +82,7 @@ func newAnthropicProvider(mc *ModelConfig, env []string) ModelProvider {
 	if mc.APIKeyEnv != "" {
 		keyEnv = mc.APIKeyEnv
 	}
-	return &anthropicProvider{model: mc.Model, keyEnv: keyEnv, env: env}
+	return &anthropicProvider{model: mc.Model, advisorModel: mc.AdvisorModel, keyEnv: keyEnv, env: env}
 }
 
 // anthropicRequest is the Anthropic /v1/messages request format.
@@ -83,6 +91,7 @@ type anthropicRequest struct {
 	MaxTokens int                     `json:"max_tokens"`
 	System    []anthropicContentBlock `json:"system,omitempty"`
 	Messages  []anthropicMessage      `json:"messages"`
+	Tools     []anthropicTool         `json:"tools,omitempty"`
 }
 
 type anthropicMessage struct {
@@ -100,27 +109,54 @@ type anthropicCacheControl struct {
 	Type string `json:"type"` // "ephemeral"
 }
 
+// anthropicTool represents a tool entry in the request's tools array. Only the
+// advisor server-side tool is populated today; fields are kept optional so we
+// can extend to additional tool shapes without breaking the wire format.
+type anthropicTool struct {
+	Type  string `json:"type"`
+	Name  string `json:"name"`
+	Model string `json:"model,omitempty"`
+}
+
 // anthropicResponse is the Anthropic /v1/messages response format.
 type anthropicResponse struct {
-	ID      string `json:"id"`
-	Type    string `json:"type"`
-	Role    string `json:"role"`
-	Content []struct {
-		Type string `json:"type"`
-		Text string `json:"text"`
-	} `json:"content"`
+	ID      string                  `json:"id"`
+	Type    string                  `json:"type"`
+	Role    string                  `json:"role"`
+	Content []anthropicResponseBlock `json:"content"`
 	Model      string `json:"model"`
 	StopReason string `json:"stop_reason"`
 	Usage      struct {
-		InputTokens              int `json:"input_tokens"`
-		OutputTokens             int `json:"output_tokens"`
-		CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
-		CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+		InputTokens              int                   `json:"input_tokens"`
+		OutputTokens             int                   `json:"output_tokens"`
+		CacheCreationInputTokens int                   `json:"cache_creation_input_tokens"`
+		CacheReadInputTokens     int                   `json:"cache_read_input_tokens"`
+		Iterations               []anthropicIteration  `json:"iterations"`
 	} `json:"usage"`
 	Error *struct {
 		Type    string `json:"type"`
 		Message string `json:"message"`
 	} `json:"error"`
+}
+
+// anthropicResponseBlock handles the assistant's content array. Only text
+// blocks carry user-visible output; server_tool_use and advisor_tool_result
+// blocks are metadata from the advisor tool and must be filtered out.
+type anthropicResponseBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// anthropicIteration is a single sub-inference entry in usage.iterations[].
+// Executor iterations have type "message"; advisor sub-inferences have
+// type "advisor_message" with the advisor model ID attached.
+type anthropicIteration struct {
+	Type                     string `json:"type"`
+	Model                    string `json:"model"`
+	InputTokens              int    `json:"input_tokens"`
+	OutputTokens             int    `json:"output_tokens"`
+	CacheCreationInputTokens int    `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int    `json:"cache_read_input_tokens"`
 }
 
 func (p *anthropicProvider) Run(ctx context.Context, prompt string, opts RunOpts) (*providerResult, error) {
@@ -154,19 +190,29 @@ func (p *anthropicProvider) Run(ctx context.Context, prompt string, opts RunOpts
 			},
 		},
 	}
+	if p.advisorModel != "" {
+		reqBody.Tools = []anthropicTool{{
+			Type:  advisorToolType,
+			Name:  advisorToolName,
+			Model: p.advisorModel,
+		}}
+	}
 
 	jsonBody, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.anthropic.com/v1/messages", bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, "POST", anthropicAPIURL, bytes.NewReader(jsonBody))
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-api-key", apiKey)
 	req.Header.Set("anthropic-version", "2023-06-01")
+	if p.advisorModel != "" {
+		req.Header.Set("anthropic-beta", advisorBetaHeader)
+	}
 
 	start := time.Now()
 	resp, err := http.DefaultClient.Do(req)
@@ -199,7 +245,10 @@ func (p *anthropicProvider) Run(ctx context.Context, prompt string, opts RunOpts
 
 	truncated := msgResp.StopReason == "max_tokens"
 
-	// Extract text from content blocks.
+	// Extract text from content blocks. server_tool_use and
+	// advisor_tool_result blocks are advisor-tool metadata and never user
+	// output; filter them out so advisor calls do not contaminate the
+	// parsed findings JSON.
 	var textParts []string
 	for _, block := range msgResp.Content {
 		if block.Type == "text" {
@@ -208,6 +257,52 @@ func (p *anthropicProvider) Run(ctx context.Context, prompt string, opts RunOpts
 	}
 	if len(textParts) == 0 {
 		return nil, fmt.Errorf("Anthropic API returned no text content") //nolint:staticcheck // proper noun
+	}
+
+	result := &providerResult{
+		Text:       strings.Join(textParts, ""),
+		DurationMS: durationMS,
+		Truncated:  truncated,
+	}
+
+	// When the advisor tool ran, usage.iterations[] carries a per-sub-inference
+	// breakdown. Split it so executor tokens bill at the executor's rate and
+	// advisor tokens bill at the advisor's rate. For plain (non-advisor) calls
+	// the iterations array is empty; fall back to the top-level usage totals.
+	if len(msgResp.Usage.Iterations) > 0 {
+		for _, it := range msgResp.Usage.Iterations {
+			model := it.Model
+			if model == "" {
+				model = msgResp.Model
+			}
+			u := CallUsage{
+				Model:             model,
+				InputTokens:       it.InputTokens,
+				OutputTokens:      it.OutputTokens,
+				CacheReadTokens:   it.CacheReadInputTokens,
+				CacheCreateTokens: it.CacheCreationInputTokens,
+				DurationMS:        durationMS,
+			}
+			u.CostUSD = estimateCost(u)
+			result.ModelUsages = append(result.ModelUsages, u)
+		}
+		// Aggregate Usage reflects the executor-visible totals reported by the
+		// API so existing dashboards that read result.Usage still work.
+		agg := CallUsage{
+			Model:             msgResp.Model,
+			InputTokens:       msgResp.Usage.InputTokens,
+			OutputTokens:      msgResp.Usage.OutputTokens,
+			CacheReadTokens:   msgResp.Usage.CacheReadInputTokens,
+			CacheCreateTokens: msgResp.Usage.CacheCreationInputTokens,
+			DurationMS:        durationMS,
+		}
+		var total float64
+		for _, mu := range result.ModelUsages {
+			total += mu.CostUSD
+		}
+		agg.CostUSD = total
+		result.Usage = agg
+		return result, nil
 	}
 
 	usage := CallUsage{
@@ -219,11 +314,6 @@ func (p *anthropicProvider) Run(ctx context.Context, prompt string, opts RunOpts
 		DurationMS:        durationMS,
 	}
 	usage.CostUSD = estimateCost(usage)
-
-	return &providerResult{
-		Text:      strings.Join(textParts, ""),
-		Usage:     usage,
-		Truncated: truncated,
-	}, nil
+	result.Usage = usage
+	return result, nil
 }
-

--- a/internal/review/provider_claude.go
+++ b/internal/review/provider_claude.go
@@ -155,12 +155,16 @@ func (p *claudeCLIProvider) Run(ctx context.Context, prompt string, opts RunOpts
 	if opts.MaxBudgetUSD > 0 {
 		args = append(args, "--max-budget-usd", fmt.Sprintf("%.2f", opts.MaxBudgetUSD))
 	}
-	if p.advisorModel != "" && !hasFlag(p.extraArgs, "--settings") {
-		// The Claude CLI surfaces the advisor as a settings-level field;
-		// inject it as a JSON string so we do not need a temp file.
-		settings := map[string]string{"advisorModel": p.advisorModel}
-		if data, err := json.Marshal(settings); err == nil {
-			args = append(args, "--settings", string(data))
+	if p.advisorModel != "" {
+		if hasFlag(p.extraArgs, "--settings") {
+			Stderrf(ansiYellow, "Warning: advisor_model is ignored because --settings is set via claude_args — merge advisorModel into your settings JSON to use both.\n")
+		} else {
+			// The Claude CLI surfaces the advisor as a settings-level field;
+			// inject it as a JSON string so we do not need a temp file.
+			settings := map[string]string{"advisorModel": p.advisorModel}
+			if data, err := json.Marshal(settings); err == nil {
+				args = append(args, "--settings", string(data))
+			}
 		}
 	}
 	args = append(args, p.extraArgs...)

--- a/internal/review/provider_claude.go
+++ b/internal/review/provider_claude.go
@@ -55,11 +55,17 @@ func validateClaude(mc *ModelConfig) error {
 // claudeCLIProvider implements ModelProvider using the Claude CLI binary.
 // Requires the `claude` binary in PATH and an OAuth token.
 type claudeCLIProvider struct {
-	model      string
-	env        []string
-	extraArgs  []string // from ClaudeArgs; appended after all managed flags
-	binaryPath string   // resolved Claude CLI binary path; never empty
+	model        string
+	advisorModel string // optional advisor model — enables the Claude CLI server-side advisor tool via --settings and the experimental env gate
+	env          []string
+	extraArgs    []string // from ClaudeArgs; appended after all managed flags
+	binaryPath   string   // resolved Claude CLI binary path; never empty
 }
+
+// claudeAdvisorEnableEnvVar is the Claude CLI env var that opts into the
+// experimental advisor tool. Surfaced as a constant so the implementation and
+// tests stay aligned with the name baked into the claude binary.
+const claudeAdvisorEnableEnvVar = "CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL"
 
 // claudeOAuthEnvVar is the environment variable the Claude CLI reads for OAuth tokens.
 const claudeOAuthEnvVar = "CLAUDE_CODE_OAUTH_TOKEN"
@@ -72,12 +78,42 @@ func newClaudeCLIProvider(mc *ModelConfig, env []string) ModelProvider {
 	// Map CODECANARY_PROVIDER_SECRET → CLAUDE_CODE_OAUTH_TOKEN so the Claude CLI
 	// can authenticate using the OAuth token obtained during `codecanary setup`.
 	env = injectClaudeOAuthToken(env)
-	return &claudeCLIProvider{
-		model:      mc.Model,
-		env:        env,
-		extraArgs:  mc.ClaudeArgs,
-		binaryPath: binaryPath,
+	if mc.AdvisorModel != "" {
+		env = injectClaudeAdvisorGate(env)
 	}
+	return &claudeCLIProvider{
+		model:        mc.Model,
+		advisorModel: mc.AdvisorModel,
+		env:          env,
+		extraArgs:    mc.ClaudeArgs,
+		binaryPath:   binaryPath,
+	}
+}
+
+// injectClaudeAdvisorGate sets CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL=1
+// so the Claude CLI activates its server-side advisor tool. Preserves any
+// caller-provided value for the same variable.
+func injectClaudeAdvisorGate(env []string) []string {
+	for _, e := range env {
+		key, _, _ := strings.Cut(e, "=")
+		if key == claudeAdvisorEnableEnvVar {
+			return env
+		}
+	}
+	return append(env, claudeAdvisorEnableEnvVar+"=1")
+}
+
+// hasFlag reports whether args contains the given flag in either `--name` or
+// `--name=value` form. Used to avoid stomping on user-provided values in
+// claude_args.
+func hasFlag(args []string, flag string) bool {
+	prefix := flag + "="
+	for _, a := range args {
+		if a == flag || strings.HasPrefix(a, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // injectClaudeOAuthToken copies CODECANARY_PROVIDER_SECRET into
@@ -118,6 +154,14 @@ func (p *claudeCLIProvider) Run(ctx context.Context, prompt string, opts RunOpts
 	}
 	if opts.MaxBudgetUSD > 0 {
 		args = append(args, "--max-budget-usd", fmt.Sprintf("%.2f", opts.MaxBudgetUSD))
+	}
+	if p.advisorModel != "" && !hasFlag(p.extraArgs, "--settings") {
+		// The Claude CLI surfaces the advisor as a settings-level field;
+		// inject it as a JSON string so we do not need a temp file.
+		settings := map[string]string{"advisorModel": p.advisorModel}
+		if data, err := json.Marshal(settings); err == nil {
+			args = append(args, "--settings", string(data))
+		}
 	}
 	args = append(args, p.extraArgs...)
 	cmd := exec.CommandContext(ctx, p.binaryPath, args...)

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -340,7 +340,7 @@ func Run(opts RunOptions) error {
 			}
 		}
 	}
-	reviewMC := &ModelConfig{Provider: cfg.Provider, Model: cfg.ReviewModel, APIBase: cfg.APIBase, APIKeyEnv: cfg.APIKeyEnv}
+	reviewMC := &ModelConfig{Provider: cfg.Provider, Model: cfg.ReviewModel, AdvisorModel: cfg.AdvisorModel, APIBase: cfg.APIBase, APIKeyEnv: cfg.APIKeyEnv}
 	triageMC := &ModelConfig{Provider: cfg.Provider, Model: cfg.TriageModel, APIBase: cfg.APIBase, APIKeyEnv: cfg.APIKeyEnv}
 	if cfg.Provider == "claude" {
 		reviewMC.ClaudeArgs = cfg.ClaudeArgs


### PR DESCRIPTION
## Summary

Adds optional `advisor_model` config that enables Anthropic's [advisor tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool) on the review call. A faster executor (e.g. Sonnet) consults a stronger advisor (Opus 4.7) mid-generation — advisor-tier quality for planning, executor-tier cost on the bulk of the output.

- **anthropic provider**: sends the `advisor-tool-2026-03-01` beta header and the `advisor_20260301` tool entry; filters `server_tool_use` / `advisor_tool_result` blocks from response text so they don't contaminate findings JSON; splits `usage.iterations[]` into per-model `ModelUsages` so advisor tokens bill at the advisor rate.
- **claude provider**: sets `CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL=1` and injects the advisor via `--settings {\"advisorModel\": \"…\"}`. Defers to user-provided `--settings` in `claude_args` when already present.
- Config validation rejects `advisor_model` on providers that can't support it (openai, openrouter) and enforces the documented executor/advisor pairings.
- Triage stays off advisor intentionally — classifier turns are too short for advisor to earn its cost.

## Caveats

- Claude CLI advisor is **experimental** (gated behind the env var and not in public docs yet). Shipping as opt-in is safe, but it can change or be removed upstream at any time. Users who want stability should use the `anthropic` provider.
- All constants are sourced from verifiable evidence: beta header / tool shape / usage-iterations schema from the Anthropic docs page linked above; CLI setting name and env gate from \`strings\` on the \`claude\` binary.

## Test plan

- [ ] \`go test ./...\` — advisor unit tests cover: validation (wrong provider, invalid advisor), anthropic wire format (beta header + tool entry + filtered response blocks + per-model usage split), claude provider env gate injection, \`hasFlag\` helper.
- [ ] \`go vet ./...\`
- [ ] \`golangci-lint run ./...\` (CI)
- [ ] Manual smoke: set \`advisor_model: claude-opus-4-7\` on a real PR with the anthropic provider; confirm a finding lands and the usage table shows a separate \`claude-opus-4-7\` line.
- [ ] Manual smoke: same on the claude provider; confirm no error from the CLI and advisor shows up in the run.