### PR TITLE
fix: keep prior ack sticky across pushes in triage

### DIFF
--- a/docs/review-flow.md
+++ b/docs/review-flow.md
@@ -94,16 +94,19 @@ First, an incremental diff is computed (`git diff <previousSHA>..HEAD`). Two dif
 - **Activity diff** (incremental): Determines whether there's new activity to evaluate. If empty, threads with no replies are skipped (no LLM cost).
 - **Context diff** (full PR diff): Used for classification and evaluation context. Ensures fixes from earlier pushes are visible even if they predate the incremental window.
 
-`ClassifyThreads()` assigns each unresolved thread one of six classifications:
+`ClassifyThreads()` assigns each unresolved thread one of seven classifications:
 
 | Classification | Condition | Evaluation |
 |---|---|---|
+| `TriagePreviouslyAcked` | Bot already posted a `<!-- codecanary:ack:* -->` reply and no human reply since | Auto-resolved by Go code (no LLM) -- prior reason carried forward |
 | `TriageSkip` | No activity diff, not outdated, no replies | Skipped (no LLM) |
 | `TriageCodeChanged` | GitHub outdated flag, or file in PR diff | LLM evaluates with file-scoped diff + file snippet |
 | `TriageHasReply` | Human replied (no code changes) | LLM evaluates reply intent |
 | `TriageCodeChangedReply` | Both code changed and human replied | LLM evaluates both |
 | `TriageCrossFileChange` | Changes in other files only | LLM evaluates with full PR diff |
 | `TriageFileRemovedFromPR` | File no longer in PR | Auto-resolved by Go code (no LLM) -- thread resolved on GitHub |
+
+`TriagePreviouslyAcked` is checked first. When the bot already recorded a deferral (`<!-- codecanary:ack:dismissed/rebutted/acknowledged -->`) and the author hasn't added a fresh reply since, `EvaluateThreadsParallel` short-circuits without an LLM call and re-emits the same fixedThread the prior cycle produced. `computeReviewSummary` then routes the thread back to its original Dismissed/Acknowledged/Rebutted bucket and the `CodeCanary / review` commit status stays green across pushes that don't touch the deferred finding. A new human reply after the ack flips the thread back to `TriageHasReply` (or `TriageCodeChangedReply`) so the fresh signal gets re-evaluated.
 
 Threads classified as `TriageFileRemovedFromPR` are auto-resolved without an LLM call. The Go code sets reason `file_removed` and resolves the thread directly.
 
@@ -196,6 +199,8 @@ If telemetry is enabled (opt-in), fires an anonymous event with aggregate stats:
 **Per-thread evaluation.** Each unresolved thread gets its own LLM call with tailored context, rather than one bulk prompt. This allows fine-grained classification, parallel execution, and per-thread budget control.
 
 **Anti-ping-pong.** The incremental prompt includes recently resolved findings so the LLM doesn't re-raise similar issues. Non-code resolutions (dismissed, acknowledged, rebutted) keep threads open for re-triage on future pushes, but post ack replies to avoid duplicate acknowledgments.
+
+**Sticky ack across pushes.** Once the bot has recorded a deferral on a thread, subsequent pushes preserve that classification (via `TriagePreviouslyAcked`) until the author adds a new reply. Without this, the next push would re-triage the thread as `TriageCodeChanged` (when the file was touched) or `TriageSkip` (when it wasn't), and the resolution reason would evaporate from the summary — flipping `Acknowledged by author: N` to `Still unresolved: N` and failing the commit status check on a thread the operator already deferred.
 
 **Context window fitting.** After building the prompt, the pipeline estimates token count and progressively trims file contents (largest first) then diff to fit the model's context window. This prevents API failures on large PRs.
 

--- a/internal/review/triage.go
+++ b/internal/review/triage.go
@@ -21,17 +21,19 @@ const (
 	TriageCodeChangedReply                               // both code changed AND has replies
 	TriageCrossFileChange                                // diff has changes but NOT in this thread's file
 	TriageFileRemovedFromPR                              // file no longer in the PR
+	TriagePreviouslyAcked                                // bot already ack'd a deferral; no new human reply since
 )
 
 // TriagedThread pairs a ReviewThread with its classification and context.
 type TriagedThread struct {
-	Thread      ReviewThread
-	Index       int                  // original index in the unresolved slice
-	Class       ThreadClassification
-	FileDiff    string               // file-scoped diff (level 1) or full diff (cross-file)
-	FullDiff    string               // full PR diff for widened-scope fallback; empty when not applicable
-	FileSnippet string               // windowed file content around finding + diff hunks
-	BotLogin    string               // login of the review bot, for filtering replies
+	Thread         ReviewThread
+	Index          int // original index in the unresolved slice
+	Class          ThreadClassification
+	FileDiff       string // file-scoped diff (level 1) or full diff (cross-file)
+	FullDiff       string // full PR diff for widened-scope fallback; empty when not applicable
+	FileSnippet    string // windowed file content around finding + diff hunks
+	BotLogin       string // login of the review bot, for filtering replies
+	PriorAckReason string // for TriagePreviouslyAcked: the previously-recorded reason (acknowledged/rebutted/dismissed)
 }
 
 // ThreadResolution is the result of a per-thread Claude evaluation.
@@ -284,8 +286,20 @@ func ClassifyThreads(threads []ReviewThread, activityDiff, contextDiff, botLogin
 		outdated := t.Outdated
 		deleted := fileDeletedInDiff(contextDiff, t.Path)
 
+		// Sticky-ack: when the bot already recorded a deferral and the
+		// author has not added a fresh reply since, preserve the prior
+		// classification instead of rerunning triage. This prevents the
+		// "Acknowledged by author: 2" → "Still unresolved: 2" regression
+		// that happened on subsequent pushes when no new signal was present.
+		var priorAck string
+		if !hasReply {
+			priorAck = parsePriorAckReason(t, botLogin)
+		}
+
 		var class ThreadClassification
 		switch {
+		case priorAck != "":
+			class = TriagePreviouslyAcked
 		case deleted:
 			// File was deleted — evaluate with full diff so Claude can check
 			// whether the code moved to a replacement file with the fix applied.
@@ -341,17 +355,58 @@ func ClassifyThreads(threads []ReviewThread, activityDiff, contextDiff, botLogin
 		}
 
 		result[i] = TriagedThread{
-			Thread:      t,
-			Index:       i,
-			Class:       class,
-			FileDiff:    fileDiff,
-			FullDiff:    fullDiff,
-			FileSnippet: fileSnippet,
-			BotLogin:    botLogin,
+			Thread:         t,
+			Index:          i,
+			Class:          class,
+			FileDiff:       fileDiff,
+			FullDiff:       fullDiff,
+			FileSnippet:    fileSnippet,
+			BotLogin:       botLogin,
+			PriorAckReason: priorAck,
 		}
 	}
 
 	return result
+}
+
+// parsePriorAckReason returns the reason recorded in the most recent
+// codecanary ack reply on the thread (acknowledged/rebutted/dismissed),
+// or "" if no ack reply is present. Handles both the current marker
+// (<!-- codecanary:ack:<reason> -->) and the legacy clanopy form.
+func parsePriorAckReason(t ReviewThread, botLogin string) string {
+	var latest string
+	for _, r := range t.Replies {
+		if r.Author != botLogin {
+			continue
+		}
+		if reason := extractAckReason(r.Body); reason != "" {
+			latest = reason
+		}
+	}
+	return latest
+}
+
+// extractAckReason pulls the reason value out of a codecanary ack marker.
+// Returns "" when the body has no marker. Unknown reasons are returned
+// as-is so callers can decide how to handle them; in practice the bot
+// only writes "acknowledged", "rebutted", "dismissed", or "unknown".
+func extractAckReason(body string) string {
+	for _, prefix := range []string{ackMarkerPrefix, legacyAckPrefix} {
+		idx := strings.Index(body, prefix)
+		if idx < 0 {
+			continue
+		}
+		rest := body[idx+len(prefix):]
+		end := strings.Index(rest, " -->")
+		if end < 0 {
+			end = strings.Index(rest, "-->")
+			if end < 0 {
+				continue
+			}
+		}
+		return strings.TrimSpace(rest[:end])
+	}
+	return ""
 }
 
 // fileInDiff checks if the diff contains changes to the given file path.
@@ -682,6 +737,19 @@ func EvaluateThreadsParallel(triaged []TriagedThread, provider ModelProvider, cf
 			results[i] = ThreadResolution{Index: t.Index, Resolved: false}
 			continue
 		}
+		if t.Class == TriagePreviouslyAcked {
+			// Sticky: carry the prior ack reason forward without burning
+			// triage tokens. computeReviewSummary will route it to the
+			// matching bucket (Dismissed/Acknowledged/Rebutted), so the
+			// commit status check stays green across pushes that don't
+			// touch the deferred finding.
+			results[i] = ThreadResolution{
+				Index:    t.Index,
+				Resolved: true,
+				Reason:   t.PriorAckReason,
+			}
+			continue
+		}
 		// Soft budget cap: skip remaining evaluations if budget is exceeded.
 		if err := CheckBudget(tracker, maxBudgetUSD); err != nil {
 			results[i] = ThreadResolution{Index: t.Index, Error: err}
@@ -789,6 +857,8 @@ func LogTriage(triaged []TriagedThread) {
 			fmt.Fprintf(os.Stderr, "  [evaluate] %s — cross-file changes detected\n", label)
 		case TriageFileRemovedFromPR:
 			fmt.Fprintf(os.Stderr, "  [resolve]  %s — file removed from PR\n", label)
+		case TriagePreviouslyAcked:
+			fmt.Fprintf(os.Stderr, "  [sticky]   %s — prior ack (%s) carried forward\n", label, t.PriorAckReason)
 		}
 	}
 
@@ -799,7 +869,7 @@ func LogTriage(triaged []TriagedThread) {
 		switch t.Class {
 		case TriageSkip:
 			skipped++
-		case TriageFileRemovedFromPR:
+		case TriageFileRemovedFromPR, TriagePreviouslyAcked:
 			autoResolved++
 		default:
 			needsEval++
@@ -812,7 +882,8 @@ func LogTriage(triaged []TriagedThread) {
 func LogResolutions(triaged []TriagedThread, resolutions []ThreadResolution) {
 	fmt.Fprintf(os.Stderr, "\n")
 	for i, r := range resolutions {
-		if triaged[i].Class == TriageSkip || triaged[i].Class == TriageFileRemovedFromPR {
+		switch triaged[i].Class {
+		case TriageSkip, TriageFileRemovedFromPR, TriagePreviouslyAcked:
 			continue
 		}
 		label := threadLabel(triaged[i].Thread)
@@ -845,7 +916,10 @@ func LogResolutions(triaged []TriagedThread, resolutions []ThreadResolution) {
 func countNonSkipped(triaged []TriagedThread) int {
 	n := 0
 	for _, t := range triaged {
-		if t.Class != TriageSkip && t.Class != TriageFileRemovedFromPR {
+		switch t.Class {
+		case TriageSkip, TriageFileRemovedFromPR, TriagePreviouslyAcked:
+			continue
+		default:
 			n++
 		}
 	}

--- a/internal/review/triage_test.go
+++ b/internal/review/triage_test.go
@@ -1,6 +1,7 @@
 package review
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -440,6 +441,131 @@ func TestToFixedThreads_PropagatesRationale(t *testing.T) {
 	if fixed[1].Rationale != "" {
 		t.Errorf("empty rationale should stay empty, got %q", fixed[1].Rationale)
 	}
+}
+
+func TestExtractAckReason(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"current marker", "<!-- codecanary:ack:rebutted -->\nKeeping open.", "rebutted"},
+		{"acknowledged", "<!-- codecanary:ack:acknowledged -->\nKeeping open.", "acknowledged"},
+		{"dismissed", "<!-- codecanary:ack:dismissed -->\nKeeping open.", "dismissed"},
+		{"legacy marker", "<!-- clanopy:ack:rebutted -->\nKeeping open.", "rebutted"},
+		{"no marker", "Some normal reply", ""},
+		{"no closing tag", "<!-- codecanary:ack:acknowledged with no closer", ""},
+		{"unknown reason", "<!-- codecanary:ack:unknown -->\n", "unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractAckReason(tc.body); got != tc.want {
+				t.Errorf("extractAckReason(%q) = %q, want %q", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParsePriorAckReason_PicksLatestBotAck(t *testing.T) {
+	thread := ReviewThread{
+		Replies: []ThreadReply{
+			{Author: "user", Body: "Deferring — see rationale."},
+			{Author: "bot", Body: "<!-- codecanary:ack:acknowledged -->\nAuthor acknowledged this finding."},
+			{Author: "bot", Body: "<!-- codecanary:ack:rebutted -->\nAuthor provided rebuttal."},
+		},
+	}
+	if got := parsePriorAckReason(thread, "bot"); got != "rebutted" {
+		t.Errorf("expected latest reason 'rebutted', got %q", got)
+	}
+}
+
+func TestParsePriorAckReason_IgnoresNonBotMarkers(t *testing.T) {
+	thread := ReviewThread{
+		Replies: []ThreadReply{
+			{Author: "attacker", Body: "<!-- codecanary:ack:dismissed -->\nFake."},
+		},
+	}
+	if got := parsePriorAckReason(thread, "bot"); got != "" {
+		t.Errorf("non-bot ack should not be sticky, got %q", got)
+	}
+}
+
+func TestClassifyThreads_StickyAckSurvivesNextPush(t *testing.T) {
+	threads := []ReviewThread{
+		{
+			Path: "CLAUDE.md",
+			Line: 724,
+			Body: "Original finding",
+			Replies: []ThreadReply{
+				{Author: "user", Body: "Deferring — forward recommendation, not yet implemented."},
+				{Author: "bot", Body: "<!-- codecanary:ack:acknowledged -->\nAuthor acknowledged."},
+			},
+		},
+	}
+	// File changed in the next push — without sticky-ack this would
+	// classify as TriageCodeChanged and lose the prior reason.
+	diff := "diff --git a/CLAUDE.md b/CLAUDE.md\n--- a/CLAUDE.md\n+++ b/CLAUDE.md\n@@ -700,3 +700,3 @@\n-old\n+new\n"
+
+	triaged := ClassifyThreads(threads, diff, diff, "bot", []string{"CLAUDE.md"}, nil)
+
+	if triaged[0].Class != TriagePreviouslyAcked {
+		t.Fatalf("expected TriagePreviouslyAcked, got %d", triaged[0].Class)
+	}
+	if triaged[0].PriorAckReason != "acknowledged" {
+		t.Errorf("expected PriorAckReason 'acknowledged', got %q", triaged[0].PriorAckReason)
+	}
+}
+
+func TestClassifyThreads_NewHumanReplyBreaksStickiness(t *testing.T) {
+	// Author replied AGAIN after the bot's ack — that's a fresh signal
+	// and should reopen the thread for evaluation, not stay sticky.
+	threads := []ReviewThread{
+		{
+			Path: "CLAUDE.md",
+			Line: 724,
+			Replies: []ThreadReply{
+				{Author: "user", Body: "Original deferring rationale."},
+				{Author: "bot", Body: "<!-- codecanary:ack:acknowledged -->\nAck."},
+				{Author: "user", Body: "Wait, actually this one needs another look."},
+			},
+		},
+	}
+	triaged := ClassifyThreads(threads, "", "", "bot", []string{"CLAUDE.md"}, nil)
+
+	if triaged[0].Class != TriageHasReply {
+		t.Fatalf("expected TriageHasReply (new reply after ack), got %d", triaged[0].Class)
+	}
+	if triaged[0].PriorAckReason != "" {
+		t.Errorf("PriorAckReason should be empty when new reply present, got %q", triaged[0].PriorAckReason)
+	}
+}
+
+func TestEvaluateThreadsParallel_StickyAckShortCircuits(t *testing.T) {
+	// Provider that panics if called — sticky-ack must skip the LLM.
+	provider := &stickyAckPanicProvider{t: t}
+
+	triaged := []TriagedThread{
+		{Index: 0, Class: TriagePreviouslyAcked, PriorAckReason: "rebutted"},
+		{Index: 1, Class: TriagePreviouslyAcked, PriorAckReason: "dismissed"},
+	}
+	results := EvaluateThreadsParallel(triaged, provider, nil, 3, &UsageTracker{}, 0)
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if !results[0].Resolved || results[0].Reason != "rebutted" {
+		t.Errorf("first result: expected resolved=true reason=rebutted, got %+v", results[0])
+	}
+	if !results[1].Resolved || results[1].Reason != "dismissed" {
+		t.Errorf("second result: expected resolved=true reason=dismissed, got %+v", results[1])
+	}
+}
+
+type stickyAckPanicProvider struct{ t *testing.T }
+
+func (p *stickyAckPanicProvider) Run(_ context.Context, _ string, _ RunOpts) (*providerResult, error) {
+	p.t.Fatalf("provider.Run must not be called for TriagePreviouslyAcked threads")
+	return nil, nil
 }
 
 func TestResolutionFormat_RequestsRationale(t *testing.T) {


### PR DESCRIPTION
## Summary

- Triage forgot prior `<!-- codecanary:ack:<reason> -->` replies on the next push, so threads classified as **Acknowledged/Rebutted/Dismissed by author** flipped back to **Still unresolved** on the next cycle. That fails the `CodeCanary / review` commit status and blocks merges even when nothing changed (real-world repro: thetechfx/bedrock#1671).
- Adds a `TriagePreviouslyAcked` class that parses the prior reason out of the marker, short-circuits LLM evaluation, and re-emits the same `fixedThread` so `computeReviewSummary` routes the thread back to its original bucket.
- A fresh human reply after the ack still breaks stickiness — that's a real new signal worth re-evaluating.

## Test plan

- [x] `go test ./...` — new tests cover marker parsing, latest-reply selection, ignoring spoofed non-bot acks, sticky behavior across a code-touching push, fresh-reply breaking stickiness, and verifying the LLM is not called for sticky threads
- [x] `go vet ./...`
- [ ] Verify on a live PR that a thread previously classified as acknowledged stays acknowledged on the next push