### PR TITLE
feat: PR description cross-check in review prompts

### DIFF
--- a/docs/review-flow.md
+++ b/docs/review-flow.md
@@ -80,7 +80,8 @@ Calls `BuildPrompt()` to assemble the full review prompt. The prompt includes (i
 8. Full contents of changed files with line numbers
 9. The unified diff
 10. Lifecycle considerations — checklist for changes that behave differently between the PR branch and the default branch (push triggers scoped to the PR branch, concurrency keys keyed on `github.ref`, test scaffolding to remove before merge). Findings emitted from this section must still anchor `file` and `line` to a diff line; the existing scope guards in `runner.go` enforce that.
-11. Output format instructions (JSON schema, examples, escaping rules)
+11. PR description cross-check — emitted only when the PR has a body. Asks the LLM to flag specific factual claims in the body that the diff contradicts (documented cost caps, "this PR does NOT do X" claims, behavior guarantees that the code doesn't implement). Same diff-anchoring requirement as the lifecycle section.
+12. Output format instructions (JSON schema, examples, escaping rules)
 
 After building, `fitPromptForModel()` checks whether the prompt fits the review model's context window (context window minus max output tokens). If it exceeds the budget, it progressively drops the largest file contents first, then truncates the diff as a last resort.
 

--- a/internal/review/prompt.go
+++ b/internal/review/prompt.go
@@ -109,6 +109,11 @@ func BuildPrompt(pr *PRData, cfg *ReviewConfig, startIndex int, projectDocs map[
 	// Lifecycle considerations — flag changes that behave differently after merge.
 	writeLifecycleSection(&b)
 
+	// PR description cross-check — flag claims in the body contradicted by the diff.
+	if pr.Body != "" {
+		writePRBodyCrossCheckSection(&b)
+	}
+
 	// Output format instructions.
 	b.WriteString("## Output Format\n")
 	b.WriteString("Return your findings as a JSON array inside a ```json code fence. Each finding must have these fields:\n\n")
@@ -207,12 +212,22 @@ func BuildReevaluatePrompt(threads []ReviewThread, incrementalDiff string) strin
 // BuildIncrementalPrompt reviews only new code, avoiding duplicate reports.
 // startIndex is the number of existing findings so fix_ref numbering continues.
 // resolved provides context about recently resolved findings to prevent ping-ponging.
-func BuildIncrementalPrompt(diff string, cfg *ReviewConfig, knownIssues []ReviewThread, prNumber int, startIndex int, fileContents map[string]string, files []string, resolved []ResolvedContext, projectDocs map[string]string) string {
+// prBody is the PR description (may be empty); when non-empty it is included so
+// the cross-check section can flag contradictions between the description and
+// the incremental diff.
+func BuildIncrementalPrompt(diff string, cfg *ReviewConfig, knownIssues []ReviewThread, prNumber int, startIndex int, fileContents map[string]string, files []string, resolved []ResolvedContext, projectDocs map[string]string, prBody string) string {
 	var b strings.Builder
 
 	b.WriteString("You are a code reviewer. Review ONLY the following incremental changes and report NEW findings.\n")
 	b.WriteString("You will be given the full contents of changed files for context, along with the diff. Only report issues that are directly related to the changes in the diff — do not flag pre-existing issues in unchanged code. Do not report a finding if your analysis concludes that the code is correct and no action is needed — only report findings that require the author to make a change or consider a specific alternative.\n")
 	b.WriteString("Also consider whether the changes could cause side effects in other files that depend on or interact with the modified code (e.g. callers, importers, shared state). If you identify a potential side effect, anchor your finding to the relevant line in the diff and describe the affected downstream code in the description.\n\n")
+
+	// PR description (when available) — needed for the cross-check section
+	// below so the LLM can flag contradictions between the description and
+	// the incremental diff.
+	if prBody != "" {
+		fmt.Fprintf(&b, "<pr-body>\n%s\n</pr-body>\n\n", escapeAllTags(prBody))
+	}
 
 	// Explicit allowlist of files in this diff.
 	if len(files) > 0 {
@@ -312,6 +327,11 @@ func BuildIncrementalPrompt(diff string, cfg *ReviewConfig, knownIssues []Review
 	// Lifecycle considerations — flag changes that behave differently after merge.
 	writeLifecycleSection(&b)
 
+	// PR description cross-check — flag claims in the body contradicted by the diff.
+	if prBody != "" {
+		writePRBodyCrossCheckSection(&b)
+	}
+
 	// Output format instructions.
 	b.WriteString("## Output Format\n")
 	b.WriteString("Return your findings as a JSON array inside a ```json code fence. Each finding must have these fields:\n\n")
@@ -390,6 +410,23 @@ func writeLifecycleSection(b *strings.Builder) {
 	b.WriteString("- Code paths or values gated on the PR being open or unmerged (e.g. test-only flags, debug switches, sample data, scaffolding) that won't behave the same way on the default branch.\n")
 	b.WriteString("- Documentation, comments, or examples that describe temporary scaffolding the diff also adds — both need to be removed before merge, and missing one leaves a stale reference.\n\n")
 	b.WriteString("For each lifecycle issue, anchor your finding's `file` and `line` to the offending diff line and explain the post-merge consequence in `description`. Do NOT report concerns in unchanged code — only in lines added or modified by this diff.\n\n")
+}
+
+// writePRBodyCrossCheckSection adds a "PR Description Cross-Check" section
+// asking the reviewer to flag specific factual claims in the PR body that the
+// diff contradicts. Should only be called when a PR body is present in the
+// prompt — otherwise the section has nothing to cross-check against.
+//
+// As with the lifecycle section, findings emitted here must still anchor
+// `file` and `line` to a diff line; runner.go's validators enforce that.
+func writePRBodyCrossCheckSection(b *strings.Builder) {
+	b.WriteString("## PR Description Cross-Check\n")
+	b.WriteString("The PR description in `<pr-body>` above often makes specific factual claims about the diff: cost caps, behavior guarantees, feature lists, performance numbers, things the PR explicitly does or does not do. Before completing the review, scan the diff for places where the code directly contradicts a specific factual claim in the description:\n\n")
+	b.WriteString("- A documented cost cap, rate limit, or numeric guarantee that the diff exceeds (e.g. body says \"~$2-4/run\", code uses a setting that produces $5-10).\n")
+	b.WriteString("- A \"this PR does NOT do X\" or \"this is dispatch-only\" claim where X actually appears in the diff.\n")
+	b.WriteString("- A behavior described in the body (e.g. \"fails closed on missing config\") that the diff doesn't implement.\n")
+	b.WriteString("- A list of inputs, outputs, or supported cases that omits something the diff adds, or includes something the diff removes.\n\n")
+	b.WriteString("For each contradiction, anchor your finding's `file` and `line` to the offending diff line and quote the contradicting text from the PR body in `description`. Do NOT flag style differences, tense mismatches, missing tests in the description, or things you wish the description said — only direct factual contradictions where the body and the code disagree on what the code does.\n\n")
 }
 
 // writeProjectDocs adds a "Project Documentation" section to the prompt builder

--- a/internal/review/prompt_test.go
+++ b/internal/review/prompt_test.go
@@ -42,7 +42,7 @@ func TestBuildIncrementalPrompt_FiltersRulesByPath(t *testing.T) {
 	}
 	files := []string{"internal/review/runner.go"}
 
-	got := BuildIncrementalPrompt("diff", cfg, nil, 1, 0, nil, files, nil, nil)
+	got := BuildIncrementalPrompt("diff", cfg, nil, 1, 0, nil, files, nil, nil, "")
 
 	if !strings.Contains(got, "go-rule") {
 		t.Errorf("incremental prompt missing applicable rule:\n%s", got)
@@ -89,7 +89,7 @@ func TestBuildIncrementalPrompt_ResolvedSectionRendersRichContext(t *testing.T) 
 
 	prompt := BuildIncrementalPrompt(
 		"diff --git a/foo b/foo\n",
-		nil, nil, 1508, 0, nil, []string{"foo"}, resolved, nil,
+		nil, nil, 1508, 0, nil, []string{"foo"}, resolved, nil, "",
 	)
 
 	mustContain := []string{
@@ -116,7 +116,7 @@ func TestBuildIncrementalPrompt_ResolvedSectionRendersRichContext(t *testing.T) 
 func TestBuildIncrementalPrompt_NoResolvedSectionWhenEmpty(t *testing.T) {
 	prompt := BuildIncrementalPrompt(
 		"diff --git a/foo b/foo\n",
-		nil, nil, 1, 0, nil, []string{"foo"}, nil, nil,
+		nil, nil, 1, 0, nil, []string{"foo"}, nil, nil, "",
 	)
 	if strings.Contains(prompt, "## Recently Resolved Issues") {
 		t.Error("resolved section should be omitted when there are no resolutions")
@@ -139,7 +139,7 @@ func TestBuildIncrementalPrompt_ResolvedSectionEscapesLLMSourcedFields(t *testin
 		},
 	}
 
-	prompt := BuildIncrementalPrompt("", nil, nil, 1, 0, nil, nil, resolved, nil)
+	prompt := BuildIncrementalPrompt("", nil, nil, 1, 0, nil, nil, resolved, nil, "")
 
 	// Raw angle brackets from LLM-sourced fields must not reach the prompt.
 	forbidden := []string{
@@ -170,7 +170,7 @@ func TestBuildIncrementalPrompt_ResolvedSectionHandlesMissingFields(t *testing.T
 	resolved := []ResolvedContext{
 		{Path: "a.go", Line: 10, Reason: "dismissed"}, // no title, description, suggestion, rationale
 	}
-	prompt := BuildIncrementalPrompt("", nil, nil, 1, 0, nil, nil, resolved, nil)
+	prompt := BuildIncrementalPrompt("", nil, nil, 1, 0, nil, nil, resolved, nil, "")
 
 	if !strings.Contains(prompt, "`a.go:10` — (no title)") {
 		t.Error("missing-title placeholder should render")
@@ -211,8 +211,70 @@ func TestBuildPrompt_IncludesLifecycleSection(t *testing.T) {
 	}
 }
 
+// The PR Description Cross-Check section lets the reviewer flag
+// claims in the PR body that the diff contradicts (cost caps, "this
+// PR does NOT do X", etc.). It must appear when a body is provided
+// and be omitted when there isn't one.
+func TestBuildPrompt_IncludesPRBodyCrossCheckWhenBodyPresent(t *testing.T) {
+	pr := &PRData{
+		Number: 1,
+		Title:  "t",
+		Body:   "Cost cap: ~$2-4/run.",
+		Files:  []string{"a.go"},
+		Diff:   "diff",
+	}
+	got := BuildPrompt(pr, nil, 0, nil)
+
+	mustContain := []string{
+		"## PR Description Cross-Check",
+		"`<pr-body>`",
+		"contradicts a specific factual claim",
+		"anchor your finding's `file` and `line`",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(got, s) {
+			t.Errorf("BuildPrompt missing expected cross-check snippet %q", s)
+		}
+	}
+}
+
+func TestBuildPrompt_OmitsPRBodyCrossCheckWhenBodyAbsent(t *testing.T) {
+	pr := &PRData{Number: 1, Title: "t", Files: []string{"a.go"}, Diff: "diff"} // no Body
+	got := BuildPrompt(pr, nil, 0, nil)
+
+	if strings.Contains(got, "## PR Description Cross-Check") {
+		t.Error("cross-check section should be omitted when PR body is empty")
+	}
+}
+
+func TestBuildIncrementalPrompt_IncludesPRBodyCrossCheckWhenBodyPresent(t *testing.T) {
+	got := BuildIncrementalPrompt("diff --git a/foo b/foo\n", nil, nil, 1, 0, nil, []string{"foo"}, nil, nil, "Cost cap: ~$2-4/run.")
+
+	mustContain := []string{
+		"<pr-body>",
+		"## PR Description Cross-Check",
+		"contradicts a specific factual claim",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(got, s) {
+			t.Errorf("BuildIncrementalPrompt missing expected cross-check snippet %q", s)
+		}
+	}
+}
+
+func TestBuildIncrementalPrompt_OmitsPRBodyAndCrossCheckWhenEmpty(t *testing.T) {
+	got := BuildIncrementalPrompt("diff --git a/foo b/foo\n", nil, nil, 1, 0, nil, []string{"foo"}, nil, nil, "")
+
+	if strings.Contains(got, "<pr-body>") {
+		t.Error("pr-body tag should be omitted when body is empty")
+	}
+	if strings.Contains(got, "## PR Description Cross-Check") {
+		t.Error("cross-check section should be omitted when body is empty")
+	}
+}
+
 func TestBuildIncrementalPrompt_IncludesLifecycleSection(t *testing.T) {
-	got := BuildIncrementalPrompt("diff --git a/foo b/foo\n", nil, nil, 1, 0, nil, []string{"foo"}, nil, nil)
+	got := BuildIncrementalPrompt("diff --git a/foo b/foo\n", nil, nil, 1, 0, nil, []string{"foo"}, nil, nil, "")
 
 	mustContain := []string{
 		"## Lifecycle Considerations",

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -701,7 +701,7 @@ func runTriage(
 			fbPlural = ""
 		}
 		Stderrf(ansiBold, "Falling back to full review (%d known issue%s excluded)...\n", len(unresolved), fbPlural)
-		prompt = BuildIncrementalPrompt(pr.Diff, cfg, unresolved, opts.PRNumber, startIndex, pr.FileContents, pr.Files, resolvedCtx, projectDocs)
+		prompt = BuildIncrementalPrompt(pr.Diff, cfg, unresolved, opts.PRNumber, startIndex, pr.FileContents, pr.Files, resolvedCtx, projectDocs, pr.Body)
 	} else if strings.TrimSpace(incrementalDiff) == "" {
 		// No new changes — return previous findings as still-open.
 		Stderrf(ansiGreen, "No new changes since last review\n")
@@ -719,7 +719,7 @@ func runTriage(
 			plural = ""
 		}
 		Stderrf(ansiBold, "Reviewing incremental changes (%d known issue%s excluded)...\n", len(unresolved), plural)
-		prompt = BuildIncrementalPrompt(incrementalDiff, cfg, unresolved, opts.PRNumber, startIndex, incContents, incFiles, resolvedCtx, projectDocs)
+		prompt = BuildIncrementalPrompt(incrementalDiff, cfg, unresolved, opts.PRNumber, startIndex, incContents, incFiles, resolvedCtx, projectDocs, pr.Body)
 	}
 
 	return prompt, fixed, stillOpenFindings


### PR DESCRIPTION
## Purpose

Stacked on top of #176. Adds a "PR Description Cross-Check" section asking the reviewer to flag specific factual claims in the PR body that the diff directly contradicts. Real cases observed escaping codecanary review:

- Documented cost cap (\`~$2-4/run\`) when a later commit changes \`--max-turns\` such that the actual cap is \$5-10/run.
- "This is dispatch-only" / "this PR does NOT do X" claims where X is in the diff.
- Behavior the body promises that the code doesn't implement.

## Details

- New helper \`writePRBodyCrossCheckSection\` in \`internal/review/prompt.go\`. Called from both \`BuildPrompt\` and \`BuildIncrementalPrompt\` only when a PR body is present.
- \`BuildIncrementalPrompt\` previously did not include the PR body at all, so this PR adds a \`prBody string\` parameter (signature change) and threads \`pr.Body\` through both call sites in \`runner.go\`.
- Test callers updated. New tests cover both presence and omission for \`BuildPrompt\` and \`BuildIncrementalPrompt\`.
- Same diff-anchoring requirement as the lifecycle section — findings must point at a line in the diff. Existing scope guards (file allowlist + 20-line proximity) enforce.

## Verify and Review

- \`go test ./... -count=1\` — all green
- \`go vet ./...\` — clean
- The instruction copy is deliberately narrow: only direct factual contradictions, not style/tense/missing-tests-in-body.

## References

- Linear: —
- Related: ediphi-precon/ediphi-core#10372 — "Max-turns doubled from documented cost cap of 30" (Cursor caught, codecanary missed). This PR closes the gap.