### PR TITLE
feat: auto-post codecanary/review commit status after bot reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,34 @@ This runs the same provider and key selection, then:
 
 Once merged, CodeCanary reviews every PR on open and push. Draft PRs are skipped by default.
 
+### Gating merges on clean reviews
+
+CodeCanary can block merges until a review comes back clean. After every review, the bot (and the local `codecanary signoff` command) posts a GitHub commit status under the context `codecanary/review`:
+
+- `success` — no unresolved findings (everything is either unraised, fixed by code, or handled by the author)
+- `failure` — one or more findings remain unresolved, with a description like `"3 unresolved findings"`
+
+To turn this into a required check:
+
+1. Make sure a review has run at least once on any PR so `codecanary/review` appears in the status-check picker.
+2. In your repo: **Settings → Branches → Branch protection rules → Edit your rule for `main`**.
+3. Enable **Require status checks to pass before merging**.
+4. Add `codecanary/review` to the required list.
+
+Statuses are keyed by commit SHA, so staling is automatic: a new push has no status until the next review run posts one, which re-blocks the merge button.
+
+**Without a workflow.** If your repo doesn't use the GitHub Action, `codecanary signoff` posts the same status from your local machine after a clean `codecanary review`:
+
+```sh
+codecanary review     # reviews locally, stores findings in ~/.codecanary/...
+# fix anything that came up, commit
+codecanary signoff    # posts codecanary/review = success on HEAD
+```
+
+The command refuses to sign off unless HEAD matches the reviewed SHA and the tree is clean — this prevents attesting a review of code that isn't actually in the commit. It needs `gh` authenticated with `repo:status` scope (default `gh auth login` covers it).
+
+Same required-check config works for both paths: the bot satisfies the check on PRs that run the workflow; `codecanary signoff` satisfies it for repos without the workflow, branches where the workflow doesn't run, or PRs from forks where secrets are unavailable.
+
 ## CLI Reference
 
 | Command | Description |
@@ -86,6 +114,7 @@ Once merged, CodeCanary reviews every PR on open and push. Draft PRs are skipped
 | `codecanary review [pr-number]` | Review a PR or local diff |
 | `codecanary findings [pr-number]` | Fetch bot findings for a PR (markdown or JSON) |
 | `codecanary reply --url <URL> --body <text>` | Post a reply on a review-comment thread (used by the skill when skipping) |
+| `codecanary signoff` | Post a `codecanary/review` commit status from the last local review (see [gating merges](#gating-merges-on-clean-reviews)) |
 | `codecanary install-skill` | Install the `codecanary-fix` Claude Code skill |
 | `codecanary setup [local\|github]` | Interactive setup wizard |
 | `codecanary auth status` | Show stored credential info |

--- a/README.md
+++ b/README.md
@@ -88,10 +88,9 @@ CodeCanary can block merges until a review comes back clean. After every review,
 
 To turn this into a required check:
 
-1. Make sure a review has run at least once on any PR so `codecanary/review` appears in the status-check picker.
-2. In your repo: **Settings → Branches → Branch protection rules → Edit your rule for `main`**.
-3. Enable **Require status checks to pass before merging**.
-4. Add `codecanary/review` to the required list.
+1. In your repo: **Settings → Branches → Branch protection rules → Edit your rule for `main`**.
+2. Enable **Require status checks to pass before merging**.
+3. Type `codecanary/review` into the status-check search box and add it to the required list. (GitHub accepts any context name; if you've already run a review, it will also show up in the autocomplete.)
 
 Statuses are keyed by commit SHA, so staling is automatic: a new push has no status until the next review run posts one, which re-blocks the merge button.
 

--- a/README.md
+++ b/README.md
@@ -86,11 +86,7 @@ CodeCanary can block merges until a review comes back clean. After every review,
 - `success` — no unresolved findings (everything is either unraised, fixed by code, or handled by the author)
 - `failure` — one or more findings remain unresolved, with a description like `"3 unresolved findings"`
 
-To turn this into a required check:
-
-1. In your repo: **Settings → Branches → Branch protection rules → Edit your rule for `main`**.
-2. Enable **Require status checks to pass before merging**.
-3. Type `codecanary/review` into the status-check search box and add it to the required list. (GitHub accepts any context name; if you've already run a review, it will also show up in the autocomplete.)
+To turn this into a required check, add `codecanary/review` to your repo's required status checks via whichever branch protection mechanism you use (rulesets, classic branch protection rules, etc.). GitHub accepts any context name; if a review has already run, it will also show up in autocomplete.
 
 Statuses are keyed by commit SHA, so staling is automatic: a new push has no status until the next review run posts one, which re-blocks the merge button.
 

--- a/cmd/review/cli/signoff.go
+++ b/cmd/review/cli/signoff.go
@@ -3,8 +3,6 @@ package cli
 import (
 	"errors"
 	"fmt"
-	"os/exec"
-	"strings"
 
 	"github.com/alansikora/codecanary/internal/review"
 	"github.com/spf13/cobra"
@@ -89,21 +87,13 @@ block merges until a clean local review exists for the tip commit.`,
 			desc = fmt.Sprintf("%d unresolved finding%s", unresolved, suffix)
 		}
 
-		apiPath := fmt.Sprintf("repos/%s/statuses/%s", slug, sha)
-		c := exec.Command("gh", "api", "-X", "POST", apiPath,
-			"-f", "context=codecanary/review",
-			"-f", "state="+statusState,
-			"-f", "description="+desc,
-		)
-		out, err := c.CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("posting commit status via gh api: %w\n%s",
-				err, strings.TrimSpace(string(out)))
+		if err := review.PostReviewCommitStatus(slug, sha, statusState, desc); err != nil {
+			return fmt.Errorf("posting commit status: %w", err)
 		}
 
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
-			"✓ codecanary/review = %s on %s@%s (%s)\n",
-			statusState, slug, shortSHA(sha), desc)
+			"✓ %s = %s on %s@%s (%s)\n",
+			review.ReviewCommitStatusContext, statusState, slug, shortSHA(sha), desc)
 		return nil
 	},
 }

--- a/docs/review-flow.md
+++ b/docs/review-flow.md
@@ -165,6 +165,8 @@ Per-thread ack replies for dismissed/acknowledged/rebutted resolutions are poste
 
 `codecanary findings` applies the same marker to filter deferrals out of its default output: threads with any `codecanary:ack:*` reply are treated as handled and omitted alongside GitHub-resolved threads. Pass `--include-resolved` to see them. This keeps the codecanary-fix skill from re-prompting on findings the operator already deferred.
 
+After the review is posted (or updated in place), `GithubPlatform.Publish` also POSTs a `codecanary/review` commit status on the reviewed SHA via `PostReviewCommitStatus`. State is `success` when `NewFindings + StillOpen == 0` (everything is either new-and-green, fixed by code, or explicitly handled by the author), and `failure` otherwise. Description is the unresolved count or "all findings resolved" / "no findings". Teams that add `codecanary/review` as a required status check in branch protection get auto-gating: merges are blocked until a review run posts a green status on HEAD. Status posting failures are logged as warnings and do not abort Publish — the review itself has already landed. The local `codecanary signoff` command posts a status under the same context, so a team can rely on a single required check that either the bot (pr-loop) or a local reviewer (local-loop) satisfies.
+
 **Local**: Prints the formatted result to stdout. Format depends on context: terminal (colored, human-readable), markdown, or JSON.
 
 ### 9. Save state

--- a/internal/review/github.go
+++ b/internal/review/github.go
@@ -312,6 +312,42 @@ func PostReview(repo string, prNumber int, result *ReviewResult, diff string, co
 	return err
 }
 
+// ReviewCommitStatusContext is the commit-status context the review bot
+// writes when a review run completes. Using a stable string lets teams
+// require it in branch protection — "codecanary/review must be green
+// before merge." Matches the context used by `codecanary signoff`, so
+// both the bot (on PRs with the workflow) and a local signoff can
+// satisfy the same required check.
+const ReviewCommitStatusContext = "codecanary/review"
+
+// PostReviewCommitStatus POSTs a commit status on the given SHA summarising
+// the review outcome. state is "success" when all findings are resolved or
+// handled by the author, "failure" otherwise. Description is shown on the
+// PR checks list, so keep it short and human-readable. Errors are returned
+// so the caller can log them — a failed status post should not abort the
+// larger Publish flow, since the review itself has already been posted.
+func PostReviewCommitStatus(repo, sha, state, description string) error {
+	if sha == "" {
+		return fmt.Errorf("commit status requires a SHA")
+	}
+	owner, name, err := parseRepoSlug(repo)
+	if err != nil {
+		return err
+	}
+	payload := map[string]string{
+		"state":       state,
+		"context":     ReviewCommitStatusContext,
+		"description": description,
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshaling commit status payload: %w", err)
+	}
+	apiPath := fmt.Sprintf("repos/%s/%s/statuses/%s", owner, name, sha)
+	_, err = ghAPIPOST(apiPath, payloadJSON)
+	return err
+}
+
 // FetchReviewFromPR extracts cached review data from a PR review's hidden HTML tag.
 func FetchReviewFromPR(repo string, prNumber int) (*ReviewResult, error) {
 	owner, name, err := parseRepoSlug(repo)

--- a/internal/review/platform_github.go
+++ b/internal/review/platform_github.go
@@ -186,7 +186,6 @@ func (g *GithubPlatform) HandleResolutions(threads []ReviewThread, fixed []fixed
 
 func (g *GithubPlatform) Publish(result *ReviewResult, pr *PRData, threads []ReviewThread, fixed []fixedThread) error {
 	summary := computeReviewSummary(threads, fixed, result.Findings)
-	defer g.postReviewCommitStatus(result.SHA, summary)
 
 	// Decide edit-vs-post: if the latest CodeCanary review on the PR carries
 	// the current HEAD SHA in its marker, this is either a reply-only run or
@@ -206,6 +205,7 @@ func (g *GithubPlatform) Publish(result *ReviewResult, pr *PRData, threads []Rev
 			return fmt.Errorf("updating review body: %w", err)
 		}
 		Stderrf(ansiGreen, "Updated latest review on PR #%d\n", g.PRNumber)
+		g.postReviewCommitStatus(result.SHA, summary)
 		return nil
 	}
 
@@ -264,6 +264,7 @@ func (g *GithubPlatform) Publish(result *ReviewResult, pr *PRData, threads []Rev
 		Stderrf(ansiGreen, "Review posted to PR #%d\n", g.PRNumber)
 	}
 
+	g.postReviewCommitStatus(result.SHA, summary)
 	return nil
 }
 

--- a/internal/review/platform_github.go
+++ b/internal/review/platform_github.go
@@ -186,6 +186,7 @@ func (g *GithubPlatform) HandleResolutions(threads []ReviewThread, fixed []fixed
 
 func (g *GithubPlatform) Publish(result *ReviewResult, pr *PRData, threads []ReviewThread, fixed []fixedThread) error {
 	summary := computeReviewSummary(threads, fixed, result.Findings)
+	defer g.postReviewCommitStatus(result.SHA, summary)
 
 	// Decide edit-vs-post: if the latest CodeCanary review on the PR carries
 	// the current HEAD SHA in its marker, this is either a reply-only run or
@@ -285,4 +286,51 @@ func (g *GithubPlatform) ReportUsage(tracker *UsageTracker) {
 			fmt.Fprintf(os.Stderr, "Warning: could not write usage env: %v\n", err)
 		}
 	}
+}
+
+// postReviewCommitStatus POSTs a `codecanary/review` commit status on the
+// reviewed SHA. state=success when no unresolved findings remain for the
+// PR (new findings this cycle + threads still open with no classification
+// both at zero); state=failure otherwise. Teams can require this check in
+// branch protection to gate merges on a clean review.
+//
+// Skipped silently when the SHA is empty (non-pr-loop contexts that
+// accidentally share the adapter). Failures are logged as warnings — the
+// review itself has already been published, so a flaky status post should
+// not abort the whole Publish flow.
+func (g *GithubPlatform) postReviewCommitStatus(sha string, summary ReviewSummary) {
+	if sha == "" {
+		return
+	}
+	state, desc := commitStatusFromSummary(summary)
+	if err := PostReviewCommitStatus(g.Repo, sha, state, desc); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not post %s commit status: %v\n",
+			ReviewCommitStatusContext, err)
+		return
+	}
+	Stderrf(ansiGreen, "Posted %s = %s on %s (%s)\n",
+		ReviewCommitStatusContext, state, shortSHA(sha), desc)
+}
+
+// commitStatusFromSummary maps a ReviewSummary to the (state, description)
+// pair sent to the commit status API. Pulled out so the mapping is
+// unit-testable without network access.
+//
+// An "unresolved" count combines new findings this cycle with threads that
+// were already open and remain unclassified — either kind should fail the
+// required check. Everything classified by triage (resolved by code, file
+// removed, dismissed, acknowledged, rebutted) counts as handled.
+func commitStatusFromSummary(summary ReviewSummary) (state, desc string) {
+	unresolved := summary.NewFindings + summary.StillOpen
+	if unresolved > 0 {
+		suffix := "s"
+		if unresolved == 1 {
+			suffix = ""
+		}
+		return "failure", fmt.Sprintf("%d unresolved finding%s", unresolved, suffix)
+	}
+	if summary.ResolvedByCode+summary.FileRemoved+summary.Dismissed+summary.Acknowledged+summary.Rebutted > 0 {
+		return "success", "all findings resolved"
+	}
+	return "success", "no findings"
 }

--- a/internal/review/summary_test.go
+++ b/internal/review/summary_test.go
@@ -86,3 +86,82 @@ func TestReplaceSummaryBlockStripsWhenEmpty(t *testing.T) {
 		t.Errorf("non-block content should be preserved, got:\n%q", updated)
 	}
 }
+
+func TestCommitStatusFromSummary(t *testing.T) {
+	cases := []struct {
+		name     string
+		summary  ReviewSummary
+		wantSt   string
+		wantDesc string
+	}{
+		{
+			name:     "empty summary is success-no-findings",
+			summary:  ReviewSummary{},
+			wantSt:   "success",
+			wantDesc: "no findings",
+		},
+		{
+			name:     "new finding fails",
+			summary:  ReviewSummary{NewFindings: 1},
+			wantSt:   "failure",
+			wantDesc: "1 unresolved finding",
+		},
+		{
+			name:     "multiple new findings uses plural",
+			summary:  ReviewSummary{NewFindings: 3},
+			wantSt:   "failure",
+			wantDesc: "3 unresolved findings",
+		},
+		{
+			name:     "still-open thread fails even without new findings",
+			summary:  ReviewSummary{StillOpen: 2},
+			wantSt:   "failure",
+			wantDesc: "2 unresolved findings",
+		},
+		{
+			name:     "new + still-open are summed",
+			summary:  ReviewSummary{NewFindings: 1, StillOpen: 1},
+			wantSt:   "failure",
+			wantDesc: "2 unresolved findings",
+		},
+		{
+			name:     "resolved-by-code with no unresolved is success",
+			summary:  ReviewSummary{ResolvedByCode: 2},
+			wantSt:   "success",
+			wantDesc: "all findings resolved",
+		},
+		{
+			name:     "dismissed counts as handled",
+			summary:  ReviewSummary{Dismissed: 1},
+			wantSt:   "success",
+			wantDesc: "all findings resolved",
+		},
+		{
+			name:     "rebutted counts as handled",
+			summary:  ReviewSummary{Rebutted: 1},
+			wantSt:   "success",
+			wantDesc: "all findings resolved",
+		},
+		{
+			name:     "acknowledged counts as handled",
+			summary:  ReviewSummary{Acknowledged: 1},
+			wantSt:   "success",
+			wantDesc: "all findings resolved",
+		},
+		{
+			name:     "mix of resolved and unresolved still fails",
+			summary:  ReviewSummary{ResolvedByCode: 2, Dismissed: 1, StillOpen: 1},
+			wantSt:   "failure",
+			wantDesc: "1 unresolved finding",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st, desc := commitStatusFromSummary(tc.summary)
+			if st != tc.wantSt || desc != tc.wantDesc {
+				t.Errorf("commitStatusFromSummary(%+v) = (%q, %q), want (%q, %q)",
+					tc.summary, st, desc, tc.wantSt, tc.wantDesc)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- After every bot review, `GithubPlatform.Publish` now POSTs a commit status under context `codecanary/review` on the reviewed SHA. `success` when no unresolved findings remain, `failure` otherwise.
- `codecanary signoff` (local) now POSTs under the same context using the shared `PostReviewCommitStatus` helper, so a single required check can be satisfied by either the bot or a local reviewer.
- Staling is free: GitHub commit statuses are keyed by SHA, so a new push invalidates the previous green state automatically — the new HEAD has no status yet, so branch protection re-blocks until the next review posts.
- Pure `commitStatusFromSummary` helper extracted and covered by a table-driven test. Doc updated in `docs/review-flow.md`.

## How to gate merges on it
1. Merge this PR.
2. On any PR with the workflow, wait for the review to run once so `codecanary/review` shows up in the branch-protection status-check picker.
3. Settings → Branches → edit the protection rule for `main` → Require status checks → add `codecanary/review`.

## Rollback
If the status POST starts failing for everyone (e.g. token scope issue), the warning fires but the review is still published — no data loss. Remove the required check in branch protection to un-gate merges while investigating.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (new `TestCommitStatusFromSummary` table test covers unresolved-vs-handled logic)
- [x] Shared `PostReviewCommitStatus` used by both Action and `codecanary signoff`
- [ ] End-to-end: merge this, push a dirty change, verify `codecanary/review = failure` lands on the new SHA
- [ ] Fix the findings, push, verify `codecanary/review = success` lands
- [ ] Add as a required check; verify merge blocks until status flips green

🤖 Generated with [Claude Code](https://claude.com/claude-code)