### PR TITLE
fix: route platform strictly by --post so local is always local

### DIFF
--- a/.claude/skills/codecanary-fix/SKILL.md
+++ b/.claude/skills/codecanary-fix/SKILL.md
@@ -38,10 +38,14 @@ is spent on triage judgment and fix application, not on watching CI.
 ## Mode selection
 
 - **PR mode (default)**: fixes land as commits on the current branch and
-  are pushed. Used when an open PR exists for the branch.
-- **Local mode** — activated automatically when no PR is detected for the
-  current branch: `codecanary review --output json` runs a review on the
-  current dirty working tree; fixes are applied but not committed or pushed.
+  are pushed. Used when an open PR exists for the branch and the operator
+  wants CodeCanary's GitHub review cycle to drive the loop.
+- **Local mode** — used when no PR exists for the branch, or when the
+  operator explicitly wants a local-only pass: `codecanary review --output
+  json` runs a review on the current dirty working tree; fixes are applied
+  but not committed or pushed. `codecanary review` is always local unless
+  `--post` is passed, so this mode works even when the branch has an open
+  PR.
 
 If you cannot tell which mode applies, ask the operator before starting.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,9 @@ Adding a new LLM provider means: create `provider_<name>.go` and register a `Pro
 
 Abstracts environment-specific operations: loading previous findings, publishing results, saving state, resolving threads, reporting usage.
 
-**Implementations**: `GithubPlatform` (posts to PRs, reads threads via API), `LocalPlatform` (prints to terminal, persists state to `.codecanary/state/`).
+**Implementations**: `GithubPlatform` (posts to PRs, reads threads via API), `LocalPlatform` (prints to terminal, persists state to `~/.codecanary/state/<branch>.json`).
+
+Routing is strict: `codecanary review --post` → `GithubPlatform`; `codecanary review` (no `--post`) → `LocalPlatform`, even when the branch has an open PR. Local is local — the branch diff (with uncommitted changes) is reviewed against the default base, previous findings come from local state, nothing is fetched from or posted to GitHub. The old `GithubPlatform`-with-`Post=false` hybrid is gone; it was the source of the "state written locally, read from GitHub" asymmetry that kept breaking incremental local reviews.
 
 Adding a new platform (e.g., GitLab) means: implement `ReviewPlatform`, wire it in the CLI.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ codecanary review --post         # same, but also post findings to the PR on Git
 codecanary review --output json  # machine-readable output
 ```
 
-If your branch has an open PR, CodeCanary auto-detects it. Otherwise it diffs against the default branch. State is tracked in `~/.codecanary/state/` for incremental reviews on subsequent runs.
+Without `--post`, `codecanary review` is always local: it diffs your branch (with uncommitted changes) against the default branch and keeps state in `~/.codecanary/state/<branch>.json` for incremental re-runs. With `--post`, it fetches the PR from GitHub — pass a number or let it auto-detect from the current branch — and posts findings as review comments.
 
 ### GitHub Actions
 

--- a/cmd/review/cli/review.go
+++ b/cmd/review/cli/review.go
@@ -11,7 +11,7 @@ import (
 var reviewCmd = &cobra.Command{
 	Use:              "review [pr-number]",
 	Short:            "Review a pull request",
-	Long:             "Review a pull request. If no PR number is given, detects the PR for the current branch. If no PR exists, reviews the local branch diff.",
+	Long:             "Review a pull request. Without --post, always runs locally against the branch diff (uncommitted changes included) and persists state under ~/.codecanary/state/. With --post, fetches the PR from GitHub and posts findings as review comments — use a PR number or omit it to auto-detect from the current branch.",
 	Args:             cobra.ArbitraryArgs,
 	TraverseChildren: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -24,82 +24,60 @@ var reviewCmd = &cobra.Command{
 		claudePath, _ := cmd.Flags().GetString("claude-path")
 		baseBranch, _ := cmd.Flags().GetString("base")
 
-		// Explicit PR number — GitHub mode.
-		if len(args) > 0 {
-			prNumber, err := strconv.Atoi(args[0])
-			if err != nil {
-				return fmt.Errorf("invalid PR number %q: %w", args[0], err)
-			}
-			if baseBranch != "" {
-				review.Stderrf(review.ColorYellow, "Warning: --base ignored in PR mode\n")
-			}
-			return review.Run(review.RunOptions{
-				Repo:       repo,
-				PRNumber:   prNumber,
-				ConfigPath: configPath,
-				Output:     output,
-				Post:       post,
-				DryRun:     dryRun,
-				ReplyOnly:  replyOnly,
-				ClaudePath: claudePath,
-				Version:    Version,
-				Platform: &review.GithubPlatform{
-					Repo:         repo,
-					PRNumber:     prNumber,
-					Post:         post,
-					DryRun:       dryRun,
-					OutputFormat: output,
-				},
-			})
-		}
-
-		// Try auto-detecting PR from current branch.
-		if prNumber, err := review.DetectPRNumber(repo); err == nil {
-			review.Stderrf(review.ColorCyan, "Auto-detected PR #%d from current branch\n", prNumber)
-			if baseBranch != "" {
-				review.Stderrf(review.ColorYellow, "Warning: --base ignored in PR mode\n")
-			}
-			return review.Run(review.RunOptions{
-				Repo:       repo,
-				PRNumber:   prNumber,
-				ConfigPath: configPath,
-				Output:     output,
-				Post:       post,
-				DryRun:     dryRun,
-				ReplyOnly:  replyOnly,
-				ClaudePath: claudePath,
-				Version:    Version,
-				Platform: &review.GithubPlatform{
-					Repo:         repo,
-					PRNumber:     prNumber,
-					Post:         post,
-					DryRun:       dryRun,
-					OutputFormat: output,
-				},
-			})
-		}
-
-		// No PR — local mode.
-		pr, err := review.FetchLocalDiff(baseBranch)
-		if err != nil {
-			return fmt.Errorf("no PR found and local diff failed: %w", err)
-		}
-		review.Stderrf(review.ColorCyan, "No PR found — reviewing local changes on %s\n", pr.HeadBranch)
-
+		// GitHub mode — only when posting. Requires a PR (explicit or auto-detected).
 		if post {
-			review.Stderrf(review.ColorYellow, "Warning: --post ignored in local mode (no PR to post to)\n")
-			post = false
+			var prNumber int
+			if len(args) > 0 {
+				n, err := strconv.Atoi(args[0])
+				if err != nil {
+					return fmt.Errorf("invalid PR number %q: %w", args[0], err)
+				}
+				prNumber = n
+			} else {
+				n, err := review.DetectPRNumber(repo)
+				if err != nil {
+					return fmt.Errorf("--post requires a PR; could not auto-detect one for the current branch: %w", err)
+				}
+				review.Stderrf(review.ColorCyan, "Auto-detected PR #%d from current branch\n", n)
+				prNumber = n
+			}
+			if baseBranch != "" {
+				review.Stderrf(review.ColorYellow, "Warning: --base ignored in --post mode\n")
+			}
+			return review.Run(review.RunOptions{
+				Repo:       repo,
+				PRNumber:   prNumber,
+				ConfigPath: configPath,
+				Output:     output,
+				Post:       true,
+				DryRun:     dryRun,
+				ReplyOnly:  replyOnly,
+				ClaudePath: claudePath,
+				Version:    Version,
+				Platform: &review.GithubPlatform{
+					Repo:     repo,
+					PRNumber: prNumber,
+					DryRun:   dryRun,
+				},
+			})
 		}
+
+		// Local mode — default. A PR number argument is ignored: local is local.
 		if replyOnly {
 			review.Stderrf(review.ColorYellow, "Warning: --reply-only ignored in local mode\n")
 			replyOnly = false
 		}
 
+		pr, err := review.FetchLocalDiff(baseBranch)
+		if err != nil {
+			return fmt.Errorf("local diff failed: %w", err)
+		}
+		review.Stderrf(review.ColorCyan, "Reviewing local changes on %s\n", pr.HeadBranch)
+
 		return review.Run(review.RunOptions{
 			PR:         pr,
 			ConfigPath: configPath,
 			Output:     output,
-			Post:       post,
 			DryRun:     dryRun,
 			ReplyOnly:  replyOnly,
 			ClaudePath: claudePath,
@@ -113,11 +91,11 @@ var reviewCmd = &cobra.Command{
 }
 
 func init() {
-	reviewCmd.Flags().StringP("repo", "r", "", "GitHub repo (owner/name)")
+	reviewCmd.Flags().StringP("repo", "r", "", "GitHub repo (owner/name) — only used with --post")
 	reviewCmd.Flags().StringP("output", "o", "markdown", "Output format: markdown, terminal, or json; auto-upgrades to terminal when stdout is a TTY")
-	reviewCmd.Flags().Bool("post", false, "Post findings as a PR comment")
+	reviewCmd.Flags().Bool("post", false, "Fetch the PR from GitHub and post findings as review comments (requires a PR; auto-detected if no number given)")
 	reviewCmd.Flags().StringP("config", "c", "", "Path to review config (auto-detected if empty)")
-	reviewCmd.Flags().Bool("reply-only", false, "Evaluate thread replies only, skip new findings")
+	reviewCmd.Flags().Bool("reply-only", false, "Evaluate thread replies only, skip new findings (--post only)")
 	reviewCmd.Flags().String("claude-path", "", "Path to the Claude CLI binary (overrides config claude_path)")
 	reviewCmd.Flags().StringP("base", "b", "", "Base branch for local review (auto-detected if empty)")
 	reviewCmd.PersistentFlags().Bool("dry-run", false, "Show prompt without running Claude")

--- a/docs/review-flow.md
+++ b/docs/review-flow.md
@@ -13,21 +13,22 @@ Both modes run through the same `Run()` function in `runner.go`. The pipeline is
 
 ## Platforms
 
-There are three runtime contexts:
+Two platforms, routed strictly by `--post`:
 
 | Context | Platform | How it runs | State storage | Output |
 |---------|----------|-------------|---------------|--------|
-| **GitHub CI** | `GithubPlatform` (Post=true) | GitHub Actions workflow | PR review threads via API | Posts review comments on the PR |
-| **GitHub local-detect** | `GithubPlatform` (Post=false) | `codecanary review <pr>` locally | `~/.codecanary/state/<branch>.json` | Prints to terminal |
-| **Local** | `LocalPlatform` | `codecanary review` (no PR number) | `~/.codecanary/state/<branch>.json` | Prints to terminal |
+| **GitHub PR** | `GithubPlatform` | `codecanary review --post` (locally or in CI) | PR review threads via API | Posts review comments on the PR |
+| **Local** | `LocalPlatform` | `codecanary review` (with or without a PR for the branch) | `~/.codecanary/state/<branch>.json` | Prints to terminal |
+
+`codecanary review` without `--post` is always local — even if the branch has an open PR. "Local is local": the branch diff (including uncommitted changes) is reviewed against the default base, and previous findings come from `~/.codecanary/state/<branch>.json`. There is no hybrid mode that reads GitHub but writes local state. Two consecutive local runs go incremental off the saved state (locked in by `TestLocalPlatformIncrementalHandoff` in `state_test.go`).
 
 ## Pipeline Steps
 
 ### 1. Fetch PR data
 
-**GitHub mode**: Fetches PR metadata (title, body, author, branches) and diff via `gh pr view` and `gh pr diff`.
+**GitHub PR** (`--post`): Fetches PR metadata (title, body, author, branches) and diff via `gh pr view` and `gh pr diff`.
 
-**Local mode**: Detects the default branch (`main`, falling back to `master`) and computes diff from merge-base to HEAD via `git diff $(git merge-base HEAD <default-branch>)..HEAD`. Uses current branch name as the title and `git config user.name` as the author.
+**Local**: Detects the default branch (`main`, falling back to `master`, or the explicit `--base`) and computes diff from merge-base to HEAD via `git diff $(git merge-base HEAD <default-branch>)..HEAD`. Uncommitted working-tree changes scoped to the branch files are appended to the incremental diff on subsequent runs. Uses current branch name as the title and `git config user.name` as the author.
 
 If the PR is a setup PR (only adds workflow files with no real code changes), the review is skipped with an informational comment.
 
@@ -53,9 +54,9 @@ Each provider is constructed via the factory registry in `provider.go`. The prov
 
 The platform adapter loads unresolved findings from the last review:
 
-**GitHub CI**: Fetches review threads via GraphQL. Filters to CodeCanary findings only (detected by HTML marker comments). Extracts the previous review's HEAD SHA from the most recent review body — clean and all-clear reviews embed this marker too, so the baseline advances even when a push produced no findings. Returns unresolved threads, the SHA, and a count for fix_ref numbering.
+**GitHub PR** (`--post`): Fetches review threads via GraphQL. Filters to CodeCanary findings only (detected by HTML marker comments). Extracts the previous review's HEAD SHA from the most recent review body — clean and all-clear reviews embed this marker too, so the baseline advances even when a push produced no findings. Returns unresolved threads, the SHA, and a count for fix_ref numbering.
 
-**Local modes**: Reads `~/.codecanary/state/<branch>.json`, which stores the SHA, branch name, and findings array from the previous review. Converts saved findings into `ReviewThread` shape for the triage pipeline.
+**Local**: Reads `~/.codecanary/state/<branch>.json`, which stores the SHA, branch name, and findings array from the previous review. Converts saved findings into `ReviewThread` shape for the triage pipeline.
 
 If no previous findings exist, this is a first review.
 
@@ -151,7 +152,7 @@ If the response is truncated (hit max output tokens), a warning is logged. The p
 
 ### 8. Publish results
 
-**GitHub CI**: Every cycle emits exactly one top-level CodeCanary review, decided by an edit-vs-post rule. `FetchLatestCodecanaryReview` reads the commit SHA from the most recent CodeCanary review's hidden marker:
+**GitHub PR** (`--post`): Every cycle emits exactly one top-level CodeCanary review, decided by an edit-vs-post rule. `FetchLatestCodecanaryReview` reads the commit SHA from the most recent CodeCanary review's hidden marker:
 
 - **Same SHA** (reply-only run, or a duplicate `synchronize` webhook on the same HEAD): the existing body is updated in place with `UpdateReviewBody`. Only the status block between the `<!-- codecanary:status -->` markers is swapped — inline comments and prior findings text are untouched.
 - **Different or no SHA** (new commits, or first review on the PR): a fresh review is posted. The body variant depends on the cycle outcome — findings review, all-clear, activity summary (no new findings but cycle activity to surface), or clean review. All variants carry the same status block and baseline SHA marker. Older CodeCanary reviews are minimized (collapsed) before posting.
@@ -162,19 +163,19 @@ Per-thread ack replies for dismissed/acknowledged/rebutted resolutions are poste
 
 `codecanary findings` applies the same marker to filter deferrals out of its default output: threads with any `codecanary:ack:*` reply are treated as handled and omitted alongside GitHub-resolved threads. Pass `--include-resolved` to see them. This keeps the codecanary-fix skill from re-prompting on findings the operator already deferred.
 
-**Local modes**: Prints the formatted result to stdout. Format depends on context: terminal (colored, human-readable), markdown, or JSON.
+**Local**: Prints the formatted result to stdout. Format depends on context: terminal (colored, human-readable), markdown, or JSON.
 
 ### 9. Save state
 
-**GitHub CI**: No-op. State is stored in the review threads themselves (the embedded JSON marker contains the SHA and findings).
+**GitHub PR** (`--post`): No-op. State is stored in the review threads themselves (the embedded JSON marker contains the SHA and findings).
 
-**Local modes**: Writes `~/.codecanary/state/<branch>.json` with the current HEAD SHA, branch name, and combined findings (still-open + new). This enables incremental reviews on the next run.
+**Local**: Writes `~/.codecanary/state/<branch>.json` with the current HEAD SHA, branch name, and combined findings (still-open + new). This enables incremental reviews on the next run.
 
 ### 10. Report usage
 
-**GitHub CI**: Writes token counts and cost to `GITHUB_ENV` for downstream workflow steps.
+**GitHub PR** (`--post`): Writes token counts and cost to `GITHUB_ENV` for downstream workflow steps.
 
-**Local modes**: Prints a usage summary table to stderr (model, tokens, cost, duration) if running in a terminal.
+**Local**: Prints a usage summary table to stderr (model, tokens, cost, duration) if running in a terminal.
 
 ### 11. Telemetry
 

--- a/internal/review/platform_github.go
+++ b/internal/review/platform_github.go
@@ -115,13 +115,13 @@ func hasAcknowledgmentReply(t ReviewThread) bool {
 	return false
 }
 
-// GithubPlatform implements ReviewPlatform for GitHub Actions / PR mode.
+// GithubPlatform implements ReviewPlatform for GitHub PR mode. It always
+// posts to the PR; "local preview" against a GitHub PR is no longer a thing —
+// `codecanary review` without --post uses LocalPlatform.
 type GithubPlatform struct {
-	Repo         string
-	PRNumber     int
-	Post         bool   // whether to post review comments to GitHub
-	DryRun       bool
-	OutputFormat string // user-requested output format (may be empty)
+	Repo     string
+	PRNumber int
+	DryRun   bool
 }
 
 func (g *GithubPlatform) LoadPreviousFindings() ([]ReviewThread, string, int) {
@@ -185,18 +185,6 @@ func (g *GithubPlatform) HandleResolutions(threads []ReviewThread, fixed []fixed
 }
 
 func (g *GithubPlatform) Publish(result *ReviewResult, pr *PRData, threads []ReviewThread, fixed []fixedThread) error {
-	// Print output to stdout when not posting to GitHub.
-	outputFormat := resolveOutputFormat(g.OutputFormat)
-	if !g.Post {
-		formatted, err := formatResult(result, outputFormat)
-		if err != nil {
-			return err
-		}
-		fmt.Print(formatted)
-		// Usage table is printed by ReportUsage for terminal output.
-		return nil
-	}
-
 	summary := computeReviewSummary(threads, fixed, result.Findings)
 
 	// Decide edit-vs-post: if the latest CodeCanary review on the PR carries
@@ -278,43 +266,16 @@ func (g *GithubPlatform) Publish(result *ReviewResult, pr *PRData, threads []Rev
 	return nil
 }
 
-func (g *GithubPlatform) SaveState(result *ReviewResult, stillOpen []Finding, isIncremental bool) error {
-	// In CI mode (Post=true), don't save local state.
-	// In LocalDetect mode (Post=false), save for future incremental reviews.
-	if g.Post || g.DryRun {
-		return nil
-	}
-
-	branch, err := currentBranch()
-	if err != nil {
-		return nil // non-fatal
-	}
-
-	allFindings := combineFindings(stillOpen, result.Findings)
-
-	if err := SaveLocalState(branch, &LocalState{
-		SHA:      result.SHA,
-		Branch:   branch,
-		Findings: allFindings,
-	}); err != nil {
-		Stderrf(ansiYellow, "Warning: could not save local state: %v\n", err)
-	}
+func (g *GithubPlatform) SaveState(_ *ReviewResult, _ []Finding, _ bool) error {
+	// No-op: GitHub mode stores state in PR review threads (embedded JSON
+	// markers carry the SHA and findings). Local state files are owned by
+	// LocalPlatform — this keeps the two adapters from fighting over the
+	// same ~/.codecanary/state/<branch>.json file.
 	return nil
 }
 
-func (g *GithubPlatform) GetIncrementalDiff(baseSHA string, prFiles []string) (string, error) {
-	diff, err := GetIncrementalDiff(baseSHA)
-	if err != nil {
-		return "", err
-	}
-
-	// In CI mode, only committed changes matter.
-	if g.Post {
-		return diff, nil
-	}
-
-	// Local-detect mode: also include uncommitted changes scoped to PR files.
-	return appendWorkingTreeDiff(diff, prFiles)
+func (g *GithubPlatform) GetIncrementalDiff(baseSHA string, _ []string) (string, error) {
+	return GetIncrementalDiff(baseSHA)
 }
 
 func (g *GithubPlatform) ReportUsage(tracker *UsageTracker) {
@@ -322,14 +283,6 @@ func (g *GithubPlatform) ReportUsage(tracker *UsageTracker) {
 	if len(report.Calls) > 0 {
 		if err := WriteUsageEnv(report); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: could not write usage env: %v\n", err)
-		}
-	}
-
-	// Also print usage table when output goes to terminal (local-detect mode).
-	if !g.Post {
-		outputFormat := resolveOutputFormat(g.OutputFormat)
-		if outputFormat == "terminal" {
-			fmt.Fprint(os.Stderr, FormatUsageTable(tracker, colorsEnabled()))
 		}
 	}
 }

--- a/internal/review/state_test.go
+++ b/internal/review/state_test.go
@@ -4,6 +4,50 @@ import (
 	"testing"
 )
 
+// TestLocalPlatformIncrementalHandoff locks in the two-run parity contract:
+// a LocalPlatform.SaveState followed by a fresh LocalPlatform.LoadPreviousFindings
+// on the same branch must return a non-empty previousSHA.
+//
+// This is the exact gate runner.go uses to decide isIncremental (see
+// runner.go:372 — `isIncremental := previousSHA != ""`). If this breaks,
+// two consecutive local `codecanary review` runs stop surfacing
+// "Re-evaluating N unresolved thread(s)..." and "N finding(s) resolved by
+// code changes" — the regression from #166/earlier that prompted this test.
+//
+// The GithubPlatform-with-Post=false hybrid used to fail this invariant by
+// writing local state it never read back. Keep this test even if the
+// adapter layout changes.
+func TestLocalPlatformIncrementalHandoff(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	branch := "test-incremental-handoff"
+
+	writer := &LocalPlatform{Branch: branch}
+	result := &ReviewResult{SHA: "deadbeef", Findings: []Finding{
+		{ID: "x", File: "a.go", Line: 1, Severity: "warning", Title: "t", Description: "d"},
+	}}
+	if err := writer.SaveState(result, nil, false); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	reader := &LocalPlatform{Branch: branch}
+	threads, previousSHA, startIndex := reader.LoadPreviousFindings()
+
+	if previousSHA == "" {
+		t.Fatal("previousSHA is empty — second run would not enter the incremental path")
+	}
+	if previousSHA != "deadbeef" {
+		t.Errorf("previousSHA = %q, want %q", previousSHA, "deadbeef")
+	}
+	if len(threads) != 1 {
+		t.Errorf("len(threads) = %d, want 1", len(threads))
+	}
+	if startIndex != 1 {
+		t.Errorf("startIndex = %d, want 1", startIndex)
+	}
+}
+
 func TestFindingFromThreadLosesLocalStateFields(t *testing.T) {
 	// This test documents the known limitation: FindingFromThread cannot
 	// reconstruct findings from the plain-text body that findingsToKnownIssues

--- a/internal/skills/codecanary-fix/SKILL.md
+++ b/internal/skills/codecanary-fix/SKILL.md
@@ -38,10 +38,14 @@ is spent on triage judgment and fix application, not on watching CI.
 ## Mode selection
 
 - **PR mode (default)**: fixes land as commits on the current branch and
-  are pushed. Used when an open PR exists for the branch.
-- **Local mode** — activated automatically when no PR is detected for the
-  current branch: `codecanary review --output json` runs a review on the
-  current dirty working tree; fixes are applied but not committed or pushed.
+  are pushed. Used when an open PR exists for the branch and the operator
+  wants CodeCanary's GitHub review cycle to drive the loop.
+- **Local mode** — used when no PR exists for the branch, or when the
+  operator explicitly wants a local-only pass: `codecanary review --output
+  json` runs a review on the current dirty working tree; fixes are applied
+  but not committed or pushed. `codecanary review` is always local unless
+  `--post` is passed, so this mode works even when the branch has an open
+  PR.
 
 If you cannot tell which mode applies, ask the operator before starting.
 


### PR DESCRIPTION
## Summary

- `codecanary review` auto-selected `GithubPlatform` whenever the branch had an open PR, even without `--post`. That hybrid read previous findings from the PR's review threads but wrote local state — so two consecutive local runs never went incremental, and the "re-checking previous findings" / "fixed by code" output disappeared. Same parity gap between GHA and local that keeps resurfacing after each refactor.
- Route strictly by `--post`: `--post` → `GithubPlatform` (requires a PR, auto-detected or arg); no `--post` → `LocalPlatform`, always, including when a PR exists for the branch. Strip every `Post=false` branch from `GithubPlatform` (`SaveState`, `Publish`, `GetIncrementalDiff`, `ReportUsage`) and drop the now-unused `Post` and `OutputFormat` fields. The two platforms no longer contend for the same `~/.codecanary/state/<branch>.json`.
- Add `TestLocalPlatformIncrementalHandoff` as a regression trap: write state via one `LocalPlatform`, load via a fresh one, assert `previousSHA != ""` — the exact gate `runner.go` uses to decide `isIncremental`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] `golangci-lint run ./...` (not installed locally; CI will run it)
- [ ] Manual: `codecanary review` twice on this branch — second run shows "Re-evaluating N unresolved thread(s)…" and "X finding(s) resolved by code changes" when applicable
- [ ] Manual: `codecanary review --post` on this PR posts findings as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)