### PR TITLE
fix: stop re-surfacing findings the author already deferred

### DIFF
--- a/.claude/skills/codecanary-fix/SKILL.md
+++ b/.claude/skills/codecanary-fix/SKILL.md
@@ -57,12 +57,13 @@ Track one piece of state across iterations:
    - **PR mode**: run
      `codecanary findings --watch --output json`.
      The command blocks until the review check completes; its stdout is
-     a single JSON object. Parse it. Deduplication is handled by GitHub
-     thread resolution — resolved threads are excluded by default.
-     Note: findings the operator previously skipped (via "Skip this
-     cycle" or "Apply some") will re-appear if their threads are still
-     open. This is intentional — skipped findings are deferred, not
-     dismissed.
+     a single JSON object. Parse it. Findings the bot considers handled
+     are excluded by default — that includes GitHub-resolved threads
+     *and* threads where the bot has recorded the author's deferral
+     (ack:dismissed / ack:rebutted / ack:acknowledged). Skip replies
+     posted by the skill in earlier cycles therefore stop re-surfacing
+     once the next bot run has ack'd them, so you should never see the
+     same deferred finding twice.
    - **Local mode**: run `codecanary review --output json`. The command
      runs the review inline; its stdout is a JSON object with a
      `findings` array in the same shape.

--- a/cmd/review/cli/findings.go
+++ b/cmd/review/cli/findings.go
@@ -204,6 +204,6 @@ func init() {
 	findingsCmd.Flags().StringP("output", "o", "markdown", "Output format: markdown or json")
 	findingsCmd.Flags().Bool("watch", false, "Poll until the review check completes before returning")
 	findingsCmd.Flags().Int("timeout", 15, "Max minutes to wait when --watch is set. Use 0 or a negative value to wait indefinitely (blocks until the review check completes or the process is interrupted)")
-	findingsCmd.Flags().Bool("include-resolved", false, "Include findings whose GitHub review thread is already marked resolved (default: skip them)")
+	findingsCmd.Flags().Bool("include-resolved", false, "Include findings the bot considers handled — GitHub-resolved threads *and* threads carrying a codecanary ack reply (dismissed/rebutted/acknowledged). Default: skip them.")
 	rootCmd.AddCommand(findingsCmd)
 }

--- a/docs/review-flow.md
+++ b/docs/review-flow.md
@@ -158,7 +158,9 @@ If the response is truncated (hit max output tokens), a warning is logged. The p
 
 The status block lists non-zero counts for: new findings, resolved by code, file removed, dismissed by author, acknowledged by author, rebutted by author, still unresolved. The block renders nothing when all counts are zero, so clean reviews remain copy-exact.
 
-Per-thread ack replies for dismissed/acknowledged/rebutted resolutions are posted earlier in the pipeline (`HandleResolutions`) and deduped via `<!-- codecanary:ack:<reason> -->` markers. Reply-only runs skip `SaveState` so the empty findings slice doesn't overwrite persisted state.
+Per-thread ack replies for dismissed/acknowledged/rebutted resolutions are posted earlier in the pipeline (`HandleResolutions`). Dedup is reason-agnostic: if the thread already carries *any* `<!-- codecanary:ack:... -->` marker, no further ack reply is posted. Reasons can shift across triage runs (LLM non-determinism), and all three convey the same outcome ("keeping open"), so one ack per thread is enough. Reply-only runs skip `SaveState` so the empty findings slice doesn't overwrite persisted state.
+
+`codecanary findings` applies the same marker to filter deferrals out of its default output: threads with any `codecanary:ack:*` reply are treated as handled and omitted alongside GitHub-resolved threads. Pass `--include-resolved` to see them. This keeps the codecanary-fix skill from re-prompting on findings the operator already deferred.
 
 **Local modes**: Prints the formatted result to stdout. Format depends on context: terminal (colored, human-readable), markdown, or JSON.
 

--- a/internal/review/comments.go
+++ b/internal/review/comments.go
@@ -195,6 +195,21 @@ func FetchReviewStatus(repo string, prNumber int) (ReviewStatus, error) {
 // Errors is populated on partial GraphQL failures (insufficient scope,
 // resource not found, etc.); when `data` is null or incomplete, those
 // errors are the only signal of what went wrong.
+type findingsCommentNode struct {
+	Body         string `json:"body"`
+	Path         string `json:"path"`
+	Line         int    `json:"line"`
+	OriginalLine int    `json:"originalLine"`
+	URL          string `json:"url"`
+	CreatedAt    string `json:"createdAt"`
+	Commit       struct {
+		Oid string `json:"oid"`
+	} `json:"commit"`
+	Author struct {
+		Login string `json:"login"`
+	} `json:"author"`
+}
+
 type graphQLFindingsResponse struct {
 	Data struct {
 		Repository struct {
@@ -204,20 +219,7 @@ type graphQLFindingsResponse struct {
 						IsResolved bool `json:"isResolved"`
 						IsOutdated bool `json:"isOutdated"`
 						Comments   struct {
-							Nodes []struct {
-								Body         string `json:"body"`
-								Path         string `json:"path"`
-								Line         int    `json:"line"`
-								OriginalLine int    `json:"originalLine"`
-								URL          string `json:"url"`
-								CreatedAt    string `json:"createdAt"`
-								Commit       struct {
-									Oid string `json:"oid"`
-								} `json:"commit"`
-								Author struct {
-									Login string `json:"login"`
-								} `json:"author"`
-							} `json:"nodes"`
+							Nodes []findingsCommentNode `json:"nodes"`
 						} `json:"comments"`
 					} `json:"nodes"`
 				} `json:"reviewThreads"`
@@ -231,10 +233,26 @@ type graphQLFindingsResponse struct {
 	} `json:"errors"`
 }
 
+// threadHasAckReply reports whether any of the given replies carries a
+// codecanary ack marker, meaning the bot already recorded the author's
+// deferral (dismissed / rebutted / acknowledged). Findings in that state
+// are filtered out of `codecanary findings` by default so the fix loop
+// doesn't re-surface deferrals every cycle.
+func threadHasAckReply(replies []findingsCommentNode) bool {
+	for _, r := range replies {
+		if strings.Contains(r.Body, ackMarkerPrefix) || strings.Contains(r.Body, legacyAckPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // FetchPRFindings returns the findings posted by the codecanary bot on
 // the given PR, keyed off GitHub's reviewThreads GraphQL endpoint so we
-// can honour per-thread resolution state. Resolved threads are omitted
-// by default; pass includeResolved=true to keep them.
+// can honour per-thread resolution state. By default, threads the bot
+// considers handled are omitted — that covers both GitHub-resolved
+// threads and threads carrying a codecanary ack marker (dismissed,
+// rebutted, acknowledged). Pass includeResolved=true to keep them.
 //
 // Uses GraphQL (not the REST comments endpoint) because isResolved
 // isn't exposed via REST. That's what caused the first iteration of
@@ -311,6 +329,13 @@ func FetchPRFindings(repo string, prNumber int, includeResolved bool) ([]PRFindi
 		}
 		head := thread.Comments.Nodes[0]
 		if !isBotAuthor(head.Author.Login) {
+			continue
+		}
+		// Skip threads the bot has already ack'd as
+		// dismissed/rebutted/acknowledged — the author deferred them,
+		// so re-surfacing them every cycle is noise. Callers that want
+		// the full history can pass includeResolved=true.
+		if !includeResolved && threadHasAckReply(thread.Comments.Nodes[1:]) {
 			continue
 		}
 		// Extract the finding marker from the body.

--- a/internal/review/platform_github.go
+++ b/internal/review/platform_github.go
@@ -99,13 +99,16 @@ func acknowledgmentMessage(reason string) string {
 	}
 }
 
-// hasAcknowledgmentReply checks if an acknowledgment reply already exists
-// on the thread for the given reason, to avoid posting duplicate replies.
-func hasAcknowledgmentReply(t ReviewThread, reason string) bool {
-	newMarker := fmt.Sprintf("%s%s -->", ackMarkerPrefix, reason)
-	oldMarker := fmt.Sprintf("%s%s -->", legacyAckPrefix, reason)
+// hasAcknowledgmentReply reports whether the thread already carries any
+// codecanary ack reply. Dedup is intentionally reason-agnostic: all three
+// ack reasons (dismissed/rebutted/acknowledged) keep the thread open and
+// convey the same outcome to the author, and triage classification across
+// runs is not deterministic — so checking only the same reason let a
+// rebutted ack get followed by a dismissed ack on the next run, stacking
+// two replies on one skip. One ack per thread is enough.
+func hasAcknowledgmentReply(t ReviewThread) bool {
 	for _, r := range t.Replies {
-		if strings.Contains(r.Body, newMarker) || strings.Contains(r.Body, oldMarker) {
+		if strings.Contains(r.Body, ackMarkerPrefix) || strings.Contains(r.Body, legacyAckPrefix) {
 			return true
 		}
 	}
@@ -171,7 +174,7 @@ func (g *GithubPlatform) HandleResolutions(threads []ReviewThread, fixed []fixed
 				}
 			}
 		} else {
-			if !hasAcknowledgmentReply(t, f.Reason) {
+			if !hasAcknowledgmentReply(t) {
 				msg := acknowledgmentMessage(f.Reason)
 				if err := ReplyToThread(t.ID, msg); err != nil {
 					fmt.Fprintf(os.Stderr, "  ! %s — failed to post acknowledgment: %v\n", label, err)

--- a/internal/skills/codecanary-fix/SKILL.md
+++ b/internal/skills/codecanary-fix/SKILL.md
@@ -57,12 +57,13 @@ Track one piece of state across iterations:
    - **PR mode**: run
      `codecanary findings --watch --output json`.
      The command blocks until the review check completes; its stdout is
-     a single JSON object. Parse it. Deduplication is handled by GitHub
-     thread resolution — resolved threads are excluded by default.
-     Note: findings the operator previously skipped (via "Skip this
-     cycle" or "Apply some") will re-appear if their threads are still
-     open. This is intentional — skipped findings are deferred, not
-     dismissed.
+     a single JSON object. Parse it. Findings the bot considers handled
+     are excluded by default — that includes GitHub-resolved threads
+     *and* threads where the bot has recorded the author's deferral
+     (ack:dismissed / ack:rebutted / ack:acknowledged). Skip replies
+     posted by the skill in earlier cycles therefore stop re-surfacing
+     once the next bot run has ack'd them, so you should never see the
+     same deferred finding twice.
    - **Local mode**: run `codecanary review --output json`. The command
      runs the review inline; its stdout is a JSON object with a
      `findings` array in the same shape.


### PR DESCRIPTION
## Summary

- `codecanary findings` filters threads carrying any `codecanary:ack:*` reply (dismissed / rebutted / acknowledged) alongside GitHub-resolved threads, so the codecanary-fix skill doesn't re-prompt on findings the operator deferred in an earlier cycle. `--include-resolved` still reveals them.
- `hasAcknowledgmentReply` is now reason-agnostic: one ack reply per thread. Triage classification is non-deterministic across runs, and a single skip reply was producing both a rebutted and a dismissed ack on consecutive bot runs (seen on thetechfx/bedrock#1531). All three ack reasons mean the same thing ("keeping open"), so stacking them adds noise with no signal.
- Skill (both embed + `.claude` copy) and `docs/review-flow.md` updated to describe the new behavior.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [ ] Verify against a real PR: deferred finding no longer reappears on the next cycle once the bot has ack'd it