### PR TITLE
fix(triage): include PreviouslyAcked in countNonSkipped

### DIFF
--- a/internal/review/triage.go
+++ b/internal/review/triage.go
@@ -912,12 +912,17 @@ func LogResolutions(triaged []TriagedThread, resolutions []ThreadResolution) {
 	}
 }
 
-// countNonSkipped returns the number of triaged threads that need LLM evaluation.
+// countNonSkipped returns the number of triaged threads that EvaluateThreadsParallel
+// must process. TriagePreviouslyAcked is included even though it short-circuits
+// without an LLM call: the function still has to run to emit the carried-forward
+// fixedThread, which is what feeds the summary's Acknowledged/Rebutted/Dismissed
+// buckets. Excluding it here was the bug behind the "Still unresolved: 2" stuck
+// status on already-acked threads.
 func countNonSkipped(triaged []TriagedThread) int {
 	n := 0
 	for _, t := range triaged {
 		switch t.Class {
-		case TriageSkip, TriageFileRemovedFromPR, TriagePreviouslyAcked:
+		case TriageSkip, TriageFileRemovedFromPR:
 			continue
 		default:
 			n++

--- a/internal/review/triage_test.go
+++ b/internal/review/triage_test.go
@@ -540,6 +540,23 @@ func TestClassifyThreads_NewHumanReplyBreaksStickiness(t *testing.T) {
 	}
 }
 
+func TestCountNonSkipped_IncludesPreviouslyAcked(t *testing.T) {
+	// Regression: sticky-ack threads must count toward needsEval so
+	// EvaluateThreadsParallel runs and emits the carried-forward fixedThread.
+	// Excluding them caused the runner to skip eval entirely, leaving the
+	// summary stuck on "Still unresolved" for threads the bot had already
+	// acked.
+	triaged := []TriagedThread{
+		{Class: TriageSkip},
+		{Class: TriageFileRemovedFromPR},
+		{Class: TriagePreviouslyAcked, PriorAckReason: "acknowledged"},
+		{Class: TriagePreviouslyAcked, PriorAckReason: "rebutted"},
+	}
+	if got := countNonSkipped(triaged); got != 2 {
+		t.Errorf("countNonSkipped = %d, want 2 (the two PreviouslyAcked threads)", got)
+	}
+}
+
 func TestEvaluateThreadsParallel_StickyAckShortCircuits(t *testing.T) {
 	// Provider that panics if called — sticky-ack must skip the LLM.
 	provider := &stickyAckPanicProvider{t: t}


### PR DESCRIPTION
Follow-up to #174.

## Summary

The first sticky-ack fix worked at the triage layer (logs showed `[sticky] ... carried forward`) but the published summary still said **Still unresolved: 2** — confirmed in production on thetechfx/bedrock#1671 right after v0.6.23 shipped.

Root cause: `countNonSkipped` excluded `TriagePreviouslyAcked`. When *every* remaining thread is sticky-ack, `needsEval` came back as zero, the runner skipped `EvaluateThreadsParallel` entirely, the fast path I added there never fired, no `fixedThread` was emitted, and `computeReviewSummary` lumped the threads into `StillOpen`.

Including PreviouslyAcked in `countNonSkipped` restores the round trip: eval runs, the fast path returns the prior reason without an LLM call, `toFixedThreads` collects the resolutions, and the summary lands them in Acknowledged/Rebutted/Dismissed.

## Test plan

- [x] `go test ./...`
- [x] New regression test `TestCountNonSkipped_IncludesPreviouslyAcked`
- [ ] Re-trigger a review on bedrock#1671 with v0.6.24 to confirm the summary flips to "Acknowledged by author: 2"