### PR TITLE
fix: surface gh stderr when FetchPR fails

### DIFF
--- a/internal/review/github.go
+++ b/internal/review/github.go
@@ -14,6 +14,24 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 )
 
+// runGH runs a gh command and returns stdout; on failure, the returned error
+// includes gh's stderr so upstream API messages surface in logs instead of just
+// "exit status 1".
+func runGH(label string, args ...string) ([]byte, error) {
+	cmd := exec.Command("gh", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			return nil, fmt.Errorf("%s: %w", label, err)
+		}
+		return nil, fmt.Errorf("%s: %w: %s", label, err, msg)
+	}
+	return out, nil
+}
+
 // parseRepoSlug splits a "owner/name" repository slug into its two parts.
 func parseRepoSlug(repo string) (owner, name string, err error) {
 	parts := strings.SplitN(repo, "/", 2)
@@ -84,12 +102,12 @@ func FetchPR(repo string, number int) (*PRData, error) {
 	numStr := fmt.Sprintf("%d", number)
 
 	// Fetch PR metadata as JSON.
-	viewOut, err := exec.Command("gh", "pr", "view", numStr,
+	viewOut, err := runGH("gh pr view", "pr", "view", numStr,
 		"--repo", repo,
 		"--json", "title,body,author,baseRefName,headRefName,files",
-	).Output()
+	)
 	if err != nil {
-		return nil, fmt.Errorf("gh pr view: %w", err)
+		return nil, err
 	}
 
 	var view ghPRView
@@ -97,12 +115,13 @@ func FetchPR(repo string, number int) (*PRData, error) {
 		return nil, fmt.Errorf("parsing gh pr view output: %w", err)
 	}
 
-	// Fetch the diff.
-	diffOut, err := exec.Command("gh", "pr", "diff", numStr,
-		"--repo", repo,
-	).Output()
+	// Fetch the diff. This hits GitHub's pull request diff API
+	// (GET /repos/{owner}/{repo}/pulls/{n} with Accept: application/vnd.github.v3.diff),
+	// which occasionally returns transient 5xx/timeouts — in that case, retrying the job
+	// is the usual fix.
+	diffOut, err := runGH("gh pr diff", "pr", "diff", numStr, "--repo", repo)
 	if err != nil {
-		return nil, fmt.Errorf("gh pr diff: %w", err)
+		return nil, fmt.Errorf("%w (GitHub pull request diff API; often transient — retrying the job usually resolves it)", err)
 	}
 
 	files := make([]string, len(view.Files))

--- a/internal/review/github.go
+++ b/internal/review/github.go
@@ -27,7 +27,7 @@ func runGH(label string, args ...string) ([]byte, error) {
 		if msg == "" {
 			return nil, fmt.Errorf("%s: %w", label, err)
 		}
-		return nil, fmt.Errorf("%s: %w: %s", label, err, msg)
+		return nil, fmt.Errorf("%s: %s: %w", label, msg, err)
 	}
 	return out, nil
 }
@@ -116,12 +116,10 @@ func FetchPR(repo string, number int) (*PRData, error) {
 	}
 
 	// Fetch the diff. This hits GitHub's pull request diff API
-	// (GET /repos/{owner}/{repo}/pulls/{n} with Accept: application/vnd.github.v3.diff),
-	// which occasionally returns transient 5xx/timeouts — in that case, retrying the job
-	// is the usual fix.
+	// (GET /repos/{owner}/{repo}/pulls/{n} with Accept: application/vnd.github.v3.diff).
 	diffOut, err := runGH("gh pr diff", "pr", "diff", numStr, "--repo", repo)
 	if err != nil {
-		return nil, fmt.Errorf("%w (GitHub pull request diff API; often transient — retrying the job usually resolves it)", err)
+		return nil, fmt.Errorf("%w (GitHub pull request diff API; if this looks like a transient 5xx/timeout, retrying the job may help)", err)
 	}
 
 	files := make([]string, len(view.Files))


### PR DESCRIPTION
## Summary
- `gh pr view` / `gh pr diff` errors in `FetchPR` were wrapped with only the exit status, so Actions logs showed `gh pr diff: exit status 1` with no detail (stderr from `.Output()` was dropped).
- Added a small `runGH` helper that pipes stderr into the wrapped error, so the real gh message (rate limit, 5xx, token scope, etc.) shows up in logs.
- For `gh pr diff` specifically, append a hint pointing at GitHub's pull request diff API (`GET /repos/{owner}/{repo}/pulls/{n}` with `Accept: application/vnd.github.v3.diff`), since transient failures there are the usual cause and a job retry typically resolves them.

Motivated by [this failing run](https://github.com/thetechfx/bedrock/actions/runs/24791879406/job/72551238868?pr=1581): the PR was small and mergeable, neighboring codecanary runs succeeded the same minute, and no stderr was visible to confirm it was just a transient API blip.

## Test plan
- [ ] `go build ./...` and `go vet ./...` pass (done locally).
- [ ] On the next real `gh pr diff` failure in Actions, verify the error line now includes gh's stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)