### PR TITLE
feat: offer skill refresh during codecanary upgrade

### DIFF
--- a/cmd/review/cli/install_skill.go
+++ b/cmd/review/cli/install_skill.go
@@ -203,6 +203,10 @@ func runPostUpgradeSkillCheck() error {
 		return nil
 	}
 
+	if mkErr := os.MkdirAll(filepath.Dir(destPath), 0o755); mkErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not create skill directory: %v\n", mkErr)
+		return nil
+	}
 	if writeErr := os.WriteFile(destPath, []byte(skills.CodecanaryFix()), 0o644); writeErr != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not upgrade skill: %v\n", writeErr)
 		return nil

--- a/cmd/review/cli/install_skill.go
+++ b/cmd/review/cli/install_skill.go
@@ -6,7 +6,9 @@ import (
 	"path/filepath"
 
 	"github.com/alansikora/codecanary/internal/skills"
+	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var installSkillCmd = &cobra.Command{
@@ -30,6 +32,14 @@ this cleanup since the caller is driving placement themselves.
 The skill content is embedded in the codecanary binary; re-run this
 command after upgrading codecanary to pick up any updates.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		postUpgrade, err := cmd.Flags().GetBool("post-upgrade")
+		if err != nil {
+			return fmt.Errorf("flag --post-upgrade: %w", err)
+		}
+		if postUpgrade {
+			return runPostUpgradeSkillCheck()
+		}
+
 		destFlag, err := cmd.Flags().GetString("dest")
 		if err != nil {
 			return fmt.Errorf("flag --dest: %w", err)
@@ -134,6 +144,74 @@ func removeLegacyLoopSkill() {
 	}
 }
 
+// skillNeedsUpgrade reports whether the codecanary-fix skill is installed
+// at the default user-scoped path and whether its content differs from
+// the copy embedded in this binary. destPath is returned regardless so
+// callers can surface it in error messages or prompts.
+func skillNeedsUpgrade() (installed bool, differs bool, destPath string, err error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false, false, "", err
+	}
+	destPath = filepath.Join(home, ".claude", "skills", "codecanary-fix", "SKILL.md")
+
+	existing, err := os.ReadFile(destPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, false, destPath, nil
+		}
+		return false, false, destPath, err
+	}
+	return true, string(existing) != skills.CodecanaryFix(), destPath, nil
+}
+
+// runPostUpgradeSkillCheck is invoked by `codecanary upgrade` after the
+// binary has been swapped. It detects drift between the freshly embedded
+// skill and the on-disk copy, asks the operator whether to overwrite,
+// and writes the new content on confirmation. Always exits with nil:
+// this is a best-effort convenience and must never mask an otherwise
+// successful upgrade.
+func runPostUpgradeSkillCheck() error {
+	installed, differs, destPath, err := skillNeedsUpgrade()
+	if err != nil || !installed || !differs {
+		return nil
+	}
+
+	// Non-interactive upgrades (CI, remote shells piping input) shouldn't
+	// hang on a prompt — surface the hint and let the operator run the
+	// explicit command when they can answer it.
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintf(os.Stderr,
+			"The codecanary-fix skill has changed. Run `codecanary install-skill --force` to upgrade %s.\n",
+			destPath)
+		return nil
+	}
+
+	var confirm bool
+	if formErr := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title("The codecanary-fix skill has been updated in this release.").
+				Description(fmt.Sprintf("Upgrade the installed copy at %s?", destPath)).
+				Value(&confirm),
+		),
+	).Run(); formErr != nil {
+		return nil
+	}
+	if !confirm {
+		return nil
+	}
+
+	if writeErr := os.WriteFile(destPath, []byte(skills.CodecanaryFix()), 0o644); writeErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not upgrade skill: %v\n", writeErr)
+		return nil
+	}
+	fmt.Fprintf(os.Stderr, "✓ upgraded codecanary-fix skill at %s\n", destPath)
+	fmt.Fprintln(os.Stderr, "  Restart Claude Code to pick it up.")
+	return nil
+}
+
 func init() {
 	installSkillCmd.Flags().String("dest", "",
 		"Destination file path (default: ~/.claude/skills/codecanary-fix/SKILL.md)")
@@ -141,5 +219,8 @@ func init() {
 		"Print the skill content to stdout instead of writing to disk")
 	installSkillCmd.Flags().Bool("force", false,
 		"Overwrite the destination file if it already exists")
+	installSkillCmd.Flags().Bool("post-upgrade", false,
+		"Internal: called by `codecanary upgrade` to prompt for a skill refresh when it has drifted")
+	_ = installSkillCmd.Flags().MarkHidden("post-upgrade")
 	rootCmd.AddCommand(installSkillCmd)
 }

--- a/cmd/review/cli/install_skill_test.go
+++ b/cmd/review/cli/install_skill_test.go
@@ -4,7 +4,76 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/alansikora/codecanary/internal/skills"
 )
+
+// TestSkillNeedsUpgrade covers the drift-detection helper that powers
+// the post-upgrade skill refresh prompt. We exercise the three states
+// callers have to distinguish (not installed / in sync / drifted) and
+// sandbox HOME so the check runs against a temp dir.
+func TestSkillNeedsUpgrade(t *testing.T) {
+	t.Run("not installed — installed=false", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		installed, differs, _, err := skillNeedsUpgrade()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if installed || differs {
+			t.Fatalf("expected installed=false, differs=false; got installed=%v differs=%v",
+				installed, differs)
+		}
+	})
+
+	t.Run("in sync — differs=false", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		dest := filepath.Join(home, ".claude", "skills", "codecanary-fix", "SKILL.md")
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			t.Fatalf("seeding dir: %v", err)
+		}
+		if err := os.WriteFile(dest, []byte(skills.CodecanaryFix()), 0o644); err != nil {
+			t.Fatalf("seeding SKILL.md: %v", err)
+		}
+
+		installed, differs, got, err := skillNeedsUpgrade()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !installed || differs {
+			t.Fatalf("expected installed=true, differs=false; got installed=%v differs=%v",
+				installed, differs)
+		}
+		if got != dest {
+			t.Fatalf("destPath = %q, want %q", got, dest)
+		}
+	})
+
+	t.Run("drifted — differs=true", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		dest := filepath.Join(home, ".claude", "skills", "codecanary-fix", "SKILL.md")
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			t.Fatalf("seeding dir: %v", err)
+		}
+		if err := os.WriteFile(dest, []byte("older skill content"), 0o644); err != nil {
+			t.Fatalf("seeding SKILL.md: %v", err)
+		}
+
+		installed, differs, _, err := skillNeedsUpgrade()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !installed || !differs {
+			t.Fatalf("expected installed=true, differs=true; got installed=%v differs=%v",
+				installed, differs)
+		}
+	})
+}
 
 // TestRemoveLegacyLoopSkill exercises the migration cleanup that runs on
 // every default `install-skill` — users who installed before the

--- a/cmd/review/cli/upgrade.go
+++ b/cmd/review/cli/upgrade.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 
 	"github.com/alansikora/codecanary/internal/selfupdate"
 	"github.com/spf13/cobra"
@@ -23,8 +25,36 @@ var upgradeCmd = &cobra.Command{
 		if err := selfupdate.Upgrade(cmd.Context(), Version, tag, os.Stderr); err != nil {
 			return fmt.Errorf("upgrade failed: %w", err)
 		}
+
+		// Binary has been swapped in place — re-exec it so the new
+		// embedded skill is the one we compare against disk. The
+		// currently-running process still holds the old skill bytes.
+		// Best-effort: any failure here is logged but never fails the
+		// upgrade, since the upgrade itself already succeeded.
+		offerSkillRefresh()
 		return nil
 	},
+}
+
+// offerSkillRefresh re-execs the newly installed binary with the hidden
+// `install-skill --post-upgrade` flag, which compares the embedded skill
+// to the installed copy and prompts the operator when they diverge.
+// Only reachable after a successful selfupdate.Upgrade — if we can't
+// resolve the binary path or the subprocess errors, we swallow the
+// failure rather than poisoning the upgrade's exit status.
+func offerSkillRefresh() {
+	execPath, err := os.Executable()
+	if err != nil {
+		return
+	}
+	if resolved, err := filepath.EvalSymlinks(execPath); err == nil {
+		execPath = resolved
+	}
+	refresh := exec.Command(execPath, "install-skill", "--post-upgrade")
+	refresh.Stdin = os.Stdin
+	refresh.Stdout = os.Stdout
+	refresh.Stderr = os.Stderr
+	_ = refresh.Run()
 }
 
 func init() {

--- a/cmd/review/cli/upgrade.go
+++ b/cmd/review/cli/upgrade.go
@@ -54,7 +54,9 @@ func offerSkillRefresh() {
 	refresh.Stdin = os.Stdin
 	refresh.Stdout = os.Stdout
 	refresh.Stderr = os.Stderr
-	_ = refresh.Run()
+	if err := refresh.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "note: skill refresh subprocess exited with error: %v\n", err)
+	}
 }
 
 func init() {


### PR DESCRIPTION
## Summary
- After a successful `codecanary upgrade`, re-exec the swapped-in binary with a hidden `install-skill --post-upgrade` flag so the drift check uses the *new* embedded skill (the running process still holds the old bytes).
- The post-upgrade check compares the embedded skill to `~/.claude/skills/codecanary-fix/SKILL.md` and prompts once via `huh.NewConfirm` to overwrite when they differ; silent no-op when not installed or already current; prints a hint instead of hanging when stdin isn't a terminal.
- Adds `skillNeedsUpgrade()` helper with unit tests for the three states (not installed / in sync / drifted).

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./cmd/review`
- [ ] Manual: install a stale SKILL.md at `~/.claude/skills/codecanary-fix/SKILL.md`, run `codecanary upgrade`, confirm the prompt appears and overwrites on "Yes"
- [ ] Manual: with no SKILL.md installed, run `codecanary upgrade` and confirm no prompt
- [ ] Manual: pipe `codecanary upgrade </dev/null` and confirm it prints the hint instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)