### PR TITLE
feat: add codecanary signoff command for GitHub commit status

### DIFF
--- a/cmd/review/cli/signoff.go
+++ b/cmd/review/cli/signoff.go
@@ -64,7 +64,10 @@ block merges until a clean local review exists for the tip commit.`,
 				return fmt.Errorf("checking working tree: %w", err)
 			}
 			if dirty {
-				return errors.New("working tree has uncommitted changes — commit or stash before signing off (or pass --force)")
+				return errors.New(
+					"working tree has uncommitted changes — commit them, " +
+						"run 'git stash --include-untracked' (plain 'git stash' leaves untracked files behind), " +
+						"or pass --force if you know the dirty files are unrelated to the PR")
 			}
 		}
 

--- a/cmd/review/cli/signoff.go
+++ b/cmd/review/cli/signoff.go
@@ -101,7 +101,7 @@ block merges until a clean local review exists for the tip commit.`,
 				err, strings.TrimSpace(string(out)))
 		}
 
-		fmt.Fprintf(cmd.OutOrStdout(),
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 			"✓ codecanary/review = %s on %s@%s (%s)\n",
 			statusState, slug, shortSHA(sha), desc)
 		return nil

--- a/cmd/review/cli/signoff.go
+++ b/cmd/review/cli/signoff.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/alansikora/codecanary/internal/review"
+	"github.com/spf13/cobra"
+)
+
+// signoffCmd posts a GitHub commit status on the current HEAD based on the
+// most recent local review for the current branch. Inspired by Rails 8.1's
+// `gh signoff` (Basecamp): combined with a required status check in branch
+// protection, this lets a team gate merges on "a human actually ran
+// codecanary locally and it came back clean", without paying for a cloud
+// review on every push.
+var signoffCmd = &cobra.Command{
+	Use:   "signoff",
+	Short: "Post a GitHub commit status from the last local review",
+	Long: `Post a GitHub commit status on HEAD reflecting the most recent local
+codecanary review for the current branch.
+
+Requires:
+  - you ran 'codecanary review' on this branch
+  - the working tree is clean and HEAD matches the reviewed SHA
+  - 'gh' is installed and authenticated with repo:status scope
+
+Combine with a required 'codecanary/review' check in branch protection to
+block merges until a clean local review exists for the tip commit.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		force, _ := cmd.Flags().GetBool("force")
+
+		slug, err := review.RepoSlug()
+		if err != nil {
+			return err
+		}
+		branch, err := review.CurrentBranch()
+		if err != nil {
+			return err
+		}
+		sha, err := review.HeadSHA()
+		if err != nil {
+			return err
+		}
+
+		state, err := review.LoadLocalState(branch)
+		if err != nil {
+			return fmt.Errorf("loading local state: %w", err)
+		}
+		if state == nil {
+			return fmt.Errorf("no local review found for branch %q — run 'codecanary review' first", branch)
+		}
+
+		if !force {
+			if state.SHA != sha {
+				return fmt.Errorf(
+					"local review was for %s but HEAD is %s — re-run 'codecanary review' (or pass --force)",
+					shortSHA(state.SHA), shortSHA(sha))
+			}
+			dirty, err := review.WorkingTreeDirty()
+			if err != nil {
+				return fmt.Errorf("checking working tree: %w", err)
+			}
+			if dirty {
+				return errors.New("working tree has uncommitted changes — commit or stash before signing off (or pass --force)")
+			}
+		}
+
+		unresolved := 0
+		for _, f := range state.Findings {
+			if f.Actionable != nil && !*f.Actionable {
+				continue
+			}
+			unresolved++
+		}
+
+		statusState, desc := "success", "0 findings"
+		if unresolved > 0 {
+			statusState = "failure"
+			suffix := "s"
+			if unresolved == 1 {
+				suffix = ""
+			}
+			desc = fmt.Sprintf("%d unresolved finding%s", unresolved, suffix)
+		}
+
+		apiPath := fmt.Sprintf("repos/%s/statuses/%s", slug, sha)
+		c := exec.Command("gh", "api", "-X", "POST", apiPath,
+			"-f", "context=codecanary/review",
+			"-f", "state="+statusState,
+			"-f", "description="+desc,
+		)
+		out, err := c.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("posting commit status via gh api: %w\n%s",
+				err, strings.TrimSpace(string(out)))
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"✓ codecanary/review = %s on %s@%s (%s)\n",
+			statusState, slug, shortSHA(sha), desc)
+		return nil
+	},
+}
+
+func init() {
+	signoffCmd.Flags().Bool("force", false,
+		"Sign off even if HEAD doesn't match the reviewed SHA or the tree is dirty")
+	rootCmd.AddCommand(signoffCmd)
+}

--- a/internal/review/config.go
+++ b/internal/review/config.go
@@ -265,15 +265,19 @@ var claudeReservedArgs = map[string]bool{
 // safeSlugSegment matches valid owner/repo name characters (GitHub-compatible).
 var safeSlugSegment = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$`)
 
-// repoSlug returns "owner/repo" derived from the git remote origin URL
+// RepoSlug returns "owner/repo" derived from the git remote origin URL
 // of the current working directory. Supports HTTPS, SSH, and SCP-style URLs.
-func repoSlug() (string, error) {
+func RepoSlug() (string, error) {
 	out, err := exec.Command("git", "remote", "get-url", "origin").Output()
 	if err != nil {
 		return "", fmt.Errorf("could not detect git remote: %w (are you in a git repo with an origin remote?)", err)
 	}
-	url := strings.TrimSpace(string(out))
+	return parseRepoSlugURL(strings.TrimSpace(string(out)))
+}
 
+// parseRepoSlugURL extracts "owner/repo" from a git remote URL. Split out
+// from RepoSlug so it's unit-testable without needing a real git repo.
+func parseRepoSlugURL(url string) (string, error) {
 	// SCP-style (no ://): git@github.com:owner/repo.git
 	if !strings.Contains(url, "://") {
 		if i := strings.Index(url, ":"); i >= 0 {
@@ -307,7 +311,7 @@ func LocalConfigPath() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("could not determine home directory: %w", err)
 	}
-	slug, err := repoSlug()
+	slug, err := RepoSlug()
 	if err != nil {
 		return "", err
 	}

--- a/internal/review/config_test.go
+++ b/internal/review/config_test.go
@@ -626,3 +626,39 @@ func TestFilterRulesNoFilesReturnsAll(t *testing.T) {
 		t.Errorf("FilterRules(_, nil) dropped rules: got %v, want input unchanged", got)
 	}
 }
+
+func TestParseRepoSlugURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		url     string
+		want    string
+		wantErr bool
+	}{
+		{"https", "https://github.com/alansikora/codecanary.git", "alansikora/codecanary", false},
+		{"https no .git", "https://github.com/alansikora/codecanary", "alansikora/codecanary", false},
+		{"ssh scheme", "ssh://git@github.com/alansikora/codecanary.git", "alansikora/codecanary", false},
+		{"scp style", "git@github.com:alansikora/codecanary.git", "alansikora/codecanary", false},
+		{"dashes and dots", "git@github.com:acme-corp/my.repo.git", "acme-corp/my.repo", false},
+		{"https with port", "https://git.example.com:8443/foo/bar.git", "foo/bar", false},
+		{"missing repo", "git@github.com:alansikora", "", true},
+		{"empty owner", "https://github.com//codecanary.git", "", true},
+		{"unsafe chars", "git@github.com:foo/bar$bad.git", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseRepoSlugURL(tc.url)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseRepoSlugURL(%q) = %q, want error", tc.url, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseRepoSlugURL(%q) unexpected error: %v", tc.url, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseRepoSlugURL(%q) = %q, want %q", tc.url, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/review/local.go
+++ b/internal/review/local.go
@@ -19,7 +19,7 @@ func FetchLocalDiff(baseBranch string) (*PRData, error) {
 		}
 	}
 
-	head, err := currentBranch()
+	head, err := CurrentBranch()
 	if err != nil {
 		return nil, fmt.Errorf("detecting current branch: %w", err)
 	}
@@ -107,8 +107,8 @@ func detectDefaultBranch() string {
 	return ""
 }
 
-// currentBranch returns the name of the current git branch.
-func currentBranch() (string, error) {
+// CurrentBranch returns the name of the current git branch.
+func CurrentBranch() (string, error) {
 	out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
 	if err != nil {
 		return "", err
@@ -118,4 +118,23 @@ func currentBranch() (string, error) {
 		return "", fmt.Errorf("detached HEAD state — check out a branch to review")
 	}
 	return branch, nil
+}
+
+// HeadSHA returns the full 40-character SHA of the current HEAD commit.
+func HeadSHA() (string, error) {
+	out, err := exec.Command("git", "rev-parse", "HEAD").Output()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse HEAD failed: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// WorkingTreeDirty reports whether the working tree has uncommitted
+// changes (staged, unstaged, or untracked).
+func WorkingTreeDirty() (bool, error) {
+	out, err := exec.Command("git", "status", "--porcelain").Output()
+	if err != nil {
+		return false, fmt.Errorf("git status failed: %w", err)
+	}
+	return len(strings.TrimSpace(string(out))) > 0, nil
 }

--- a/internal/review/mode.go
+++ b/internal/review/mode.go
@@ -42,12 +42,12 @@ type ModeInfo struct {
 
 // DetectMode resolves the loop mode for the current working tree.
 //
-// It calls currentBranch(), DetectPRNumber(), DetectRepo(), and scans
+// It calls CurrentBranch(), DetectPRNumber(), DetectRepo(), and scans
 // .github/workflows/*.yml — all best-effort. A missing PR or missing
 // workflow is not an error, just a signal that pushes the decision
 // toward a local-loop mode.
 func DetectMode() (*ModeInfo, error) {
-	branch, err := currentBranch()
+	branch, err := CurrentBranch()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/review/state.go
+++ b/internal/review/state.go
@@ -91,7 +91,7 @@ func stateFilePaths(branch string) (preferred, legacy string) {
 	safe := strings.ReplaceAll(branch, "/", "-")
 	legacy = filepath.Join(home, ".codecanary", "state", safe+".json")
 
-	slug, err := repoSlug()
+	slug, err := RepoSlug()
 	if err != nil {
 		return legacy, legacy
 	}

--- a/internal/review/state_test.go
+++ b/internal/review/state_test.go
@@ -223,12 +223,12 @@ func TestStateFileRepoScoped(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
-	// Tests run inside the codecanary repo so repoSlug() resolves; skip
+	// Tests run inside the codecanary repo so RepoSlug() resolves; skip
 	// gracefully on CI runners that check out without a configured
 	// origin remote (shallow clones, detached HEAD) instead of failing.
-	slug, err := repoSlug()
+	slug, err := RepoSlug()
 	if err != nil {
-		t.Skipf("repoSlug() unavailable (%v); skipping repo-scoped state test", err)
+		t.Skipf("RepoSlug() unavailable (%v); skipping repo-scoped state test", err)
 	}
 
 	branch := "test-repo-scoped"
@@ -253,12 +253,12 @@ func TestStateFileRepoScoped(t *testing.T) {
 }
 
 // TestStateFileFallback verifies that state falls back to the legacy
-// ~/.codecanary/state/ path when repoSlug() fails (e.g., no git remote).
+// ~/.codecanary/state/ path when RepoSlug() fails (e.g., no git remote).
 func TestStateFileFallback(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
-	// Chdir into a non-git directory so repoSlug() errors out.
+	// Chdir into a non-git directory so RepoSlug() errors out.
 	nonGit := t.TempDir()
 	t.Chdir(nonGit)
 
@@ -284,9 +284,9 @@ func TestStateFileMigration(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
-	slug, err := repoSlug()
+	slug, err := RepoSlug()
 	if err != nil {
-		t.Skipf("repoSlug() unavailable (%v); skipping migration test", err)
+		t.Skipf("RepoSlug() unavailable (%v); skipping migration test", err)
 	}
 
 	branch := "test-migration"


### PR DESCRIPTION
## Summary
- New `codecanary signoff` subcommand posts a `codecanary/review` commit status on HEAD via `gh api`, based on the last local review's state file. Inspired by Rails 8.1 + Basecamp's `gh signoff`.
- Refuses to sign off unless HEAD matches the reviewed SHA and the working tree is clean (use `--force` to override) — so the status can't attest to a tree that isn't the commit.
- Exports `RepoSlug` / `CurrentBranch`, adds `HeadSHA` / `WorkingTreeDirty`, and factors the remote-URL parser into `parseRepoSlugURL` for unit testing.

## Usage
```
# after a clean local review
codecanary review
codecanary signoff
# → ✓ codecanary/review = success on owner/repo@abc1234 (0 findings)
```

Add `codecanary/review` as a required status check in branch protection to gate merges on a local review.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (new `TestParseRepoSlugURL` covers HTTPS/SSH/SCP/.git/ports/rejection cases)
- [x] `codecanary signoff --help` renders
- [x] No local state → error points to running `codecanary review` first
- [ ] End-to-end: run review, commit, `codecanary signoff` → green status visible on a real PR
- [ ] Dirty tree / stale SHA correctly blocks without `--force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)