### PR TITLE
feat: friendlier provider error messages

### DIFF
--- a/internal/review/provider_anthropic.go
+++ b/internal/review/provider_anthropic.go
@@ -231,7 +231,15 @@ func (p *anthropicProvider) Run(ctx context.Context, prompt string, opts RunOpts
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Anthropic API returned status %d: %s", resp.StatusCode, string(body)) //nolint:staticcheck // proper noun
+		// Try to decode the structured {error:{type,message}} envelope so we
+		// can surface the upstream message; fall back to the raw body when
+		// the body is empty or not JSON.
+		var errResp anthropicResponse
+		msg := ""
+		if err := json.Unmarshal(body, &errResp); err == nil && errResp.Error != nil {
+			msg = errResp.Error.Message
+		}
+		return nil, classifyProviderError("anthropic", resp.StatusCode, msg, string(body))
 	}
 
 	var msgResp anthropicResponse
@@ -240,7 +248,7 @@ func (p *anthropicProvider) Run(ctx context.Context, prompt string, opts RunOpts
 	}
 
 	if msgResp.Error != nil {
-		return nil, fmt.Errorf("Anthropic API error: %s", msgResp.Error.Message) //nolint:staticcheck // proper noun
+		return nil, classifyProviderError("anthropic", resp.StatusCode, msgResp.Error.Message, string(body))
 	}
 
 	truncated := msgResp.StopReason == "max_tokens"

--- a/internal/review/provider_claude.go
+++ b/internal/review/provider_claude.go
@@ -178,29 +178,26 @@ func (p *claudeCLIProvider) Run(ctx context.Context, prompt string, opts RunOpts
 		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
+			// The CLI may still emit the JSON envelope on stdout when it exits
+			// non-zero (e.g. 429). Try to parse and classify it first so the
+			// user sees a friendly message; fall back to a raw dump only when
+			// we cannot extract structured info.
+			if resp, ok := tryParseClaudeEnvelope(output); ok && resp.IsError {
+				return nil, classifyProviderError("claude", resp.APIErrorStatus, resp.Result, string(output))
+			}
 			return nil, fmt.Errorf("claude failed: %s\n%s", string(exitErr.Stderr), string(output))
 		}
 		return nil, fmt.Errorf("running claude: %w", err)
 	}
 
-	// The Claude CLI may print non-JSON status lines (e.g. status-line UI) to
-	// stdout before or after the JSON envelope. Seek to the first '{' to skip
-	// any leading noise, then use a json.Decoder which stops after the first
-	// complete value — tolerating any trailing noise as well.
-	// Preserve the original output for the plain-text fallback.
-	jsonOutput := output
-	if i := bytes.IndexByte(output, '{'); i > 0 {
-		jsonOutput = output[i:]
-	}
-
-	var resp claudeJSONResponse
-	if err := json.NewDecoder(bytes.NewReader(jsonOutput)).Decode(&resp); err != nil {
+	resp, ok := tryParseClaudeEnvelope(output)
+	if !ok {
 		// Fallback: treat entire original output as plain text (e.g. older CLI version).
 		return &providerResult{Text: string(output)}, nil
 	}
 
 	if resp.IsError {
-		return nil, fmt.Errorf("claude returned error: %s", resp.Result)
+		return nil, classifyProviderError("claude", resp.APIErrorStatus, resp.Result, string(output))
 	}
 
 	// Note: the Claude CLI JSON output does not expose stop_reason, so we
@@ -229,4 +226,20 @@ func (p *claudeCLIProvider) Run(ctx context.Context, prompt string, opts RunOpts
 		})
 	}
 	return result, nil
+}
+
+// tryParseClaudeEnvelope pulls a claudeJSONResponse out of the CLI's stdout.
+// The Claude CLI may print non-JSON status lines (status-line UI) before or
+// after the JSON envelope, so we seek to the first '{' and let json.Decoder
+// stop after the first complete value — tolerating trailing noise.
+func tryParseClaudeEnvelope(output []byte) (claudeJSONResponse, bool) {
+	var resp claudeJSONResponse
+	jsonOutput := output
+	if i := bytes.IndexByte(output, '{'); i > 0 {
+		jsonOutput = output[i:]
+	}
+	if err := json.NewDecoder(bytes.NewReader(jsonOutput)).Decode(&resp); err != nil {
+		return resp, false
+	}
+	return resp, true
 }

--- a/internal/review/provider_errors.go
+++ b/internal/review/provider_errors.go
@@ -63,18 +63,37 @@ func (e *ProviderError) Error() string {
 		return b.String()
 	}
 
-	// No provider-specific hint registered — tell the user we're falling back
-	// to the raw upstream response so they can still debug.
+	// The provider is registered but we have no hint for this specific Kind
+	// (e.g. a 400/422 against anthropic). Return the header + upstream message
+	// alone; the "no formatter" banner is reserved for providers that aren't
+	// in the registry at all.
+	if _, providerRegistered := providerHints[e.Provider]; providerRegistered {
+		return b.String()
+	}
+
+	// Unregistered provider — surface the banner and preserve the raw body so
+	// the user still has something to debug with. Truncate defensively: some
+	// upstreams return HTML error pages that would otherwise swamp terminal
+	// output and logs.
 	b.WriteString(fmt.Sprintf(
 		"\n\nNo formatted error handler for %q provider — showing raw upstream response.",
 		e.Provider,
 	))
 	if e.RawBody != "" {
+		body := e.RawBody
+		if len(body) > maxRawBodyDisplay {
+			body = body[:maxRawBodyDisplay] + "... (truncated)"
+		}
 		b.WriteString("\n\n")
-		b.WriteString(e.RawBody)
+		b.WriteString(body)
 	}
 	return b.String()
 }
+
+// maxRawBodyDisplay caps how many bytes of the raw upstream body we echo
+// inside Error(). Chosen as a balance between debuggability and not flooding
+// terminals or log aggregators with HTML error pages from proxies.
+const maxRawBodyDisplay = 2048
 
 // providerHints maps (provider, kind) to a human-readable next-step message.
 // Providers that opt in register entries here; the formatter falls through to

--- a/internal/review/provider_errors.go
+++ b/internal/review/provider_errors.go
@@ -1,0 +1,149 @@
+package review
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ErrorKind classifies a provider failure at the protocol level. Hints are
+// derived from Kind + Provider so that providers without a registered hint
+// still get status-code-based classification.
+type ErrorKind int
+
+const (
+	ErrorKindUnknown ErrorKind = iota
+	ErrorKindRateLimit
+	ErrorKindAuth
+	ErrorKindServer
+)
+
+func (k ErrorKind) String() string {
+	switch k {
+	case ErrorKindRateLimit:
+		return "rate limit"
+	case ErrorKindAuth:
+		return "authentication"
+	case ErrorKindServer:
+		return "server error"
+	default:
+		return "error"
+	}
+}
+
+// ProviderError is the typed error returned by provider adapters when the
+// upstream service reports a failure. It carries enough context for the
+// formatter to render a friendly message with provider-specific hints, and
+// falls back to a raw-body dump for providers that have not been taught to
+// populate Message.
+type ProviderError struct {
+	Provider string    // e.g. "anthropic", "claude", "openai"
+	Status   int       // HTTP status or api_error_status from the upstream
+	Kind     ErrorKind // protocol-level classification
+	Message  string    // upstream-reported message, trimmed
+	RawBody  string    // original response body, retained for diagnostics
+}
+
+func (e *ProviderError) Error() string {
+	var b strings.Builder
+
+	header := fmt.Sprintf("%s %s", e.Provider, e.Kind)
+	if e.Status != 0 {
+		header = fmt.Sprintf("%s (%d)", header, e.Status)
+	}
+	b.WriteString(header)
+	if e.Message != "" {
+		b.WriteString(": ")
+		b.WriteString(e.Message)
+	}
+
+	hint := lookupProviderHint(e.Provider, e.Kind)
+	if hint != "" {
+		b.WriteString("\n\nHint: ")
+		b.WriteString(hint)
+		return b.String()
+	}
+
+	// No provider-specific hint registered — tell the user we're falling back
+	// to the raw upstream response so they can still debug.
+	b.WriteString(fmt.Sprintf(
+		"\n\nNo formatted error handler for %q provider — showing raw upstream response.",
+		e.Provider,
+	))
+	if e.RawBody != "" {
+		b.WriteString("\n\n")
+		b.WriteString(e.RawBody)
+	}
+	return b.String()
+}
+
+// providerHints maps (provider, kind) to a human-readable next-step message.
+// Providers that opt in register entries here; the formatter falls through to
+// the generic "no formatter" banner when a provider is missing.
+var providerHints = map[string]map[ErrorKind]string{
+	"anthropic": {
+		ErrorKindRateLimit: "Anthropic API rate limit hit. Check your workspace limits at console.anthropic.com, lower --max-budget-usd, or retry after the window resets.",
+		ErrorKindAuth:      "Anthropic API rejected the credential. Run `codecanary auth status` and, if needed, `codecanary setup local` to refresh it.",
+		ErrorKindServer:    "Anthropic API reported a server error. This is usually transient — retry in a minute.",
+	},
+	"claude": {
+		ErrorKindRateLimit: "Your Claude subscription quota is exhausted (the reset time above is in your plan's timezone). Options: wait for reset, switch `provider:` in .codecanary/config.yml to `anthropic`/`openai`/`openrouter`/`grok`, or swap accounts with `codecanary auth delete` followed by `codecanary setup local`.",
+		ErrorKindAuth:      "Claude CLI rejected the OAuth token. Run `codecanary auth delete` then `codecanary setup local` to re-authenticate.",
+		ErrorKindServer:    "Claude CLI reported a server error. This is usually transient — retry in a minute.",
+	},
+}
+
+func lookupProviderHint(provider string, kind ErrorKind) string {
+	byKind, ok := providerHints[provider]
+	if !ok {
+		return ""
+	}
+	return byKind[kind]
+}
+
+// classifyProviderError builds a typed ProviderError from the raw pieces a
+// provider adapter has on hand. The classifier uses HTTP status codes — which
+// are protocol-level, not provider-specific — so even providers without a
+// registered hint get the right Kind.
+//
+// Callers should pass the upstream message if they can parse one; raw is the
+// full response body (or JSON envelope) retained for the fallback path.
+func classifyProviderError(provider string, status int, message, raw string) *ProviderError {
+	kind := kindFromStatus(status)
+	// Some providers (notably the Claude CLI when exiting 0) don't report a
+	// numeric status on every error. Heuristically upgrade Unknown to
+	// RateLimit when the message itself clearly says so.
+	if kind == ErrorKindUnknown && looksLikeRateLimit(message) {
+		kind = ErrorKindRateLimit
+	}
+	return &ProviderError{
+		Provider: provider,
+		Status:   status,
+		Kind:     kind,
+		Message:  strings.TrimSpace(message),
+		RawBody:  strings.TrimSpace(raw),
+	}
+}
+
+func kindFromStatus(status int) ErrorKind {
+	switch {
+	case status == 429:
+		return ErrorKindRateLimit
+	case status == 401 || status == 403:
+		return ErrorKindAuth
+	case status >= 500 && status < 600:
+		return ErrorKindServer
+	default:
+		return ErrorKindUnknown
+	}
+}
+
+func looksLikeRateLimit(message string) bool {
+	if message == "" {
+		return false
+	}
+	m := strings.ToLower(message)
+	return strings.Contains(m, "rate limit") ||
+		strings.Contains(m, "rate_limit") ||
+		strings.Contains(m, "hit your limit") ||
+		strings.Contains(m, "quota")
+}

--- a/internal/review/provider_errors.go
+++ b/internal/review/provider_errors.go
@@ -75,10 +75,11 @@ func (e *ProviderError) Error() string {
 	// the user still has something to debug with. Truncate defensively: some
 	// upstreams return HTML error pages that would otherwise swamp terminal
 	// output and logs.
-	b.WriteString(fmt.Sprintf(
+	fmt.Fprintf(
+		&b,
 		"\n\nNo formatted error handler for %q provider — showing raw upstream response.",
 		e.Provider,
-	))
+	)
 	if e.RawBody != "" {
 		body := e.RawBody
 		if len(body) > maxRawBodyDisplay {

--- a/internal/review/provider_errors_test.go
+++ b/internal/review/provider_errors_test.go
@@ -95,6 +95,23 @@ func TestProviderError_Error_UnknownKindStillReportsStatus(t *testing.T) {
 	if !strings.Contains(got, "anthropic error (418)") {
 		t.Errorf("expected generic 'error' label with status, got: %q", got)
 	}
+	// Registered providers never trigger the "no formatter" banner, even
+	// when we don't have a hint for this specific Kind.
+	if strings.Contains(got, "No formatted error handler") {
+		t.Errorf("registered provider should not get fallback banner: %q", got)
+	}
+}
+
+func TestProviderError_Error_TruncatesLargeRawBody(t *testing.T) {
+	big := strings.Repeat("x", maxRawBodyDisplay+500)
+	pe := classifyProviderError("openrouter", 503, "", big)
+	got := pe.Error()
+	if !strings.Contains(got, "... (truncated)") {
+		t.Errorf("expected truncation marker, got: %q", got)
+	}
+	if strings.Count(got, "x") > maxRawBodyDisplay+10 {
+		t.Errorf("body not trimmed: saw %d x's", strings.Count(got, "x"))
+	}
 }
 
 func TestTryParseClaudeEnvelope_HandlesAPIErrorStatus(t *testing.T) {

--- a/internal/review/provider_errors_test.go
+++ b/internal/review/provider_errors_test.go
@@ -1,0 +1,122 @@
+package review
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClassifyProviderError_KindFromStatus(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider string
+		status   int
+		message  string
+		wantKind ErrorKind
+	}{
+		{"anthropic 429", "anthropic", 429, "rate limit hit", ErrorKindRateLimit},
+		{"anthropic 401", "anthropic", 401, "bad key", ErrorKindAuth},
+		{"anthropic 403", "anthropic", 403, "forbidden", ErrorKindAuth},
+		{"anthropic 500", "anthropic", 500, "oops", ErrorKindServer},
+		{"anthropic 502", "anthropic", 502, "bad gateway", ErrorKindServer},
+		{"anthropic 400", "anthropic", 400, "bad request", ErrorKindUnknown},
+		{"claude 429", "claude", 429, "", ErrorKindRateLimit},
+		{"claude cli zero status rate-limit text", "claude", 0, "You've hit your limit · resets 8pm", ErrorKindRateLimit},
+		{"claude cli zero status quota text", "claude", 0, "monthly quota exceeded", ErrorKindRateLimit},
+		{"openai 429", "openai", 429, "", ErrorKindRateLimit},
+		{"grok 401", "grok", 401, "", ErrorKindAuth},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			pe := classifyProviderError(c.provider, c.status, c.message, "")
+			if pe.Kind != c.wantKind {
+				t.Fatalf("Kind = %v, want %v", pe.Kind, c.wantKind)
+			}
+			if pe.Provider != c.provider {
+				t.Fatalf("Provider = %q, want %q", pe.Provider, c.provider)
+			}
+			if pe.Status != c.status {
+				t.Fatalf("Status = %d, want %d", pe.Status, c.status)
+			}
+		})
+	}
+}
+
+func TestProviderError_Error_AnthropicHasHint(t *testing.T) {
+	pe := classifyProviderError("anthropic", 429, "rate_limit_error: slow down", `{"error":{"message":"rate_limit_error: slow down"}}`)
+	got := pe.Error()
+	if !strings.Contains(got, "anthropic rate limit (429)") {
+		t.Errorf("missing header: %q", got)
+	}
+	if !strings.Contains(got, "rate_limit_error: slow down") {
+		t.Errorf("missing upstream message: %q", got)
+	}
+	if !strings.Contains(got, "Hint:") {
+		t.Errorf("expected registered hint, got: %q", got)
+	}
+	if strings.Contains(got, "No formatted error handler") {
+		t.Errorf("should not render fallback banner when a hint is registered: %q", got)
+	}
+}
+
+func TestProviderError_Error_ClaudeRateLimitHasHint(t *testing.T) {
+	// Matches the real-world payload: api_error_status=429, message carries
+	// the subscription-reset notice.
+	pe := classifyProviderError("claude", 429, "You've hit your limit · resets 8pm (America/Sao_Paulo)", "")
+	got := pe.Error()
+	if !strings.Contains(got, "claude rate limit (429)") {
+		t.Errorf("missing header: %q", got)
+	}
+	if !strings.Contains(got, "You've hit your limit") {
+		t.Errorf("missing upstream message: %q", got)
+	}
+	if !strings.Contains(got, "Hint:") || !strings.Contains(got, "subscription") {
+		t.Errorf("expected subscription hint, got: %q", got)
+	}
+}
+
+func TestProviderError_Error_UnformattedProviderFallsBack(t *testing.T) {
+	raw := `{"error":{"code":"rate_limit_exceeded","message":"too many requests"}}`
+	pe := classifyProviderError("openrouter", 429, "too many requests", raw)
+	got := pe.Error()
+	if !strings.Contains(got, "openrouter rate limit (429)") {
+		t.Errorf("missing header: %q", got)
+	}
+	if !strings.Contains(got, `No formatted error handler for "openrouter" provider`) {
+		t.Errorf("expected no-formatter banner for unregistered provider, got: %q", got)
+	}
+	if !strings.Contains(got, raw) {
+		t.Errorf("raw body should be preserved under the banner, got: %q", got)
+	}
+}
+
+func TestProviderError_Error_UnknownKindStillReportsStatus(t *testing.T) {
+	pe := classifyProviderError("anthropic", 418, "i am a teapot", "")
+	got := pe.Error()
+	if !strings.Contains(got, "anthropic error (418)") {
+		t.Errorf("expected generic 'error' label with status, got: %q", got)
+	}
+}
+
+func TestTryParseClaudeEnvelope_HandlesAPIErrorStatus(t *testing.T) {
+	raw := []byte(`prefix noise {"type":"result","is_error":true,"api_error_status":429,"result":"You've hit your limit · resets 8pm (America/Sao_Paulo)"}`)
+	resp, ok := tryParseClaudeEnvelope(raw)
+	if !ok {
+		t.Fatal("expected parse to succeed")
+	}
+	if !resp.IsError {
+		t.Errorf("IsError = false, want true")
+	}
+	if resp.APIErrorStatus != 429 {
+		t.Errorf("APIErrorStatus = %d, want 429", resp.APIErrorStatus)
+	}
+	if !strings.Contains(resp.Result, "hit your limit") {
+		t.Errorf("Result missing rate-limit text: %q", resp.Result)
+	}
+}
+
+func TestTryParseClaudeEnvelope_NotJSON(t *testing.T) {
+	_, ok := tryParseClaudeEnvelope([]byte("plain text with no brace"))
+	if ok {
+		t.Fatal("expected parse to fail on non-JSON output")
+	}
+}

--- a/internal/review/usage.go
+++ b/internal/review/usage.go
@@ -186,10 +186,11 @@ func PrintUsageSummary(report *UsageReport) {
 
 // claudeJSONResponse represents the JSON output from `claude --print --output-format json`.
 type claudeJSONResponse struct {
-	Result     string  `json:"result"`
-	IsError    bool    `json:"is_error"`
-	CostUSD    float64 `json:"total_cost_usd"`
-	DurationMS int     `json:"duration_ms"`
+	Result         string  `json:"result"`
+	IsError        bool    `json:"is_error"`
+	APIErrorStatus int     `json:"api_error_status"` // HTTP status when is_error is true (e.g. 429 on rate limit)
+	CostUSD        float64 `json:"total_cost_usd"`
+	DurationMS     int     `json:"duration_ms"`
 	Usage      struct {
 		InputTokens              int `json:"input_tokens"`
 		OutputTokens             int `json:"output_tokens"`


### PR DESCRIPTION
## Summary
- Introduce a typed `ProviderError` with kind-based classification (rate limit / auth / server) and a per-provider hint registry.
- Wire the Anthropic API and Claude CLI adapters to build `ProviderError` on upstream failures instead of dumping raw JSON.
- For providers without a registered hint (`openai`, `openrouter`, `grok`), the formatter prints a "No formatted error handler for X provider — showing raw upstream response." banner above the raw body, so output is always at least as good as today.
- Parse the Claude CLI's `is_error: true` envelope even on non-zero exit so the new 429 path catches `"You've hit your limit · resets 8pm"`-style messages.

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./cmd/review`
- [ ] Manually trigger a 429 against the Claude CLI and confirm the new hint renders
- [ ] Confirm Anthropic auth errors print the `codecanary setup local` hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)