### PR TITLE
feat: three-mode codecanary-fix loop (pr / local-with-git / local-only)

### DIFF
--- a/.claude/skills/codecanary-fix/SKILL.md
+++ b/.claude/skills/codecanary-fix/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: codecanary-fix
 description: |
-  Drive a codecanary review → triage → fix → push feedback loop to convergence.
+  Drive a codecanary review → triage → fix feedback loop to convergence.
   Use this whenever the operator says "handle codecanary", "handle codecanary
-  reviews", or invokes /codecanary-fix. Defaults to PR mode (watches the
-  codecanary GitHub action, fetches findings, applies approved fixes, commits,
-  pushes, and re-watches). Falls back to local mode automatically when no PR
-  is detected, reviewing uncommitted changes and skipping all git plumbing.
-  Always confirms every finding with the user before applying — never
-  auto-applies. Every skipped finding gets a reply posted on its review
-  thread explaining the rationale.
+  reviews", or invokes /codecanary-fix. The CLI auto-detects one of three
+  modes: pr-loop (bot-driven; commit + push each cycle), local-loop-git
+  (PR exists but no workflow; local reviews, commit each cycle without
+  pushing, offer to push at exit), or local-loop-nogit (no PR; local
+  reviews, apply in place, no git). Always confirms every finding with
+  the operator before applying — never auto-applies. In pr-loop, every
+  skipped finding gets a reply posted on its review thread explaining
+  the rationale.
 ---
 
 # codecanary-fix
@@ -37,23 +38,39 @@ is spent on triage judgment and fix application, not on watching CI.
 
 ## Mode selection
 
-- **PR mode (default)**: fixes land as commits on the current branch and
-  are pushed. Used when an open PR exists for the branch and the operator
-  wants CodeCanary's GitHub review cycle to drive the loop.
-- **Local mode** — used when no PR exists for the branch, or when the
-  operator explicitly wants a local-only pass: `codecanary review --output
-  json` runs a review on the current dirty working tree; fixes are applied
-  but not committed or pushed. `codecanary review` is always local unless
-  `--post` is passed, so this mode works even when the branch has an open
-  PR.
+The CLI decides the mode. Before the first iteration, run
+`codecanary mode --output json` and parse the JSON. The `mode` field
+is one of three values — you never guess, you never ask the operator
+unless the CLI itself errors.
 
-If you cannot tell which mode applies, ask the operator before starting.
+- **`pr-loop`** — an open PR exists for the branch *and* a CodeCanary
+  workflow is wired up on the branch (`.github/workflows/*.yml`
+  referencing `alansikora/codecanary`). Findings come from the bot;
+  fixes commit and push each cycle, triggering the next bot run.
+- **`local-loop-git`** — an open PR exists but no CodeCanary workflow
+  is detected on the branch. Findings come from `codecanary review`
+  run locally. Fixes commit on the PR branch each cycle **without
+  pushing**; at session end the operator is asked whether to push the
+  accumulated commits.
+- **`local-loop-nogit`** — no open PR for the branch. Findings come
+  from `codecanary review` run locally. Fixes are applied in place;
+  no commits, no pushes, no prompts.
+
+Only fall back to asking the operator if `codecanary mode` errors out
+(e.g., detached HEAD, not in a git repo).
 
 ## Startup header
 
-Before the first iteration, run `codecanary --version` and extract the
-version string from its output (e.g. `codecanary version 0.6.13` →
-`0.6.13`). Then print a boxed hash-style banner to the operator.
+Before the first iteration:
+
+1. Run `codecanary --version` and extract the version string (e.g.
+   `codecanary version 0.6.13` → `0.6.13`).
+2. Run `codecanary mode --output json` and parse the result. Stash:
+   - `MODE` — one of `pr-loop`, `local-loop-git`, `local-loop-nogit`.
+   - `PR` — the PR number, or null.
+   - `WORKFLOW_DETECTED` — boolean.
+   - `REASONS` — array of human-readable detection reasons.
+3. Print a boxed hash-style banner to the operator.
 
 Concrete example — if the version is `0.6.13`, the banner must be
 exactly:
@@ -89,30 +106,56 @@ Rules for rendering:
 - Render it inside a fenced code block so the alignment survives in
   Markdown.
 
+Right after the banner, print a one-line mode summary so the operator
+can see what was detected before the loop starts. Format:
+
+```
+Mode: <mode>  —  <one-line reason>
+```
+
+Where the reason is synthesised from the `REASONS` array. Examples:
+
+- `Mode: pr-loop  —  PR #167, CodeCanary workflow detected`
+- `Mode: local-loop-git  —  PR #167, no CodeCanary workflow on this branch (fixes will commit, not push)`
+- `Mode: local-loop-nogit  —  no open PR (fixes applied in place)`
+
+If `MODE` came back as something unexpected (CLI error, empty JSON),
+surface the error and stop. Do not proceed without a valid mode.
+
 ## The loop
 
-Track one piece of state across iterations:
+Track this state across iterations:
+
 - `CYCLE` — integer, starts at 0, increments at the top of every iteration.
+- `DEFERRED_FIX_REFS` — set of strings, initially empty. Used in
+  `local-loop-git` and `local-loop-nogit` to suppress findings the
+  operator already skipped in a previous cycle (the bot's ack layer
+  isn't there to do this for us, so we do it client-side).
+- `CYCLE_COMMITS` — list of `{sha, subject}`, initially empty. Used
+  in `local-loop-git` to list commits at session end for the push
+  prompt.
 
 ### Iteration
 
 1. `CYCLE = CYCLE + 1`.
-2. Fetch findings:
-   - **PR mode**: run
-     `codecanary findings --watch --output json`.
-     The command blocks until the review check completes; its stdout is
-     a single JSON object. Parse it. Findings the bot considers handled
+2. Fetch findings, branched on `MODE`:
+   - **`pr-loop`**: run `codecanary findings --watch --output json`.
+     The command blocks until the review check completes; stdout is a
+     single JSON object. Parse it. Findings the bot considers handled
      are excluded by default — that includes GitHub-resolved threads
      *and* threads where the bot has recorded the author's deferral
      (ack:dismissed / ack:rebutted / ack:acknowledged). Skip replies
      posted by the skill in earlier cycles therefore stop re-surfacing
      once the next bot run has ack'd them, so you should never see the
      same deferred finding twice.
-   - **Local mode**: run `codecanary review --output json`. The command
-     runs the review inline; its stdout is a JSON object with a
-     `findings` array in the same shape.
-3. **PR mode only** — check the `conclusion` field in the JSON output.
-   (Skip this step entirely for local mode — there is no check run.)
+   - **`local-loop-git` / `local-loop-nogit`**: run
+     `codecanary review --output json`. The command runs the review
+     inline; stdout is a JSON object with a `findings` array in the
+     same shape. After parsing, **filter out any finding whose
+     `fix_ref` is in `DEFERRED_FIX_REFS`** — those are prior-cycle
+     skips and must not be re-surfaced.
+3. **`pr-loop` only** — check the `conclusion` field in the JSON output.
+   (Skip this step entirely for local modes — there is no check run.)
    If `conclusion` is `failure`, the review run itself broke. If
    `conclusion` is `cancelled` or `timed_out`, the run was interrupted
    (e.g. a newer push superseded it). In any of these cases — or any
@@ -123,14 +166,19 @@ Track one piece of state across iterations:
    is fine. Roll `CYCLE` back by one (`CYCLE = CYCLE - 1`) so the
    next retry starts at the correct count. Wait for the operator to
    explicitly ask you to retry before starting another cycle.
-4. If the findings list is empty (for either mode), tell the operator
-   the review is clean and exit. Do not loop further.
+
+   **Do not silently fall back to a local mode on pr-loop failures.**
+   A broken GHA is a signal the operator needs to investigate — hiding
+   it by switching to local reviews obscures real problems.
+4. If the findings list is empty (for any mode), tell the operator
+   the review is clean and proceed to the **exit handling** section
+   below. Do not loop further.
 5. If `CYCLE > 1`, emit this reminder to the operator before the
    triage table, substituting *N* with the current value of `CYCLE`:
    > This is review cycle *N*. Before applying fixes, check whether the new
    > findings are caused by your previous fixes or are genuinely different
-   > issues. If the bot keeps re-flagging the same `fix_ref` across cycles,
-   > stop and verify your fix actually addresses what the bot meant —
+   > issues. If the reviewer keeps re-flagging the same `fix_ref` across
+   > cycles, stop and verify your fix actually addresses what was meant —
    > don't keep patching symptoms.
 6. Render a triage table (Markdown) summarizing the findings:
    - Columns: severity, file:line, fix_ref, title, proposed action
@@ -149,85 +197,172 @@ Track one piece of state across iterations:
    - If the suggestion in the finding is an exact code snippet and fits
      the context, prefer it verbatim; otherwise adapt it to the codebase
      conventions (existing imports, types, error-handling style).
-9. **Post replies on every skipped finding** (PR mode only — local mode
-   has no thread to reply to). A skipped finding is any finding not
+9. Handle skipped findings. A skipped finding is any finding not
    applied this cycle — that covers both "Skip this cycle" (all
-   skipped) and "Apply some" (the unselected ones). For each skipped
-   finding, run:
+   skipped) and "Apply some" (the unselected ones). Branch on `MODE`:
 
-   ```sh
-   codecanary reply --url "<comment_url>" --body "<rationale>"
-   ```
+   - **`pr-loop`** — post replies on the review threads. For each
+     skipped finding, run:
 
-   where `<comment_url>` is the finding's `comment_url` field from the
-   findings JSON, and `<rationale>` is a concise 1–2 sentence summary
-   of *why* you're deferring this finding (your own analysis, not
-   just "operator skipped"). Examples:
-   - "Deferring: the bot's suggested rename conflicts with the public
-     API exported in `pkg/foo`. Revisit after the v2 cutover."
-   - "Skipping: the flagged line is dead code slated for removal in
-     the next PR (#154)."
-   - "Skipping: dot notation in the README is deliberate — matches
-     upstream xAI naming. Fix is to update the bot's context, not
-     the README."
+     ```sh
+     codecanary reply --url "<comment_url>" --body "<rationale>"
+     ```
 
-   Post one reply per skipped finding, sequentially. If a reply fails
-   (e.g. thread already resolved), surface the error to the operator
-   and continue with the remaining skips.
-10. Finalize the cycle:
-    - **PR mode**:
+     where `<comment_url>` is the finding's `comment_url` field from the
+     findings JSON, and `<rationale>` is a concise 1–2 sentence summary
+     of *why* you're deferring this finding (your own analysis, not
+     just "operator skipped"). Examples:
+     - "Deferring: the bot's suggested rename conflicts with the public
+       API exported in `pkg/foo`. Revisit after the v2 cutover."
+     - "Skipping: the flagged line is dead code slated for removal in
+       the next PR (#154)."
+     - "Skipping: dot notation in the README is deliberate — matches
+       upstream xAI naming. Fix is to update the bot's context, not
+       the README."
+
+     Post one reply per skipped finding, sequentially. If a reply fails
+     (e.g. thread already resolved), surface the error to the operator
+     and continue with the remaining skips.
+
+   - **`local-loop-git` / `local-loop-nogit`** — there is no review
+     thread to reply to. Instead, add each skipped finding's
+     `fix_ref` to `DEFERRED_FIX_REFS` so it is filtered out in
+     future iterations. No `codecanary reply` calls in local modes.
+10. Finalize the cycle, branched on `MODE`:
+    - **`pr-loop`**:
       - Run `go build ./...` and `go test ./...` if any Go files changed.
       - Commit with a message like:
         `fix: address codecanary review on #<PR> (cycle <N>)`
         plus a brief bullet list of which findings were addressed.
       - Push the branch.
       - Go back to step 1.
-    - **Local mode**: stop. Report the summary of applied fixes to the
-      operator. Do not commit, do not push, do not loop — a single pass
-      is the contract for local mode.
+    - **`local-loop-git`**:
+      - Run `go build ./...` and `go test ./...` if any Go files changed.
+      - Commit with a message like:
+        `fix: address codecanary review (cycle <N>) [local]`
+        plus a brief bullet list of which findings were addressed.
+      - **Do not push.** Capture the commit SHA and subject into
+        `CYCLE_COMMITS`.
+      - Go back to step 1.
+    - **`local-loop-nogit`**:
+      - Do not commit, do not push.
+      - Go back to step 1.
+
+### Exit handling
+
+When the loop terminates — findings empty, operator aborts, operator
+chose "Skip this cycle", CLI errors out — do the mode-specific exit:
+
+- **`pr-loop`**: report the outcome (clean / aborted / stopped due to
+  check failure) and stop. No push prompt (pushes already happened
+  each cycle).
+- **`local-loop-git`**: if `CYCLE_COMMITS` is non-empty, print the
+  list exactly like this:
+
+  ```
+  Committed during this session (not yet pushed):
+    <sha-short>  <subject>
+    <sha-short>  <subject>
+  ```
+
+  Then `AskUserQuestion` with:
+  - "Push these commits now"
+  - "Leave local (I'll push later)" *(Recommended)*
+  - "Show diff first"
+
+  On "Push these commits now", run `git push`. On "Show diff first",
+  run `git log --stat --oneline <base>..HEAD` where `<base>` is the
+  PR's base branch (from the CLI's JSON if available, else the git
+  default), then ask the same question again without the "Show diff
+  first" option.
+
+  If `CYCLE_COMMITS` is empty (nothing was applied), just report the
+  outcome and stop.
+- **`local-loop-nogit`**: report the outcome and the summary of
+  applied fixes. No commits to list, no prompts.
 
 ## Stopping conditions
 
 Exit the loop (and tell the operator *why*) whenever any of these hold:
 
-- **PR mode**: the findings list comes back empty and `conclusion` is
+- **`pr-loop`**: the findings list comes back empty and `conclusion` is
   healthy (`success` or `neutral`) — normal success.
-- **Local mode**: the findings list comes back empty — normal success.
-  (There is no `conclusion` field in local mode; its absence is expected.)
-- The operator chose "Skip this cycle" or "Abort". (In "Skip this cycle"
-  mode, still post the skip replies from step 9 before exiting.)
+- **`local-loop-git` / `local-loop-nogit`**: the findings list comes
+  back empty — normal success. (There is no `conclusion` field in
+  local modes; its absence is expected.)
+- The operator chose "Skip this cycle" or "Abort". For "Skip this
+  cycle" in `pr-loop`, still post the skip replies from step 9 before
+  exiting. For "Skip this cycle" in local modes, still update
+  `DEFERRED_FIX_REFS`.
 - The CLI errors out (network failure, no PR detected, timeout on
-  `--watch`). Surface the error verbatim and stop.
+  `--watch`, `codecanary mode` failed to resolve). Surface the error
+  verbatim and stop.
 - You detect you're in a stable disagreement loop: the same `fix_ref`
   values appear in two consecutive cycles after you applied fixes for
   them. This is the signal from step 5 turning into a hard stop — tell
   the operator which fix_refs keep re-emerging and ask them to review
-  whether the fix is correct before continuing.
+  whether the fix is correct before continuing. Applies to all three
+  modes — a local reviewer can re-flag a bad fix the same way the bot
+  does.
+
+Always proceed to the **exit handling** section after stopping — it
+is where the push prompt for `local-loop-git` lives.
 
 ## What not to do
 
 - Don't iterate without operator confirmation.
 - Don't auto-apply nitpicks or "obvious" fixes.
-- Don't skip a finding silently — every skip gets a `codecanary reply`
-  with the rationale (step 9). The only exception is local mode, which
-  has no review thread to reply to.
+- Don't skip a finding silently — in `pr-loop`, every skip gets a
+  `codecanary reply` with the rationale (step 9). In local modes,
+  every skip adds its `fix_ref` to `DEFERRED_FIX_REFS` so the next
+  cycle doesn't surface it again.
+- Don't guess the mode. Always read it from `codecanary mode --output json`.
+- Don't silently fall back from `pr-loop` to a local mode when the
+  GHA fails — surface the error, stop, let the operator decide.
 - Don't write your own logic to parse `<!-- codecanary:finding ... -->`
   markers — the CLI already returns structured Findings.
 - Don't `gh api` or `gh pr view` yourself — the CLI handles that
   (`codecanary findings` for reads, `codecanary reply` for thread
-  replies).
+  replies, `codecanary mode` for mode detection).
 - Don't attempt concurrent PR work. One branch at a time.
 - Don't commit to `main` or an unrelated branch; always stay on the PR's
-  feature branch.
+  feature branch. Applies to both `pr-loop` and `local-loop-git`.
 - Don't force-push. The loop only appends commits.
+- Don't push in `local-loop-git` without asking — the push prompt at
+  session end is the only authorised push.
 
-## Example operator turn
+## Example operator turns
 
 ```
 user: handle codecanary on this PR
 
-A: (invokes `codecanary findings --watch --output json`,
-            parses JSON, renders triage table, asks for confirmation,
-            applies approved fixes, runs `codecanary reply` on each
-            skipped finding with a rationale, commits, pushes, loops)
+A: (runs `codecanary mode --output json` → pr-loop,
+    prints banner + mode line, invokes
+    `codecanary findings --watch --output json`, parses JSON,
+    renders triage table, asks for confirmation, applies approved
+    fixes, runs `codecanary reply` on each skipped finding with a
+    rationale, commits, pushes, loops)
+```
+
+```
+user: handle codecanary
+
+A: (runs `codecanary mode --output json` → local-loop-nogit,
+    prints banner + mode line, invokes
+    `codecanary review --output json`, parses JSON, renders triage
+    table, asks for confirmation, applies approved fixes, tracks
+    skipped fix_refs in DEFERRED_FIX_REFS, loops. On empty findings
+    or "Abort", reports the summary and stops — no commit, no push)
+```
+
+```
+user: handle codecanary (on a branch with a PR but no GHA)
+
+A: (runs `codecanary mode --output json` → local-loop-git,
+    prints banner + mode line, invokes
+    `codecanary review --output json`, parses JSON, renders triage
+    table, asks for confirmation, applies approved fixes, commits
+    locally without pushing, tracks skipped fix_refs, loops. On
+    empty findings, prints the list of accumulated commits and asks
+    whether to push)
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ Adding a new LLM provider means: create `provider_<name>.go` and register a `Pro
 
 Abstracts environment-specific operations: loading previous findings, publishing results, saving state, resolving threads, reporting usage.
 
-**Implementations**: `GithubPlatform` (posts to PRs, reads threads via API), `LocalPlatform` (prints to terminal, persists state to `~/.codecanary/state/<branch>.json`).
+**Implementations**: `GithubPlatform` (posts to PRs, reads threads via API), `LocalPlatform` (prints to terminal, persists state to `~/.codecanary/repos/<owner>/<repo>/state/<branch>.json` — per-repo scoping keeps branch names like `main` from colliding across repos; falls back to `~/.codecanary/state/<branch>.json` when no git remote is resolvable).
 
 Routing is strict: `codecanary review --post` → `GithubPlatform`; `codecanary review` (no `--post`) → `LocalPlatform`, even when the branch has an open PR. Local is local — the branch diff (with uncommitted changes) is reviewed against the default base, previous findings come from local state, nothing is fetched from or posted to GitHub. The old `GithubPlatform`-with-`Post=false` hybrid is gone; it was the source of the "state written locally, read from GitHub" asymmetry that kept breaking incremental local reviews.
 

--- a/cmd/review/cli/mode.go
+++ b/cmd/review/cli/mode.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/alansikora/codecanary/internal/review"
+	"github.com/spf13/cobra"
+)
+
+var modeCmd = &cobra.Command{
+	Use:   "mode",
+	Short: "Detect which review loop applies to the current branch",
+	Long: `Report which review loop the codecanary-fix skill should run for the
+current branch.
+
+Three modes, resolved in order:
+
+  pr-loop            — PR open and CodeCanary workflow detected on the
+                       branch. The bot runs on every push; fixes commit
+                       and push each cycle.
+  local-loop-git     — PR open but no CodeCanary workflow detected. The
+                       loop reviews locally and commits each cycle on
+                       the PR branch without pushing; the operator is
+                       prompted to push at session end.
+  local-loop-nogit   — no PR. The loop reviews locally and applies
+                       fixes in place; no git mutations.
+
+Use --output json to get the full detection payload for automation.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		output, _ := cmd.Flags().GetString("output")
+
+		info, err := review.DetectMode()
+		if err != nil {
+			return err
+		}
+
+		switch output {
+		case "json":
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(info)
+		default:
+			return emitModeHuman(info)
+		}
+	},
+}
+
+func emitModeHuman(info *review.ModeInfo) error {
+	fmt.Printf("Mode: %s\n", info.Mode)
+	fmt.Printf("Branch: %s\n", info.Branch)
+	if info.Repo != "" {
+		fmt.Printf("Repo: %s\n", info.Repo)
+	}
+	if info.PR != nil {
+		fmt.Printf("PR: #%d\n", *info.PR)
+	} else {
+		fmt.Println("PR: (none)")
+	}
+	if info.WorkflowDetected {
+		fmt.Printf("Workflow: %s\n", info.WorkflowPath)
+	} else {
+		fmt.Println("Workflow: (none)")
+	}
+	if len(info.Reasons) > 0 {
+		fmt.Println("Reasons:")
+		for _, r := range info.Reasons {
+			fmt.Printf("  - %s\n", r)
+		}
+	}
+	return nil
+}
+
+func init() {
+	modeCmd.Flags().StringP("output", "o", "human", "Output format: human or json")
+	rootCmd.AddCommand(modeCmd)
+}

--- a/docs/review-flow.md
+++ b/docs/review-flow.md
@@ -18,9 +18,11 @@ Two platforms, routed strictly by `--post`:
 | Context | Platform | How it runs | State storage | Output |
 |---------|----------|-------------|---------------|--------|
 | **GitHub PR** | `GithubPlatform` | `codecanary review --post` (locally or in CI) | PR review threads via API | Posts review comments on the PR |
-| **Local** | `LocalPlatform` | `codecanary review` (with or without a PR for the branch) | `~/.codecanary/state/<branch>.json` | Prints to terminal |
+| **Local** | `LocalPlatform` | `codecanary review` (with or without a PR for the branch) | `~/.codecanary/repos/<owner>/<repo>/state/<branch>.json` | Prints to terminal |
 
-`codecanary review` without `--post` is always local — even if the branch has an open PR. "Local is local": the branch diff (including uncommitted changes) is reviewed against the default base, and previous findings come from `~/.codecanary/state/<branch>.json`. There is no hybrid mode that reads GitHub but writes local state. Two consecutive local runs go incremental off the saved state (locked in by `TestLocalPlatformIncrementalHandoff` in `state_test.go`).
+`codecanary review` without `--post` is always local — even if the branch has an open PR. "Local is local": the branch diff (including uncommitted changes) is reviewed against the default base, and previous findings come from the repo-scoped state file. There is no hybrid mode that reads GitHub but writes local state. Two consecutive local runs go incremental off the saved state (locked in by `TestLocalPlatformIncrementalHandoff` in `state_test.go`).
+
+State files are keyed by `owner/repo/branch` so the same branch name across different repos (e.g. `main` in repo A vs. repo B) no longer collides. When the git remote can't be resolved (detached worktree, no remote), state falls back to the legacy `~/.codecanary/state/<branch>.json` path. On first save after the upgrade, any existing legacy file is read once, migrated to the repo-scoped path, and the legacy copy is removed — transparent to the operator.
 
 ## Pipeline Steps
 
@@ -56,7 +58,7 @@ The platform adapter loads unresolved findings from the last review:
 
 **GitHub PR** (`--post`): Fetches review threads via GraphQL. Filters to CodeCanary findings only (detected by HTML marker comments). Extracts the previous review's HEAD SHA from the most recent review body — clean and all-clear reviews embed this marker too, so the baseline advances even when a push produced no findings. Returns unresolved threads, the SHA, and a count for fix_ref numbering.
 
-**Local**: Reads `~/.codecanary/state/<branch>.json`, which stores the SHA, branch name, and findings array from the previous review. Converts saved findings into `ReviewThread` shape for the triage pipeline.
+**Local**: Reads `~/.codecanary/repos/<owner>/<repo>/state/<branch>.json`, which stores the SHA, branch name, and findings array from the previous review. Falls back to `~/.codecanary/state/<branch>.json` when the repo slug can't be resolved or a pre-migration state file is present. Converts saved findings into `ReviewThread` shape for the triage pipeline.
 
 If no previous findings exist, this is a first review.
 
@@ -169,7 +171,7 @@ Per-thread ack replies for dismissed/acknowledged/rebutted resolutions are poste
 
 **GitHub PR** (`--post`): No-op. State is stored in the review threads themselves (the embedded JSON marker contains the SHA and findings).
 
-**Local**: Writes `~/.codecanary/state/<branch>.json` with the current HEAD SHA, branch name, and combined findings (still-open + new). This enables incremental reviews on the next run.
+**Local**: Writes `~/.codecanary/repos/<owner>/<repo>/state/<branch>.json` with the current HEAD SHA, branch name, and combined findings (still-open + new). If a legacy `~/.codecanary/state/<branch>.json` exists from a pre-migration run, it is removed after the new file lands. This enables incremental reviews on the next run.
 
 ### 10. Report usage
 
@@ -196,3 +198,15 @@ If telemetry is enabled (opt-in), fires an anonymous event with aggregate stats:
 **Context window fitting.** After building the prompt, the pipeline estimates token count and progressively trims file contents (largest first) then diff to fit the model's context window. This prevents API failures on large PRs.
 
 **Finding validation.** All findings are validated against the PR diff regardless of what diff the LLM prompt contained. Line proximity checks (within 20 lines of a changed line) catch hallucinated line numbers and prevent scope creep from rebase noise.
+
+## The codecanary-fix loop
+
+The `codecanary-fix` Claude skill wraps the review pipeline in a confirm-and-apply loop. The skill calls `codecanary mode --output json` once at startup; the CLI returns one of three modes based on whether an open PR exists for the current branch and whether a CodeCanary workflow file is detected under `.github/workflows/`:
+
+| Mode | PR | Workflow | Findings source | Cycle finalization |
+|---|---|---|---|---|
+| `pr-loop` | yes | yes | `codecanary findings --watch` (bot posts on push) | commit + push; bot re-runs |
+| `local-loop-git` | yes | no | `codecanary review` (local engine) | commit on PR branch, **no push**; operator is asked at session end whether to push accumulated commits |
+| `local-loop-nogit` | no | — | `codecanary review` (local engine) | no commits, no pushes; fixes applied in place |
+
+Workflow detection is a textual scan for a non-commented `uses: alansikora/codecanary...` step in any workflow file on the current branch. All three modes share the same triage UX (Markdown table, `AskUserQuestion` confirmation). The bot's ack layer (`<!-- codecanary:ack:* -->` markers) handles deferral persistence in `pr-loop`; local modes use an in-memory `DEFERRED_FIX_REFS` set in the skill so operator-skipped findings don't re-surface within a session. `pr-loop` failures (GHA broken, `conclusion: failure`) never silently fall back to a local mode — the operator is asked to investigate.

--- a/internal/review/mode.go
+++ b/internal/review/mode.go
@@ -3,6 +3,7 @@ package review
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -89,15 +90,23 @@ func DetectMode() (*ModeInfo, error) {
 }
 
 // detectCodecanaryWorkflow scans .github/workflows/*.yml and *.yaml in
-// the current working tree for a step that uses the CodeCanary action.
-// Returns the first matching file's path relative to cwd.
+// the current repository for a step that uses the CodeCanary action.
+// Returns the first matching file's path relative to the repo root.
+//
+// The scan is rooted at `git rev-parse --show-toplevel` rather than
+// the current working directory so calls from a subdirectory still
+// find workflow files correctly — running `codecanary` from
+// `repo/cmd/review/` must not silently miscategorise the mode.
+// When not in a git repo, falls back to a cwd-relative scan so the
+// detector keeps working in tests and non-git setups.
 //
 // Textual scan, not YAML parsing: the detection rule (a `uses:` line
 // referencing the action repo) is stable, and a real parse would need
 // to resolve matrix expansions and reusable workflows for no win.
 // Commented-out lines are skipped.
 func detectCodecanaryWorkflow() (string, bool) {
-	workflowsDir := filepath.Join(".github", "workflows")
+	root := gitRepoRoot()
+	workflowsDir := filepath.Join(root, ".github", "workflows")
 	entries, err := os.ReadDir(workflowsDir)
 	if err != nil {
 		return "", false
@@ -121,6 +130,19 @@ func detectCodecanaryWorkflow() (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// gitRepoRoot returns the absolute path to the current git repository's
+// root via `git rev-parse --show-toplevel`, or an empty string when
+// not inside a git repo. An empty return makes filepath.Join collapse
+// to the cwd-relative path, which is the right fallback for tests
+// that Chdir into a bare temp directory.
+func gitRepoRoot() string {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // workflowUsesCodecanary returns true if the given workflow YAML text

--- a/internal/review/mode.go
+++ b/internal/review/mode.go
@@ -1,0 +1,149 @@
+package review
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Mode identifies which review loop the codecanary-fix skill should run.
+type Mode string
+
+const (
+	// ModePRLoop — PR exists and a CodeCanary GitHub Action is wired up
+	// on the branch. The loop waits on the bot, applies approved fixes,
+	// commits + pushes, and waits again.
+	ModePRLoop Mode = "pr-loop"
+
+	// ModeLocalLoopGit — PR exists but no CodeCanary workflow is
+	// detected on the branch. The loop runs reviews locally and commits
+	// each cycle on the PR branch without pushing; the operator is
+	// prompted to push at the end of the session.
+	ModeLocalLoopGit Mode = "local-loop-git"
+
+	// ModeLocalLoopNoGit — no PR for the current branch. The loop runs
+	// reviews locally, applies fixes in place, and never touches git.
+	ModeLocalLoopNoGit Mode = "local-loop-nogit"
+)
+
+// ModeInfo is the full detection result. It serialises to the JSON
+// shape consumed by the codecanary-fix skill; field names are load-bearing.
+type ModeInfo struct {
+	Mode             Mode     `json:"mode"`
+	PR               *int     `json:"pr"`
+	Branch           string   `json:"branch"`
+	Repo             string   `json:"repo,omitempty"`
+	WorkflowDetected bool     `json:"workflow_detected"`
+	WorkflowPath     string   `json:"workflow_path,omitempty"`
+	Reasons          []string `json:"reasons"`
+}
+
+// DetectMode resolves the loop mode for the current working tree.
+//
+// It calls currentBranch(), DetectPRNumber(), DetectRepo(), and scans
+// .github/workflows/*.yml — all best-effort. A missing PR or missing
+// workflow is not an error, just a signal that pushes the decision
+// toward a local-loop mode.
+func DetectMode() (*ModeInfo, error) {
+	branch, err := currentBranch()
+	if err != nil {
+		return nil, err
+	}
+
+	info := &ModeInfo{Branch: branch}
+
+	if repo, err := DetectRepo(); err == nil {
+		info.Repo = repo
+	}
+
+	if pr, err := DetectPRNumber(""); err == nil {
+		info.PR = &pr
+		info.Reasons = append(info.Reasons,
+			fmt.Sprintf("open PR #%d on branch %s", pr, branch))
+	} else {
+		info.Reasons = append(info.Reasons,
+			fmt.Sprintf("no open PR for branch %s", branch))
+	}
+
+	if path, ok := detectCodecanaryWorkflow(); ok {
+		info.WorkflowDetected = true
+		info.WorkflowPath = path
+		info.Reasons = append(info.Reasons,
+			fmt.Sprintf("CodeCanary workflow detected at %s", path))
+	} else {
+		info.Reasons = append(info.Reasons,
+			"no CodeCanary workflow detected on this branch")
+	}
+
+	switch {
+	case info.PR != nil && info.WorkflowDetected:
+		info.Mode = ModePRLoop
+	case info.PR != nil:
+		info.Mode = ModeLocalLoopGit
+	default:
+		info.Mode = ModeLocalLoopNoGit
+	}
+
+	return info, nil
+}
+
+// detectCodecanaryWorkflow scans .github/workflows/*.yml and *.yaml in
+// the current working tree for a step that uses the CodeCanary action.
+// Returns the first matching file's path relative to cwd.
+//
+// Textual scan, not YAML parsing: the detection rule (a `uses:` line
+// referencing the action repo) is stable, and a real parse would need
+// to resolve matrix expansions and reusable workflows for no win.
+// Commented-out lines are skipped.
+func detectCodecanaryWorkflow() (string, bool) {
+	workflowsDir := filepath.Join(".github", "workflows")
+	entries, err := os.ReadDir(workflowsDir)
+	if err != nil {
+		return "", false
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".yml") && !strings.HasSuffix(name, ".yaml") {
+			continue
+		}
+		path := filepath.Join(workflowsDir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		if workflowUsesCodecanary(string(data)) {
+			return path, true
+		}
+	}
+	return "", false
+}
+
+// workflowUsesCodecanary returns true if the given workflow YAML text
+// contains a non-commented `uses:` line referencing the CodeCanary
+// action repository.
+func workflowUsesCodecanary(yaml string) bool {
+	for _, line := range strings.Split(yaml, "\n") {
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		// Strip a "- " list prefix if present, then match on "uses:".
+		trimmed = strings.TrimPrefix(trimmed, "- ")
+		trimmed = strings.TrimLeft(trimmed, " \t")
+		if !strings.HasPrefix(trimmed, "uses:") {
+			continue
+		}
+		value := strings.TrimSpace(strings.TrimPrefix(trimmed, "uses:"))
+		// Strip optional surrounding quotes.
+		value = strings.Trim(value, `"'`)
+		if strings.HasPrefix(value, "alansikora/codecanary") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/review/mode.go
+++ b/internal/review/mode.go
@@ -126,10 +126,27 @@ func detectCodecanaryWorkflow() (string, bool) {
 			continue
 		}
 		if workflowUsesCodecanary(string(data)) {
-			return path, true
+			return relToRoot(root, path), true
 		}
 	}
 	return "", false
+}
+
+// relToRoot returns path relative to root so WorkflowPath stays stable
+// in the JSON output regardless of the caller's cwd. When root is
+// empty (non-git fallback), path is already cwd-relative and returned
+// as-is. On any Rel() error, falls back to the absolute path rather
+// than returning an empty string — a visible full path is better than
+// a silently-empty one for downstream consumers.
+func relToRoot(root, path string) string {
+	if root == "" {
+		return path
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return path
+	}
+	return rel
 }
 
 // gitRepoRoot returns the absolute path to the current git repository's

--- a/internal/review/mode_test.go
+++ b/internal/review/mode_test.go
@@ -80,8 +80,13 @@ func TestDetectCodecanaryWorkflow(t *testing.T) {
 		if !ok {
 			t.Fatal("expected workflow to be detected")
 		}
-		if filepath.Base(path) != "codecanary.yml" {
-			t.Errorf("got %q, want basename codecanary.yml", path)
+		// The returned path must be repo-root-relative so JSON output
+		// stays stable regardless of caller cwd. In the non-git
+		// fallback this means cwd-relative, which equals the same
+		// relative form.
+		want := filepath.Join(".github", "workflows", "codecanary.yml")
+		if path != want {
+			t.Errorf("got %q, want %q", path, want)
 		}
 	})
 

--- a/internal/review/mode_test.go
+++ b/internal/review/mode_test.go
@@ -1,0 +1,122 @@
+package review
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWorkflowUsesCodecanary(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{
+			name: "direct match",
+			yaml: "      - uses: alansikora/codecanary@canary\n",
+			want: true,
+		},
+		{
+			name: "quoted value",
+			yaml: `      - uses: "alansikora/codecanary@v1"` + "\n",
+			want: true,
+		},
+		{
+			name: "bare uses without list dash",
+			yaml: "uses: alansikora/codecanary@main\n",
+			want: true,
+		},
+		{
+			name: "commented out",
+			yaml: "      # - uses: alansikora/codecanary@canary\n",
+			want: false,
+		},
+		{
+			name: "different action",
+			yaml: "      - uses: actions/checkout@v6\n",
+			want: false,
+		},
+		{
+			name: "empty",
+			yaml: "",
+			want: false,
+		},
+		{
+			name: "prefix mention in another context",
+			yaml: "      run: echo alansikora/codecanary\n",
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := workflowUsesCodecanary(tc.yaml)
+			if got != tc.want {
+				t.Errorf("workflowUsesCodecanary() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// writeWorkflow creates .github/workflows/<name> relative to dir.
+func writeWorkflow(t *testing.T, dir, name, body string) {
+	t.Helper()
+	path := filepath.Join(dir, ".github", "workflows", name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestDetectCodecanaryWorkflow(t *testing.T) {
+	t.Run("workflow present", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		writeWorkflow(t, dir, "codecanary.yml", "jobs:\n  review:\n    steps:\n      - uses: alansikora/codecanary@canary\n")
+
+		path, ok := detectCodecanaryWorkflow()
+		if !ok {
+			t.Fatal("expected workflow to be detected")
+		}
+		if filepath.Base(path) != "codecanary.yml" {
+			t.Errorf("got %q, want basename codecanary.yml", path)
+		}
+	})
+
+	t.Run("no workflows directory", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		if _, ok := detectCodecanaryWorkflow(); ok {
+			t.Error("expected no detection in empty dir")
+		}
+	})
+
+	t.Run("unrelated workflow only", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		writeWorkflow(t, dir, "ci.yml", "jobs:\n  build:\n    steps:\n      - uses: actions/checkout@v6\n")
+		if _, ok := detectCodecanaryWorkflow(); ok {
+			t.Error("expected no detection when only unrelated workflows present")
+		}
+	})
+
+	t.Run("yaml extension also matched", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		writeWorkflow(t, dir, "codecanary.yaml", "      - uses: alansikora/codecanary@main\n")
+		if _, ok := detectCodecanaryWorkflow(); !ok {
+			t.Error("expected .yaml extension to be detected")
+		}
+	})
+
+	t.Run("commented-out uses ignored", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		writeWorkflow(t, dir, "codecanary.yml", "      # - uses: alansikora/codecanary@canary\n")
+		if _, ok := detectCodecanaryWorkflow(); ok {
+			t.Error("expected commented-out uses to be ignored")
+		}
+	})
+}

--- a/internal/review/state.go
+++ b/internal/review/state.go
@@ -63,7 +63,7 @@ func SaveLocalState(branch string, state *LocalState) error {
 	}
 	data = append(data, '\n')
 
-	if err := os.WriteFile(preferred, data, 0o644); err != nil {
+	if err := os.WriteFile(preferred, data, 0o600); err != nil {
 		return fmt.Errorf("writing local state: %w", err)
 	}
 	if preferred != legacy {

--- a/internal/review/state.go
+++ b/internal/review/state.go
@@ -19,9 +19,18 @@ type LocalState struct {
 
 // LoadLocalState reads the state file for the given branch.
 // Returns nil, nil if no state file exists.
+//
+// If the preferred (repo-scoped) file is missing but a legacy
+// (branch-only) file exists, the legacy file is read — the next
+// SaveLocalState call will migrate it to the preferred location.
 func LoadLocalState(branch string) (*LocalState, error) {
-	path := stateFilePath(branch)
+	preferred, legacy := stateFilePaths(branch)
+
+	path := preferred
 	data, err := os.ReadFile(path)
+	if err != nil && os.IsNotExist(err) && preferred != legacy {
+		data, err = os.ReadFile(legacy)
+	}
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -36,12 +45,13 @@ func LoadLocalState(branch string) (*LocalState, error) {
 	return &state, nil
 }
 
-// SaveLocalState writes the state file for the given branch.
+// SaveLocalState writes the state file for the given branch to the
+// repo-scoped path. If a legacy (branch-only) file exists, it is
+// removed after the new file is written successfully.
 func SaveLocalState(branch string, state *LocalState) error {
-	path := stateFilePath(branch)
+	preferred, legacy := stateFilePaths(branch)
 
-	// Ensure the .codecanary/.state/ directory exists.
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(preferred), 0o755); err != nil {
 		return fmt.Errorf("creating state directory: %w", err)
 	}
 
@@ -53,22 +63,40 @@ func SaveLocalState(branch string, state *LocalState) error {
 	}
 	data = append(data, '\n')
 
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	if err := os.WriteFile(preferred, data, 0o644); err != nil {
 		return fmt.Errorf("writing local state: %w", err)
+	}
+	if preferred != legacy {
+		// Clean up any legacy file left over from before repo-scoped state
+		// landed. Best-effort: ignore errors (e.g., permissions, gone already).
+		_ = os.Remove(legacy)
 	}
 	return nil
 }
 
-// stateFilePath returns the path to ~/.codecanary/state/<sanitized-branch>.json.
-// Branch name slashes are replaced with dashes for filesystem safety.
-func stateFilePath(branch string) string {
+// stateFilePaths returns the preferred and legacy state file paths
+// for the given branch.
+//
+//	preferred: ~/.codecanary/repos/<owner>/<repo>/state/<branch>.json
+//	legacy:    ~/.codecanary/state/<branch>.json
+//
+// If the repo slug cannot be derived (no git remote), both paths
+// collapse to the legacy path — we keep working rather than erroring.
+// Branch-name slashes are replaced with dashes for filesystem safety.
+func stateFilePaths(branch string) (preferred, legacy string) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		// Best-effort fallback to repo-level path.
 		home = "."
 	}
 	safe := strings.ReplaceAll(branch, "/", "-")
-	return filepath.Join(home, ".codecanary", "state", safe+".json")
+	legacy = filepath.Join(home, ".codecanary", "state", safe+".json")
+
+	slug, err := repoSlug()
+	if err != nil {
+		return legacy, legacy
+	}
+	preferred = filepath.Join(home, ".codecanary", "repos", slug, "state", safe+".json")
+	return preferred, legacy
 }
 
 // mergeFindings appends new findings to existing ones, deduplicating by

--- a/internal/review/state_test.go
+++ b/internal/review/state_test.go
@@ -223,10 +223,12 @@ func TestStateFileRepoScoped(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
-	// Tests run inside the codecanary repo, so repoSlug() resolves.
+	// Tests run inside the codecanary repo so repoSlug() resolves; skip
+	// gracefully on CI runners that check out without a configured
+	// origin remote (shallow clones, detached HEAD) instead of failing.
 	slug, err := repoSlug()
 	if err != nil {
-		t.Fatalf("repoSlug(): %v (test must run inside a git repo with an origin remote)", err)
+		t.Skipf("repoSlug() unavailable (%v); skipping repo-scoped state test", err)
 	}
 
 	branch := "test-repo-scoped"
@@ -284,7 +286,7 @@ func TestStateFileMigration(t *testing.T) {
 
 	slug, err := repoSlug()
 	if err != nil {
-		t.Fatalf("repoSlug(): %v", err)
+		t.Skipf("repoSlug() unavailable (%v); skipping migration test", err)
 	}
 
 	branch := "test-migration"

--- a/internal/review/state_test.go
+++ b/internal/review/state_test.go
@@ -1,6 +1,8 @@
 package review
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -211,5 +213,112 @@ func TestLocalStillOpenFindingsPreserved(t *testing.T) {
 	}
 	if _, ok := lp.SavedFinding(999); ok {
 		t.Error("SavedFinding(999) should return false")
+	}
+}
+
+// TestStateFileRepoScoped verifies that state files land under
+// ~/.codecanary/repos/<owner>/<repo>/state/ when a git remote is
+// available — the fix for branch-name collisions across repos.
+func TestStateFileRepoScoped(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	// Tests run inside the codecanary repo, so repoSlug() resolves.
+	slug, err := repoSlug()
+	if err != nil {
+		t.Fatalf("repoSlug(): %v (test must run inside a git repo with an origin remote)", err)
+	}
+
+	branch := "test-repo-scoped"
+	if err := SaveLocalState(branch, &LocalState{SHA: "abc", Branch: branch}); err != nil {
+		t.Fatalf("SaveLocalState: %v", err)
+	}
+
+	want := filepath.Join(tmpHome, ".codecanary", "repos", slug, "state", branch+".json")
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("expected state file at %s: %v", want, err)
+	}
+
+	legacy := filepath.Join(tmpHome, ".codecanary", "state", branch+".json")
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Errorf("legacy path %s should not exist on a fresh save (err=%v)", legacy, err)
+	}
+
+	got, err := LoadLocalState(branch)
+	if err != nil || got == nil || got.SHA != "abc" {
+		t.Fatalf("LoadLocalState roundtrip failed: got=%+v err=%v", got, err)
+	}
+}
+
+// TestStateFileFallback verifies that state falls back to the legacy
+// ~/.codecanary/state/ path when repoSlug() fails (e.g., no git remote).
+func TestStateFileFallback(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	// Chdir into a non-git directory so repoSlug() errors out.
+	nonGit := t.TempDir()
+	t.Chdir(nonGit)
+
+	branch := "test-fallback"
+	if err := SaveLocalState(branch, &LocalState{SHA: "xyz", Branch: branch}); err != nil {
+		t.Fatalf("SaveLocalState: %v", err)
+	}
+
+	want := filepath.Join(tmpHome, ".codecanary", "state", branch+".json")
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("expected fallback state file at %s: %v", want, err)
+	}
+
+	got, err := LoadLocalState(branch)
+	if err != nil || got == nil || got.SHA != "xyz" {
+		t.Fatalf("LoadLocalState roundtrip failed: got=%+v err=%v", got, err)
+	}
+}
+
+// TestStateFileMigration verifies that a legacy state file is read on
+// load and removed after the next save writes to the repo-scoped path.
+func TestStateFileMigration(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	slug, err := repoSlug()
+	if err != nil {
+		t.Fatalf("repoSlug(): %v", err)
+	}
+
+	branch := "test-migration"
+	legacy := filepath.Join(tmpHome, ".codecanary", "state", branch+".json")
+	preferred := filepath.Join(tmpHome, ".codecanary", "repos", slug, "state", branch+".json")
+
+	// Pre-populate the legacy path directly.
+	if err := os.MkdirAll(filepath.Dir(legacy), 0o755); err != nil {
+		t.Fatalf("mkdir legacy: %v", err)
+	}
+	if err := os.WriteFile(legacy, []byte(`{"sha":"legacy-sha","branch":"test-migration","findings":[],"reviewed_at":"2026-01-01T00:00:00Z"}`), 0o644); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+
+	// Load should find the legacy file since the preferred path doesn't exist yet.
+	got, err := LoadLocalState(branch)
+	if err != nil || got == nil || got.SHA != "legacy-sha" {
+		t.Fatalf("LoadLocalState did not read legacy: got=%+v err=%v", got, err)
+	}
+
+	// Save migrates: preferred gets written, legacy gets removed.
+	if err := SaveLocalState(branch, &LocalState{SHA: "new-sha", Branch: branch}); err != nil {
+		t.Fatalf("SaveLocalState: %v", err)
+	}
+	if _, err := os.Stat(preferred); err != nil {
+		t.Fatalf("preferred path not written: %v", err)
+	}
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Errorf("legacy path should be removed after migration (err=%v)", err)
+	}
+
+	// Next load picks up the new file.
+	got, err = LoadLocalState(branch)
+	if err != nil || got == nil || got.SHA != "new-sha" {
+		t.Fatalf("LoadLocalState after migration: got=%+v err=%v", got, err)
 	}
 }

--- a/internal/skills/codecanary-fix/SKILL.md
+++ b/internal/skills/codecanary-fix/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: codecanary-fix
 description: |
-  Drive a codecanary review → triage → fix → push feedback loop to convergence.
+  Drive a codecanary review → triage → fix feedback loop to convergence.
   Use this whenever the operator says "handle codecanary", "handle codecanary
-  reviews", or invokes /codecanary-fix. Defaults to PR mode (watches the
-  codecanary GitHub action, fetches findings, applies approved fixes, commits,
-  pushes, and re-watches). Falls back to local mode automatically when no PR
-  is detected, reviewing uncommitted changes and skipping all git plumbing.
-  Always confirms every finding with the user before applying — never
-  auto-applies. Every skipped finding gets a reply posted on its review
-  thread explaining the rationale.
+  reviews", or invokes /codecanary-fix. The CLI auto-detects one of three
+  modes: pr-loop (bot-driven; commit + push each cycle), local-loop-git
+  (PR exists but no workflow; local reviews, commit each cycle without
+  pushing, offer to push at exit), or local-loop-nogit (no PR; local
+  reviews, apply in place, no git). Always confirms every finding with
+  the operator before applying — never auto-applies. In pr-loop, every
+  skipped finding gets a reply posted on its review thread explaining
+  the rationale.
 ---
 
 # codecanary-fix
@@ -37,23 +38,39 @@ is spent on triage judgment and fix application, not on watching CI.
 
 ## Mode selection
 
-- **PR mode (default)**: fixes land as commits on the current branch and
-  are pushed. Used when an open PR exists for the branch and the operator
-  wants CodeCanary's GitHub review cycle to drive the loop.
-- **Local mode** — used when no PR exists for the branch, or when the
-  operator explicitly wants a local-only pass: `codecanary review --output
-  json` runs a review on the current dirty working tree; fixes are applied
-  but not committed or pushed. `codecanary review` is always local unless
-  `--post` is passed, so this mode works even when the branch has an open
-  PR.
+The CLI decides the mode. Before the first iteration, run
+`codecanary mode --output json` and parse the JSON. The `mode` field
+is one of three values — you never guess, you never ask the operator
+unless the CLI itself errors.
 
-If you cannot tell which mode applies, ask the operator before starting.
+- **`pr-loop`** — an open PR exists for the branch *and* a CodeCanary
+  workflow is wired up on the branch (`.github/workflows/*.yml`
+  referencing `alansikora/codecanary`). Findings come from the bot;
+  fixes commit and push each cycle, triggering the next bot run.
+- **`local-loop-git`** — an open PR exists but no CodeCanary workflow
+  is detected on the branch. Findings come from `codecanary review`
+  run locally. Fixes commit on the PR branch each cycle **without
+  pushing**; at session end the operator is asked whether to push the
+  accumulated commits.
+- **`local-loop-nogit`** — no open PR for the branch. Findings come
+  from `codecanary review` run locally. Fixes are applied in place;
+  no commits, no pushes, no prompts.
+
+Only fall back to asking the operator if `codecanary mode` errors out
+(e.g., detached HEAD, not in a git repo).
 
 ## Startup header
 
-Before the first iteration, run `codecanary --version` and extract the
-version string from its output (e.g. `codecanary version 0.6.13` →
-`0.6.13`). Then print a boxed hash-style banner to the operator.
+Before the first iteration:
+
+1. Run `codecanary --version` and extract the version string (e.g.
+   `codecanary version 0.6.13` → `0.6.13`).
+2. Run `codecanary mode --output json` and parse the result. Stash:
+   - `MODE` — one of `pr-loop`, `local-loop-git`, `local-loop-nogit`.
+   - `PR` — the PR number, or null.
+   - `WORKFLOW_DETECTED` — boolean.
+   - `REASONS` — array of human-readable detection reasons.
+3. Print a boxed hash-style banner to the operator.
 
 Concrete example — if the version is `0.6.13`, the banner must be
 exactly:
@@ -89,30 +106,56 @@ Rules for rendering:
 - Render it inside a fenced code block so the alignment survives in
   Markdown.
 
+Right after the banner, print a one-line mode summary so the operator
+can see what was detected before the loop starts. Format:
+
+```
+Mode: <mode>  —  <one-line reason>
+```
+
+Where the reason is synthesised from the `REASONS` array. Examples:
+
+- `Mode: pr-loop  —  PR #167, CodeCanary workflow detected`
+- `Mode: local-loop-git  —  PR #167, no CodeCanary workflow on this branch (fixes will commit, not push)`
+- `Mode: local-loop-nogit  —  no open PR (fixes applied in place)`
+
+If `MODE` came back as something unexpected (CLI error, empty JSON),
+surface the error and stop. Do not proceed without a valid mode.
+
 ## The loop
 
-Track one piece of state across iterations:
+Track this state across iterations:
+
 - `CYCLE` — integer, starts at 0, increments at the top of every iteration.
+- `DEFERRED_FIX_REFS` — set of strings, initially empty. Used in
+  `local-loop-git` and `local-loop-nogit` to suppress findings the
+  operator already skipped in a previous cycle (the bot's ack layer
+  isn't there to do this for us, so we do it client-side).
+- `CYCLE_COMMITS` — list of `{sha, subject}`, initially empty. Used
+  in `local-loop-git` to list commits at session end for the push
+  prompt.
 
 ### Iteration
 
 1. `CYCLE = CYCLE + 1`.
-2. Fetch findings:
-   - **PR mode**: run
-     `codecanary findings --watch --output json`.
-     The command blocks until the review check completes; its stdout is
-     a single JSON object. Parse it. Findings the bot considers handled
+2. Fetch findings, branched on `MODE`:
+   - **`pr-loop`**: run `codecanary findings --watch --output json`.
+     The command blocks until the review check completes; stdout is a
+     single JSON object. Parse it. Findings the bot considers handled
      are excluded by default — that includes GitHub-resolved threads
      *and* threads where the bot has recorded the author's deferral
      (ack:dismissed / ack:rebutted / ack:acknowledged). Skip replies
      posted by the skill in earlier cycles therefore stop re-surfacing
      once the next bot run has ack'd them, so you should never see the
      same deferred finding twice.
-   - **Local mode**: run `codecanary review --output json`. The command
-     runs the review inline; its stdout is a JSON object with a
-     `findings` array in the same shape.
-3. **PR mode only** — check the `conclusion` field in the JSON output.
-   (Skip this step entirely for local mode — there is no check run.)
+   - **`local-loop-git` / `local-loop-nogit`**: run
+     `codecanary review --output json`. The command runs the review
+     inline; stdout is a JSON object with a `findings` array in the
+     same shape. After parsing, **filter out any finding whose
+     `fix_ref` is in `DEFERRED_FIX_REFS`** — those are prior-cycle
+     skips and must not be re-surfaced.
+3. **`pr-loop` only** — check the `conclusion` field in the JSON output.
+   (Skip this step entirely for local modes — there is no check run.)
    If `conclusion` is `failure`, the review run itself broke. If
    `conclusion` is `cancelled` or `timed_out`, the run was interrupted
    (e.g. a newer push superseded it). In any of these cases — or any
@@ -123,14 +166,19 @@ Track one piece of state across iterations:
    is fine. Roll `CYCLE` back by one (`CYCLE = CYCLE - 1`) so the
    next retry starts at the correct count. Wait for the operator to
    explicitly ask you to retry before starting another cycle.
-4. If the findings list is empty (for either mode), tell the operator
-   the review is clean and exit. Do not loop further.
+
+   **Do not silently fall back to a local mode on pr-loop failures.**
+   A broken GHA is a signal the operator needs to investigate — hiding
+   it by switching to local reviews obscures real problems.
+4. If the findings list is empty (for any mode), tell the operator
+   the review is clean and proceed to the **exit handling** section
+   below. Do not loop further.
 5. If `CYCLE > 1`, emit this reminder to the operator before the
    triage table, substituting *N* with the current value of `CYCLE`:
    > This is review cycle *N*. Before applying fixes, check whether the new
    > findings are caused by your previous fixes or are genuinely different
-   > issues. If the bot keeps re-flagging the same `fix_ref` across cycles,
-   > stop and verify your fix actually addresses what the bot meant —
+   > issues. If the reviewer keeps re-flagging the same `fix_ref` across
+   > cycles, stop and verify your fix actually addresses what was meant —
    > don't keep patching symptoms.
 6. Render a triage table (Markdown) summarizing the findings:
    - Columns: severity, file:line, fix_ref, title, proposed action
@@ -149,85 +197,172 @@ Track one piece of state across iterations:
    - If the suggestion in the finding is an exact code snippet and fits
      the context, prefer it verbatim; otherwise adapt it to the codebase
      conventions (existing imports, types, error-handling style).
-9. **Post replies on every skipped finding** (PR mode only — local mode
-   has no thread to reply to). A skipped finding is any finding not
+9. Handle skipped findings. A skipped finding is any finding not
    applied this cycle — that covers both "Skip this cycle" (all
-   skipped) and "Apply some" (the unselected ones). For each skipped
-   finding, run:
+   skipped) and "Apply some" (the unselected ones). Branch on `MODE`:
 
-   ```sh
-   codecanary reply --url "<comment_url>" --body "<rationale>"
-   ```
+   - **`pr-loop`** — post replies on the review threads. For each
+     skipped finding, run:
 
-   where `<comment_url>` is the finding's `comment_url` field from the
-   findings JSON, and `<rationale>` is a concise 1–2 sentence summary
-   of *why* you're deferring this finding (your own analysis, not
-   just "operator skipped"). Examples:
-   - "Deferring: the bot's suggested rename conflicts with the public
-     API exported in `pkg/foo`. Revisit after the v2 cutover."
-   - "Skipping: the flagged line is dead code slated for removal in
-     the next PR (#154)."
-   - "Skipping: dot notation in the README is deliberate — matches
-     upstream xAI naming. Fix is to update the bot's context, not
-     the README."
+     ```sh
+     codecanary reply --url "<comment_url>" --body "<rationale>"
+     ```
 
-   Post one reply per skipped finding, sequentially. If a reply fails
-   (e.g. thread already resolved), surface the error to the operator
-   and continue with the remaining skips.
-10. Finalize the cycle:
-    - **PR mode**:
+     where `<comment_url>` is the finding's `comment_url` field from the
+     findings JSON, and `<rationale>` is a concise 1–2 sentence summary
+     of *why* you're deferring this finding (your own analysis, not
+     just "operator skipped"). Examples:
+     - "Deferring: the bot's suggested rename conflicts with the public
+       API exported in `pkg/foo`. Revisit after the v2 cutover."
+     - "Skipping: the flagged line is dead code slated for removal in
+       the next PR (#154)."
+     - "Skipping: dot notation in the README is deliberate — matches
+       upstream xAI naming. Fix is to update the bot's context, not
+       the README."
+
+     Post one reply per skipped finding, sequentially. If a reply fails
+     (e.g. thread already resolved), surface the error to the operator
+     and continue with the remaining skips.
+
+   - **`local-loop-git` / `local-loop-nogit`** — there is no review
+     thread to reply to. Instead, add each skipped finding's
+     `fix_ref` to `DEFERRED_FIX_REFS` so it is filtered out in
+     future iterations. No `codecanary reply` calls in local modes.
+10. Finalize the cycle, branched on `MODE`:
+    - **`pr-loop`**:
       - Run `go build ./...` and `go test ./...` if any Go files changed.
       - Commit with a message like:
         `fix: address codecanary review on #<PR> (cycle <N>)`
         plus a brief bullet list of which findings were addressed.
       - Push the branch.
       - Go back to step 1.
-    - **Local mode**: stop. Report the summary of applied fixes to the
-      operator. Do not commit, do not push, do not loop — a single pass
-      is the contract for local mode.
+    - **`local-loop-git`**:
+      - Run `go build ./...` and `go test ./...` if any Go files changed.
+      - Commit with a message like:
+        `fix: address codecanary review (cycle <N>) [local]`
+        plus a brief bullet list of which findings were addressed.
+      - **Do not push.** Capture the commit SHA and subject into
+        `CYCLE_COMMITS`.
+      - Go back to step 1.
+    - **`local-loop-nogit`**:
+      - Do not commit, do not push.
+      - Go back to step 1.
+
+### Exit handling
+
+When the loop terminates — findings empty, operator aborts, operator
+chose "Skip this cycle", CLI errors out — do the mode-specific exit:
+
+- **`pr-loop`**: report the outcome (clean / aborted / stopped due to
+  check failure) and stop. No push prompt (pushes already happened
+  each cycle).
+- **`local-loop-git`**: if `CYCLE_COMMITS` is non-empty, print the
+  list exactly like this:
+
+  ```
+  Committed during this session (not yet pushed):
+    <sha-short>  <subject>
+    <sha-short>  <subject>
+  ```
+
+  Then `AskUserQuestion` with:
+  - "Push these commits now"
+  - "Leave local (I'll push later)" *(Recommended)*
+  - "Show diff first"
+
+  On "Push these commits now", run `git push`. On "Show diff first",
+  run `git log --stat --oneline <base>..HEAD` where `<base>` is the
+  PR's base branch (from the CLI's JSON if available, else the git
+  default), then ask the same question again without the "Show diff
+  first" option.
+
+  If `CYCLE_COMMITS` is empty (nothing was applied), just report the
+  outcome and stop.
+- **`local-loop-nogit`**: report the outcome and the summary of
+  applied fixes. No commits to list, no prompts.
 
 ## Stopping conditions
 
 Exit the loop (and tell the operator *why*) whenever any of these hold:
 
-- **PR mode**: the findings list comes back empty and `conclusion` is
+- **`pr-loop`**: the findings list comes back empty and `conclusion` is
   healthy (`success` or `neutral`) — normal success.
-- **Local mode**: the findings list comes back empty — normal success.
-  (There is no `conclusion` field in local mode; its absence is expected.)
-- The operator chose "Skip this cycle" or "Abort". (In "Skip this cycle"
-  mode, still post the skip replies from step 9 before exiting.)
+- **`local-loop-git` / `local-loop-nogit`**: the findings list comes
+  back empty — normal success. (There is no `conclusion` field in
+  local modes; its absence is expected.)
+- The operator chose "Skip this cycle" or "Abort". For "Skip this
+  cycle" in `pr-loop`, still post the skip replies from step 9 before
+  exiting. For "Skip this cycle" in local modes, still update
+  `DEFERRED_FIX_REFS`.
 - The CLI errors out (network failure, no PR detected, timeout on
-  `--watch`). Surface the error verbatim and stop.
+  `--watch`, `codecanary mode` failed to resolve). Surface the error
+  verbatim and stop.
 - You detect you're in a stable disagreement loop: the same `fix_ref`
   values appear in two consecutive cycles after you applied fixes for
   them. This is the signal from step 5 turning into a hard stop — tell
   the operator which fix_refs keep re-emerging and ask them to review
-  whether the fix is correct before continuing.
+  whether the fix is correct before continuing. Applies to all three
+  modes — a local reviewer can re-flag a bad fix the same way the bot
+  does.
+
+Always proceed to the **exit handling** section after stopping — it
+is where the push prompt for `local-loop-git` lives.
 
 ## What not to do
 
 - Don't iterate without operator confirmation.
 - Don't auto-apply nitpicks or "obvious" fixes.
-- Don't skip a finding silently — every skip gets a `codecanary reply`
-  with the rationale (step 9). The only exception is local mode, which
-  has no review thread to reply to.
+- Don't skip a finding silently — in `pr-loop`, every skip gets a
+  `codecanary reply` with the rationale (step 9). In local modes,
+  every skip adds its `fix_ref` to `DEFERRED_FIX_REFS` so the next
+  cycle doesn't surface it again.
+- Don't guess the mode. Always read it from `codecanary mode --output json`.
+- Don't silently fall back from `pr-loop` to a local mode when the
+  GHA fails — surface the error, stop, let the operator decide.
 - Don't write your own logic to parse `<!-- codecanary:finding ... -->`
   markers — the CLI already returns structured Findings.
 - Don't `gh api` or `gh pr view` yourself — the CLI handles that
   (`codecanary findings` for reads, `codecanary reply` for thread
-  replies).
+  replies, `codecanary mode` for mode detection).
 - Don't attempt concurrent PR work. One branch at a time.
 - Don't commit to `main` or an unrelated branch; always stay on the PR's
-  feature branch.
+  feature branch. Applies to both `pr-loop` and `local-loop-git`.
 - Don't force-push. The loop only appends commits.
+- Don't push in `local-loop-git` without asking — the push prompt at
+  session end is the only authorised push.
 
-## Example operator turn
+## Example operator turns
 
 ```
 user: handle codecanary on this PR
 
-A: (invokes `codecanary findings --watch --output json`,
-            parses JSON, renders triage table, asks for confirmation,
-            applies approved fixes, runs `codecanary reply` on each
-            skipped finding with a rationale, commits, pushes, loops)
+A: (runs `codecanary mode --output json` → pr-loop,
+    prints banner + mode line, invokes
+    `codecanary findings --watch --output json`, parses JSON,
+    renders triage table, asks for confirmation, applies approved
+    fixes, runs `codecanary reply` on each skipped finding with a
+    rationale, commits, pushes, loops)
+```
+
+```
+user: handle codecanary
+
+A: (runs `codecanary mode --output json` → local-loop-nogit,
+    prints banner + mode line, invokes
+    `codecanary review --output json`, parses JSON, renders triage
+    table, asks for confirmation, applies approved fixes, tracks
+    skipped fix_refs in DEFERRED_FIX_REFS, loops. On empty findings
+    or "Abort", reports the summary and stops — no commit, no push)
+```
+
+```
+user: handle codecanary (on a branch with a PR but no GHA)
+
+A: (runs `codecanary mode --output json` → local-loop-git,
+    prints banner + mode line, invokes
+    `codecanary review --output json`, parses JSON, renders triage
+    table, asks for confirmation, applies approved fixes, commits
+    locally without pushing, tracks skipped fix_refs, loops. On
+    empty findings, prints the list of accumulated commits and asks
+    whether to push)
 ```


### PR DESCRIPTION
## Summary

- New `codecanary mode` subcommand detects which loop applies to the current branch, returning one of three values: `pr-loop`, `local-loop-git`, `local-loop-nogit`. The `codecanary-fix` skill now calls it at startup and branches the loop accordingly instead of guessing from PR presence alone.
- Local state is now repo-scoped (`~/.codecanary/repos/<owner>/<repo>/state/<branch>.json`) so branches like `main` across repos no longer collide. Legacy files are migrated on first save.
- The skill's local mode is no longer single-pass: `local-loop-nogit` loops until findings are empty, and `local-loop-git` commits each cycle on the PR branch without pushing — the operator is asked once at session end whether to push the accumulated commits.

## How modes resolve

| PR open? | CodeCanary workflow on branch? | Mode |
|---|---|---|
| yes | yes | `pr-loop` (bot-driven; commit + push each cycle — unchanged) |
| yes | no  | `local-loop-git` (local reviews; commit each cycle without pushing; prompt to push at exit) |
| no  | —   | `local-loop-nogit` (local reviews; apply in place; no git) |

Workflow detection is a textual scan for a non-commented `uses: alansikora/codecanary...` step in any `.github/workflows/*.{yml,yaml}` file on the branch.

## Why local modes don't re-surface skipped findings

The bot's `<!-- codecanary:ack:* -->` markers keep `pr-loop` clean automatically. Local modes have no thread to attach an ack to, so the skill keeps an in-memory `DEFERRED_FIX_REFS` set across cycles and filters the review output client-side before triage.

`pr-loop` failures (broken GHA, `conclusion: failure`) never silently fall back to a local mode — the operator is told and the loop stops.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` all green.
- [x] New state tests: repo-scoped path, no-remote fallback, legacy-to-scoped migration (+ removal of legacy after save).
- [x] New mode tests: `uses:` parser (direct/quoted/bare/commented/unrelated/empty/non-uses prefix match) and filesystem detector (present / missing dir / unrelated workflow only / .yaml extension / commented-out).
- [x] Smoke-tested `codecanary mode` on this repo: correctly returns `local-loop-nogit` on `main` (no PR) despite the workflow file being present.
- [x] Ran /codecanary-fix on this PR to convergence — cycle 1 surfaced 3 warnings (0o600 perms, cwd-dependent workflow scan, brittle test guard), cycle 2 caught a regression (absolute WorkflowPath), cycle 3 clean.
- [ ] Cross-check that existing local state in `~/.codecanary/state/<branch>.json` gets migrated transparently on the next `codecanary review` run.