### PR TITLE
feat: add lifecycle considerations to review prompts

### DIFF
--- a/docs/review-flow.md
+++ b/docs/review-flow.md
@@ -79,7 +79,8 @@ Calls `BuildPrompt()` to assemble the full review prompt. The prompt includes (i
 7. Explicit file allowlist (anti-hallucination)
 8. Full contents of changed files with line numbers
 9. The unified diff
-10. Output format instructions (JSON schema, examples, escaping rules)
+10. Lifecycle considerations — checklist for changes that behave differently between the PR branch and the default branch (push triggers scoped to the PR branch, concurrency keys keyed on `github.ref`, test scaffolding to remove before merge). Findings emitted from this section must still anchor `file` and `line` to a diff line; the existing scope guards in `runner.go` enforce that.
+11. Output format instructions (JSON schema, examples, escaping rules)
 
 After building, `fitPromptForModel()` checks whether the prompt fits the review model's context window (context window minus max output tokens). If it exceeds the budget, it progressively drops the largest file contents first, then truncates the diff as a last resort.
 

--- a/internal/review/prompt.go
+++ b/internal/review/prompt.go
@@ -106,6 +106,9 @@ func BuildPrompt(pr *PRData, cfg *ReviewConfig, startIndex int, projectDocs map[
 	writeFencedBlock(&b, "diff", pr.Diff)
 	b.WriteString("\n")
 
+	// Lifecycle considerations — flag changes that behave differently after merge.
+	writeLifecycleSection(&b)
+
 	// Output format instructions.
 	b.WriteString("## Output Format\n")
 	b.WriteString("Return your findings as a JSON array inside a ```json code fence. Each finding must have these fields:\n\n")
@@ -306,6 +309,9 @@ func BuildIncrementalPrompt(diff string, cfg *ReviewConfig, knownIssues []Review
 	writeFencedBlock(&b, "diff", diff)
 	b.WriteString("\n")
 
+	// Lifecycle considerations — flag changes that behave differently after merge.
+	writeLifecycleSection(&b)
+
 	// Output format instructions.
 	b.WriteString("## Output Format\n")
 	b.WriteString("Return your findings as a JSON array inside a ```json code fence. Each finding must have these fields:\n\n")
@@ -363,6 +369,27 @@ func writeRulesSection(b *strings.Builder, cfg *ReviewConfig, files []string) {
 	default:
 		b.WriteString("## Review Rules\nNo specific rules are defined. Perform a general code review covering correctness, security, performance, and maintainability.\n\n")
 	}
+}
+
+// writeLifecycleSection adds a "Lifecycle Considerations" section that asks
+// the reviewer to flag changes that behave differently between the PR branch
+// (where the review runs) and the default branch (where the code lives after
+// merge). These bugs are easy to miss in a hunk-only review because the code
+// looks correct in isolation — the defect is the gap between PR-branch and
+// post-merge state.
+//
+// All findings emitted from this section must still anchor `file` and `line`
+// to a diff line; the existing file allowlist + line-proximity validators in
+// runner.go enforce that. The section only widens the LLM's attention, not
+// the validator's tolerance.
+func writeLifecycleSection(b *strings.Builder) {
+	b.WriteString("## Lifecycle Considerations\n")
+	b.WriteString("Some changes behave differently between the PR branch (where this review runs) and the default branch (where the code lives after merge). Scan the diff for places where this asymmetry could cause a real bug post-merge:\n\n")
+	b.WriteString("- A trigger, branch filter, or workflow condition is hard-coded to the PR's source branch (e.g. `branches: [feature/foo]`, `if: github.ref == 'refs/heads/feature/foo'`, `if: github.head_ref == ...`). These typically need to be removed or generalized before merge.\n")
+	b.WriteString("- A concurrency group, lock key, cache key, or identifier is keyed on a value that is unique-per-branch on the PR but shared post-merge (e.g. `${{ github.ref }}` resolves to many distinct refs across PRs but to a single value on the default branch). After merge, dispatches that should run in parallel will silently cancel each other.\n")
+	b.WriteString("- Code paths or values gated on the PR being open or unmerged (e.g. test-only flags, debug switches, sample data, scaffolding) that won't behave the same way on the default branch.\n")
+	b.WriteString("- Documentation, comments, or examples that describe temporary scaffolding the diff also adds — both need to be removed before merge, and missing one leaves a stale reference.\n\n")
+	b.WriteString("For each lifecycle issue, anchor your finding's `file` and `line` to the offending diff line and explain the post-merge consequence in `description`. Do NOT report concerns in unchanged code — only in lines added or modified by this diff.\n\n")
 }
 
 // writeProjectDocs adds a "Project Documentation" section to the prompt builder

--- a/internal/review/prompt_test.go
+++ b/internal/review/prompt_test.go
@@ -188,3 +188,41 @@ func TestBuildIncrementalPrompt_ResolvedSectionHandlesMissingFields(t *testing.T
 		t.Error("suggestion block should be omitted when empty")
 	}
 }
+
+// The Lifecycle Considerations section is what catches "behaves on PR
+// branch but not on main" bugs (push triggers scoped to the PR branch,
+// concurrency keys keyed on github.ref, etc.). It must appear in both
+// full and incremental prompts and must remind the LLM to anchor
+// findings to diff lines.
+func TestBuildPrompt_IncludesLifecycleSection(t *testing.T) {
+	pr := &PRData{Number: 1, Title: "t", Files: []string{"a.go"}, Diff: "diff"}
+	got := BuildPrompt(pr, nil, 0, nil)
+
+	mustContain := []string{
+		"## Lifecycle Considerations",
+		"behave differently between the PR branch",
+		"github.ref",
+		"anchor your finding's `file` and `line`",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(got, s) {
+			t.Errorf("BuildPrompt missing expected lifecycle snippet %q", s)
+		}
+	}
+}
+
+func TestBuildIncrementalPrompt_IncludesLifecycleSection(t *testing.T) {
+	got := BuildIncrementalPrompt("diff --git a/foo b/foo\n", nil, nil, 1, 0, nil, []string{"foo"}, nil, nil)
+
+	mustContain := []string{
+		"## Lifecycle Considerations",
+		"behave differently between the PR branch",
+		"github.ref",
+		"anchor your finding's `file` and `line`",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(got, s) {
+			t.Errorf("BuildIncrementalPrompt missing expected lifecycle snippet %q", s)
+		}
+	}
+}


### PR DESCRIPTION
## Purpose

Adds a "Lifecycle Considerations" section to the review prompt asking the LLM to flag changes that behave differently between the PR branch (where the review runs) and the default branch (where the code lives after merge). These bugs are easy to miss in a hunk-only review because the code looks correct in isolation — the defect is the gap between PR-branch state and post-merge state.

Concrete bug categories the section targets (all observed escaping codecanary review on real PRs):
- Triggers / branch filters / workflow conditions hard-coded to the PR's source branch (\`branches: [feature/foo]\`, \`if: github.ref == 'refs/heads/feature/foo'\`)
- Concurrency, cache, or lock keys keyed only on a value that is unique-per-PR but shared post-merge (e.g. \`\${{ github.ref }}\`)
- Code paths gated on the PR being open or unmerged
- Test scaffolding the diff also adds and intends to remove

## Details

- New helper \`writeLifecycleSection\` in \`internal/review/prompt.go\`. Called from both \`BuildPrompt\` and \`BuildIncrementalPrompt\`, positioned between the diff and the Output Format section so the LLM has the diff fresh in context when it considers lifecycle.
- The section text explicitly requires findings to anchor \`file\` and \`line\` to a diff line ("Do NOT report concerns in unchanged code — only in lines added or modified by this diff"). Existing scope guards (file allowlist + 20-line proximity validator) enforce that — this PR widens attention, not validator tolerance.
- Two new tests in \`prompt_test.go\` confirming the section is present in both prompt builders.
- \`docs/review-flow.md\` updated to list the new section in the prompt assembly order.

## Verify and Review

- \`go test ./... -count=1\` — all green
- \`go vet ./...\` — clean
- The new section name and prompt copy are easy to tweak; the next PR in this stack (PR-description vs code contradiction) follows the same pattern.

## References

- Linear: —
- Related: ediphi-precon/ediphi-core#10372 — real PR where codecanary missed three lifecycle issues that Cursor Bugbot caught (push trigger removal, github.ref concurrency collision, max-turns vs PR-desc cap). Findings 6 / 7 / 8 in [the analysis](https://github.com/ediphi-precon/ediphi-core/pull/10372).