### PR TITLE
feat: show boxed version banner when codecanary-fix starts

### DIFF
--- a/.claude/skills/codecanary-fix/SKILL.md
+++ b/.claude/skills/codecanary-fix/SKILL.md
@@ -45,6 +45,37 @@ is spent on triage judgment and fix application, not on watching CI.
 
 If you cannot tell which mode applies, ask the operator before starting.
 
+## Startup header
+
+Before the first iteration, run `codecanary --version` and extract the
+version string from its output (e.g. `codecanary version 0.6.13` →
+`0.6.13`). Then print a boxed hash-style banner to the operator using
+this exact shape:
+
+```
+####################################
+#                                  #
+#     CodeCanary v<VERSION> — Fix     #
+#                                  #
+####################################
+```
+
+Rules for rendering:
+
+- Use ASCII `#` characters only (no Unicode box-drawing).
+- The banner is five lines: a top row of `#`, a blank-interior row, the
+  title row, another blank-interior row, and a bottom row of `#`.
+- Top and bottom rows are solid `#` characters of the same width.
+- All three interior rows start and end with a single `#` and have
+  spaces in between.
+- Pad the title row with spaces on both sides so its total width
+  matches the top and bottom rows. Keep at least four spaces of
+  padding on each side of `CodeCanary v<VERSION> — Fix` so the title
+  feels centered.
+- Print the banner once per skill invocation, before the loop starts.
+- Render it inside a fenced code block so the alignment survives in
+  Markdown.
+
 ## The loop
 
 Track one piece of state across iterations:

--- a/.claude/skills/codecanary-fix/SKILL.md
+++ b/.claude/skills/codecanary-fix/SKILL.md
@@ -49,29 +49,38 @@ If you cannot tell which mode applies, ask the operator before starting.
 
 Before the first iteration, run `codecanary --version` and extract the
 version string from its output (e.g. `codecanary version 0.6.13` →
-`0.6.13`). Then print a boxed hash-style banner to the operator using
-this exact shape:
+`0.6.13`). Then print a boxed hash-style banner to the operator.
+
+Concrete example — if the version is `0.6.13`, the banner must be
+exactly:
 
 ```
-####################################
-#                                  #
-#     CodeCanary v<VERSION> — Fix     #
-#                                  #
-####################################
+##################################
+#                                #
+#    CodeCanary v0.6.13 — Fix    #
+#                                #
+##################################
 ```
+
+Here the top and bottom rows are 34 `#` characters; the title
+`CodeCanary v0.6.13 — Fix` is 24 display columns and is wrapped by
+`#` + 4 spaces on the left and 4 spaces + `#` on the right, for a
+total of 34 columns. The blank interior rows are `#` + 32 spaces + `#`.
 
 Rules for rendering:
 
 - Use ASCII `#` characters only (no Unicode box-drawing).
 - The banner is five lines: a top row of `#`, a blank-interior row, the
   title row, another blank-interior row, and a bottom row of `#`.
-- Top and bottom rows are solid `#` characters of the same width.
-- All three interior rows start and end with a single `#` and have
-  spaces in between.
-- Pad the title row with spaces on both sides so its total width
-  matches the top and bottom rows. Keep at least four spaces of
-  padding on each side of `CodeCanary v<VERSION> — Fix` so the title
-  feels centered.
+- The version string is variable-length — you must **recompute the
+  padding** for each invocation so every row has the same column
+  width. Do not copy the example padding literally if the version
+  differs; count the characters in `CodeCanary v<VERSION> — Fix`
+  and rebuild the border/padding around it.
+- Keep at least four spaces of padding on each side of the title so
+  it feels centered, and match top/bottom row widths to the title
+  row width exactly.
+- Count `—` (em dash) as one display column.
 - Print the banner once per skill invocation, before the loop starts.
 - Render it inside a fenced code block so the alignment survives in
   Markdown.

--- a/internal/skills/codecanary-fix/SKILL.md
+++ b/internal/skills/codecanary-fix/SKILL.md
@@ -45,6 +45,37 @@ is spent on triage judgment and fix application, not on watching CI.
 
 If you cannot tell which mode applies, ask the operator before starting.
 
+## Startup header
+
+Before the first iteration, run `codecanary --version` and extract the
+version string from its output (e.g. `codecanary version 0.6.13` →
+`0.6.13`). Then print a boxed hash-style banner to the operator using
+this exact shape:
+
+```
+####################################
+#                                  #
+#     CodeCanary v<VERSION> — Fix     #
+#                                  #
+####################################
+```
+
+Rules for rendering:
+
+- Use ASCII `#` characters only (no Unicode box-drawing).
+- The banner is five lines: a top row of `#`, a blank-interior row, the
+  title row, another blank-interior row, and a bottom row of `#`.
+- Top and bottom rows are solid `#` characters of the same width.
+- All three interior rows start and end with a single `#` and have
+  spaces in between.
+- Pad the title row with spaces on both sides so its total width
+  matches the top and bottom rows. Keep at least four spaces of
+  padding on each side of `CodeCanary v<VERSION> — Fix` so the title
+  feels centered.
+- Print the banner once per skill invocation, before the loop starts.
+- Render it inside a fenced code block so the alignment survives in
+  Markdown.
+
 ## The loop
 
 Track one piece of state across iterations:

--- a/internal/skills/codecanary-fix/SKILL.md
+++ b/internal/skills/codecanary-fix/SKILL.md
@@ -49,29 +49,38 @@ If you cannot tell which mode applies, ask the operator before starting.
 
 Before the first iteration, run `codecanary --version` and extract the
 version string from its output (e.g. `codecanary version 0.6.13` →
-`0.6.13`). Then print a boxed hash-style banner to the operator using
-this exact shape:
+`0.6.13`). Then print a boxed hash-style banner to the operator.
+
+Concrete example — if the version is `0.6.13`, the banner must be
+exactly:
 
 ```
-####################################
-#                                  #
-#     CodeCanary v<VERSION> — Fix     #
-#                                  #
-####################################
+##################################
+#                                #
+#    CodeCanary v0.6.13 — Fix    #
+#                                #
+##################################
 ```
+
+Here the top and bottom rows are 34 `#` characters; the title
+`CodeCanary v0.6.13 — Fix` is 24 display columns and is wrapped by
+`#` + 4 spaces on the left and 4 spaces + `#` on the right, for a
+total of 34 columns. The blank interior rows are `#` + 32 spaces + `#`.
 
 Rules for rendering:
 
 - Use ASCII `#` characters only (no Unicode box-drawing).
 - The banner is five lines: a top row of `#`, a blank-interior row, the
   title row, another blank-interior row, and a bottom row of `#`.
-- Top and bottom rows are solid `#` characters of the same width.
-- All three interior rows start and end with a single `#` and have
-  spaces in between.
-- Pad the title row with spaces on both sides so its total width
-  matches the top and bottom rows. Keep at least four spaces of
-  padding on each side of `CodeCanary v<VERSION> — Fix` so the title
-  feels centered.
+- The version string is variable-length — you must **recompute the
+  padding** for each invocation so every row has the same column
+  width. Do not copy the example padding literally if the version
+  differs; count the characters in `CodeCanary v<VERSION> — Fix`
+  and rebuild the border/padding around it.
+- Keep at least four spaces of padding on each side of the title so
+  it feels centered, and match top/bottom row widths to the title
+  row width exactly.
+- Count `—` (em dash) as one display column.
 - Print the banner once per skill invocation, before the loop starts.
 - Render it inside a fenced code block so the alignment survives in
   Markdown.


### PR DESCRIPTION
## Summary
- Teach the `codecanary-fix` skill to run `codecanary --version` at the top of each invocation and render a hash-bordered ASCII banner that includes the version, so the operator can see at a glance which binary is driving the loop.
- Updates both embedded (`internal/skills/...`) and project (`.claude/skills/...`) copies of the SKILL so the parity test passes.

Example banner the skill renders:

```
####################################
#                                  #
#     CodeCanary v0.6.13 — Fix     #
#                                  #
####################################
```

## Test plan
- [x] `go test ./internal/skills/` — SKILL parity check passes
- [x] `go build ./...`
- [ ] Next invocation of `/codecanary-fix` displays the banner before cycle 1