### PR TITLE
feat: read path-scoped .claude/rules/*.md as review context

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Keys are stored in your system keychain (macOS Keychain, GNOME Keyring, KDE Wall
 
 1. Fetches PR metadata and diff (via `gh` CLI or local git)
 2. Reads file contents for context (respecting ignore patterns and size limits)
-3. Auto-discovers project docs (CLAUDE.md files) for additional context
+3. Auto-discovers project docs (CLAUDE.md files) and path-scoped `.claude/rules/*.md` for additional context
 4. Calls your configured LLM to analyze the changes
 5. Posts findings as inline PR review comments (or prints to terminal)
 

--- a/cmd/review/cli/breaking.go
+++ b/cmd/review/cli/breaking.go
@@ -32,6 +32,7 @@ type breakingResult struct {
 
 var breakingManifest = []breakingSurface{
 	{"internal/review/config.go", "Config Schema", "Users may need to update `.codecanary/config.yml` field names, types, or values"},
+	{"internal/review/rules.go", "Context Sources", "How CodeCanary discovers `.claude/rules/*.md` context files changed; reviews may load different rules"},
 	{"cmd/review/cli/review.go", "CLI Flags", "CLI flag names or defaults may have changed"},
 	{"cmd/review/cli/root.go", "CLI Flags", "CLI flag names or defaults may have changed"},
 	{"cmd/review/cli/costs.go", "CLI Costs", "`codecanary review costs` behavior may have changed"},

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -178,6 +178,23 @@ ignore:
 
 CodeCanary automatically reads `CLAUDE.md` files from your repo root, `.claude/` directory, and top-level subdirectories. These are injected into the review prompt as additional context. Per-file cap is 4KB, total cap is 12KB.
 
+## Path-scoped rules (`.claude/rules/*.md`)
+
+CodeCanary also reads Claude Code rule files from `.claude/rules/*.md` so you don't have to duplicate conventions into `review.yml`. Each rule file may begin with YAML frontmatter:
+
+```markdown
+---
+description: API endpoints must use the auth middleware
+paths:
+  - "apps/api/**"
+---
+
+All new endpoints under `apps/api` must register the shared auth middleware
+before any handler logic. Reject requests with a 401 when the token is absent.
+```
+
+A rule is included in the review prompt only when a changed file matches one of its `paths` globs (using the same `**` glob syntax as `ignore`). A rule file with no `paths` frontmatter is always included. Rules have their own byte budget — 8KB per file, 32KB total — independent of the CLAUDE.md caps; oversized rules are truncated with a warning.
+
 ## Draft PRs
 
 Draft PRs are skipped by default in the GitHub Actions workflow. When you convert a draft to ready, CodeCanary triggers automatically.

--- a/docs/review-flow.md
+++ b/docs/review-flow.md
@@ -37,6 +37,7 @@ If the PR is a setup PR (only adds workflow files with no real code changes), th
 
 - **Config**: Reads `config.yml` (provider, models, budgets, timeouts). If a `review.yml` exists alongside it, its rules/context/ignore fields override the config.
 - **Project docs**: Discovers CLAUDE.md files (root, `.claude/`, top-level directories). Up to 5 files, 4KB each, 12KB total.
+- **Path-scoped rules**: Discovers Claude Code rule files under `.claude/rules/*.md`. Each may carry YAML frontmatter (`description`, `paths`); a rule is included only when a changed file matches one of its `paths` globs (no `paths` = always included). Rules share their own byte budget (8KB per file, 32KB total) separate from the CLAUDE.md caps, and merge into the same project-docs context.
 - **File contents**: Reads changed files from disk with size limits (default 100KB per file, 500KB total). Skips binary files, ignored patterns, and files exceeding limits.
 - **Environment**: Builds a filtered env for LLM subprocesses (only allowed prefixes like `CODECANARY_`, `GITHUB_`, plus essential vars like `PATH`). Injects keychain credentials if not already set.
 

--- a/internal/review/docs_test.go
+++ b/internal/review/docs_test.go
@@ -1,0 +1,146 @@
+package review
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeRuleFile creates .claude/rules/<name> with the given content, relative
+// to the current working directory (tests chdir into a temp dir first).
+func writeRuleFile(t *testing.T, name, content string) {
+	t.Helper()
+	dir := filepath.Join(".claude", "rules")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir rules dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("writing rule file: %v", err)
+	}
+}
+
+func TestSplitFrontmatter(t *testing.T) {
+	meta, body := splitFrontmatter("---\ndescription: API rules\npaths:\n  - \"apps/api/**\"\n---\nUse the auth middleware.\n")
+	if meta.Description != "API rules" {
+		t.Errorf("description = %q, want %q", meta.Description, "API rules")
+	}
+	if len(meta.Paths) != 1 || meta.Paths[0] != "apps/api/**" {
+		t.Errorf("paths = %v, want [apps/api/**]", meta.Paths)
+	}
+	if strings.TrimSpace(body) != "Use the auth middleware." {
+		t.Errorf("body = %q, want %q", body, "Use the auth middleware.")
+	}
+}
+
+func TestSplitFrontmatter_NoFrontmatter(t *testing.T) {
+	meta, body := splitFrontmatter("Just a plain rule body.\n")
+	if meta.Description != "" || len(meta.Paths) != 0 {
+		t.Errorf("expected empty meta, got %+v", meta)
+	}
+	if body != "Just a plain rule body.\n" {
+		t.Errorf("body = %q, want whole content", body)
+	}
+}
+
+func TestSplitFrontmatter_Unterminated(t *testing.T) {
+	content := "---\ndescription: oops\nno closing fence"
+	meta, body := splitFrontmatter(content)
+	if meta.Description != "" {
+		t.Errorf("expected no meta for unterminated frontmatter, got %+v", meta)
+	}
+	if body != content {
+		t.Errorf("expected whole content as body, got %q", body)
+	}
+}
+
+func TestReadClaudeRules_ScopeIn(t *testing.T) {
+	t.Chdir(t.TempDir())
+	writeRuleFile(t, "api.md", "---\ndescription: API rules\npaths:\n  - \"apps/api/**\"\n---\nUse the auth middleware.\n")
+
+	rules := ReadClaudeRules([]string{"apps/api/handler.go"})
+
+	key := filepath.Join(".claude", "rules", "api.md")
+	content, ok := rules[key]
+	if !ok {
+		t.Fatalf("expected rule %q to be included, got keys %v", key, keysOf(rules))
+	}
+	if !strings.Contains(content, "API rules") || !strings.Contains(content, "auth middleware") {
+		t.Errorf("content missing description or body: %q", content)
+	}
+}
+
+func TestReadClaudeRules_ScopeOut(t *testing.T) {
+	t.Chdir(t.TempDir())
+	writeRuleFile(t, "api.md", "---\npaths:\n  - \"apps/api/**\"\n---\nUse the auth middleware.\n")
+
+	rules := ReadClaudeRules([]string{"apps/web/page.tsx"})
+	if len(rules) != 0 {
+		t.Errorf("expected no rules for non-matching change, got %v", keysOf(rules))
+	}
+}
+
+func TestReadClaudeRules_NoPathsAlwaysIncluded(t *testing.T) {
+	t.Chdir(t.TempDir())
+	writeRuleFile(t, "global.md", "---\ndescription: global rule\n---\nAlways applies.\n")
+
+	rules := ReadClaudeRules([]string{"anything/at/all.go"})
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule (no paths => always), got %v", keysOf(rules))
+	}
+}
+
+func TestReadClaudeRules_NoFrontmatterAlwaysIncluded(t *testing.T) {
+	t.Chdir(t.TempDir())
+	writeRuleFile(t, "plain.md", "No frontmatter here, just conventions.\n")
+
+	rules := ReadClaudeRules([]string{"src/x.go"})
+	if len(rules) != 1 {
+		t.Fatalf("expected plain rule to always be included, got %v", keysOf(rules))
+	}
+}
+
+func TestReadClaudeRules_PerFileTruncation(t *testing.T) {
+	t.Chdir(t.TempDir())
+	big := strings.Repeat("x", maxRuleBytes+500)
+	writeRuleFile(t, "big.md", big)
+
+	rules := ReadClaudeRules([]string{"src/x.go"})
+	key := filepath.Join(".claude", "rules", "big.md")
+	content := rules[key]
+	if !strings.Contains(content, "... (truncated)") {
+		t.Errorf("expected truncation marker in oversized rule")
+	}
+	if len(content) > maxRuleBytes+len("\n... (truncated)") {
+		t.Errorf("content not truncated: %d bytes", len(content))
+	}
+}
+
+func TestReadClaudeRules_TotalBudget(t *testing.T) {
+	t.Chdir(t.TempDir())
+	// Each near maxRuleBytes; total budget admits some but not all.
+	chunk := strings.Repeat("y", maxRuleBytes-100)
+	for _, n := range []string{"a.md", "b.md", "c.md", "d.md", "e.md", "f.md"} {
+		writeRuleFile(t, n, chunk)
+	}
+
+	rules := ReadClaudeRules([]string{"src/x.go"})
+	total := 0
+	for _, c := range rules {
+		total += len(c)
+	}
+	if total > maxTotalRuleBytes {
+		t.Errorf("total rule bytes %d exceeds budget %d", total, maxTotalRuleBytes)
+	}
+	if len(rules) == 0 {
+		t.Errorf("expected at least one rule within budget")
+	}
+}
+
+func keysOf(m map[string]string) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}

--- a/internal/review/github.go
+++ b/internal/review/github.go
@@ -6,12 +6,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/bmatcuk/doublestar/v4"
 )
 
 // parseRepoSlug splits a "owner/name" repository slug into its two parts.
@@ -35,7 +32,7 @@ const MaxFindingProximity = 20
 var reviewMarkerPrefixes = []string{"<!-- codecanary:review ", "<!-- clanopy:review "}
 
 const (
-	reviewMarkerSuffix = " -->"
+	reviewMarkerSuffix  = " -->"
 	findingMarkerPrefix = "<!-- codecanary:finding "
 	ackMarkerPrefix     = "<!-- codecanary:ack:"
 	legacyAckPrefix     = "<!-- clanopy:ack:"
@@ -56,9 +53,9 @@ type PRData struct {
 
 // ghPRView is the JSON shape returned by gh pr view.
 type ghPRView struct {
-	Title       string `json:"title"`
-	Body        string `json:"body"`
-	Author      struct {
+	Title  string `json:"title"`
+	Body   string `json:"body"`
+	Author struct {
 		Login string `json:"login"`
 	} `json:"author"`
 	BaseRefName string `json:"baseRefName"`
@@ -420,7 +417,7 @@ type graphQLThreadsResponse struct {
 					Nodes []struct {
 						ID         string `json:"id"`
 						IsResolved bool   `json:"isResolved"`
-						Comments struct {
+						Comments   struct {
 							Nodes []struct {
 								Body         string `json:"body"`
 								Path         string `json:"path"`
@@ -1046,7 +1043,7 @@ func FetchFileContents(files []string, ignorePatterns []string, maxPerFile, maxT
 
 	for _, path := range files {
 		// Check ignore patterns.
-		if matchesIgnore(path, ignorePatterns) {
+		if matchesAnyGlob(path, ignorePatterns) {
 			skipped = append(skipped, path)
 			continue
 		}
@@ -1127,19 +1124,4 @@ func isSetupFile(path string) bool {
 	return strings.HasPrefix(path, ".github/workflows/") ||
 		strings.HasPrefix(path, ".codecanary/") || path == ".codecanary.yml" ||
 		strings.HasPrefix(path, ".clanopy/")
-}
-
-// matchesIgnore checks if a path matches any of the ignore glob patterns.
-// Uses doublestar to support ** recursive globs (e.g. "dist/**", "src/**/*.test.*").
-func matchesIgnore(path string, patterns []string) bool {
-	for _, pat := range patterns {
-		if matched, _ := doublestar.Match(pat, path); matched {
-			return true
-		}
-		// Also try matching against just the filename.
-		if matched, _ := doublestar.Match(pat, filepath.Base(path)); matched {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/review/glob.go
+++ b/internal/review/glob.go
@@ -1,0 +1,24 @@
+package review
+
+import (
+	"path/filepath"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+// matchesAnyGlob reports whether path matches any of the glob patterns. Each
+// pattern is tried against the full path first and then against just the base
+// filename, so both "src/**/*.go" and "*.go" work. Uses doublestar to support
+// ** recursive globs (e.g. "dist/**", "src/**/*.test.*").
+func matchesAnyGlob(path string, patterns []string) bool {
+	for _, pat := range patterns {
+		if matched, _ := doublestar.Match(pat, path); matched {
+			return true
+		}
+		// Also try matching against just the filename.
+		if matched, _ := doublestar.Match(pat, filepath.Base(path)); matched {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/review/rules.go
+++ b/internal/review/rules.go
@@ -1,0 +1,114 @@
+package review
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// maxRuleBytes caps the size of a single .claude/rules/*.md file included in
+// the prompt. Rules are path-scoped, so this budget is intentionally separate
+// from (and smaller than) the CLAUDE.md caps.
+const maxRuleBytes = 8192
+
+// maxTotalRuleBytes caps the combined size of all rule files included.
+const maxTotalRuleBytes = 32768
+
+// claudeRule is the YAML frontmatter of a .claude/rules/*.md file. Mirrors the
+// subset of Claude Code's rule format CodeCanary uses for scoping.
+type claudeRule struct {
+	Description string   `yaml:"description"`
+	Paths       []string `yaml:"paths"`
+}
+
+// ReadClaudeRules discovers Claude Code path-scoped rule files under
+// .claude/rules/*.md and returns a map of path → content for the rules that
+// apply to the current change. A rule applies when any changed file matches
+// one of its `paths:` globs; a rule with no `paths:` frontmatter always
+// applies (matching Claude Code semantics). Results share a byte budget
+// independent of the CLAUDE.md caps.
+func ReadClaudeRules(changedFiles []string) map[string]string {
+	matches, err := filepath.Glob(filepath.Join(".claude", "rules", "*.md"))
+	if err != nil {
+		return nil
+	}
+
+	rules := make(map[string]string)
+	totalBytes := 0
+	for _, p := range matches {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+
+		meta, body := splitFrontmatter(string(data))
+
+		// Scope: skip rules whose paths don't match any changed file.
+		if len(meta.Paths) > 0 && !anyFileMatches(changedFiles, meta.Paths) {
+			continue
+		}
+
+		content := body
+		if meta.Description != "" {
+			content = meta.Description + "\n\n" + body
+		}
+		if len(content) > maxRuleBytes {
+			content = content[:maxRuleBytes] + "\n... (truncated)"
+			fmt.Fprintf(os.Stderr, "Rule %s exceeds %d bytes and was truncated for the review prompt\n", p, maxRuleBytes)
+		}
+		if totalBytes+len(content) > maxTotalRuleBytes {
+			fmt.Fprintf(os.Stderr, "Rule budget (%d bytes) exhausted; skipping %s\n", maxTotalRuleBytes, p)
+			continue
+		}
+
+		rules[p] = content
+		totalBytes += len(content)
+	}
+
+	return rules
+}
+
+// anyFileMatches reports whether any of the files matches any of the patterns.
+func anyFileMatches(files, patterns []string) bool {
+	for _, f := range files {
+		if matchesAnyGlob(f, patterns) {
+			return true
+		}
+	}
+	return false
+}
+
+// splitFrontmatter separates leading `---`-fenced YAML frontmatter from the
+// document body. If the content has no frontmatter, meta is the zero value and
+// body is the whole content.
+func splitFrontmatter(content string) (meta claudeRule, body string) {
+	if !strings.HasPrefix(content, "---\n") && !strings.HasPrefix(content, "---\r\n") {
+		return claudeRule{}, content
+	}
+
+	// Drop the opening fence and find the closing one.
+	rest := content[strings.IndexByte(content, '\n')+1:]
+	end := strings.Index(rest, "\n---")
+	if end == -1 {
+		// Unterminated frontmatter — treat the whole thing as body.
+		return claudeRule{}, content
+	}
+
+	front := rest[:end]
+	body = rest[end+len("\n---"):]
+	// Skip to the end of the closing fence line.
+	if nl := strings.IndexByte(body, '\n'); nl != -1 {
+		body = body[nl+1:]
+	} else {
+		body = ""
+	}
+
+	if err := yaml.Unmarshal([]byte(front), &meta); err != nil {
+		// Malformed frontmatter — fall back to treating everything as body.
+		return claudeRule{}, content
+	}
+	return meta, strings.TrimLeft(body, "\n")
+}

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -105,6 +105,9 @@ func prepareReview(pr *PRData, configPath string) (*reviewContext, error) {
 	}
 
 	projectDocs := ReadProjectDocs()
+	for k, v := range ReadClaudeRules(pr.Files) {
+		projectDocs[k] = v
+	}
 	if len(projectDocs) > 0 {
 		fmt.Fprintf(os.Stderr, "Loaded %d project doc(s) for review context\n", len(projectDocs))
 	}


### PR DESCRIPTION
## Context

Claude Code auto-loads convention files from `.claude/rules/*.md` (markdown with YAML frontmatter: `description` + `paths` globs). CodeCanary couldn't see them, forcing consumers to hand-duplicate every convention into `.codecanary/review.yml`, which drifts.

## Changes

- **`ReadClaudeRules`** (`internal/review/rules.go`): globs `.claude/rules/*.md`, parses leading `---` frontmatter, and includes a rule only when a changed file matches its `paths` globs. A rule with no `paths` is always included (matches Claude Code semantics). Own byte budget (8KB/file, 32KB total) separate from the CLAUDE.md caps, with a visible truncation warning to stderr.
- Promote `matchesIgnore` → shared **`matchesAnyGlob`** in new `internal/review/glob.go` so rules (and later features) reuse one glob helper; moved the `doublestar` import out of the GitHub-flow file.
- Merge discovered rules into the `ProjectDocs` map in `prepareReview` so they flow through `writeProjectDocs` with **no prompt-builder changes**.
- Tests (`docs_test.go`): frontmatter parsing, scope in/out, no-frontmatter fallback, per-file and total byte budgets.
- Added `rules.go` to the breaking-change manifest; updated `review-flow.md`, `configuration.md`, `README.md`.

## Follow-ups (this is 1 of 3)

Two dependent PRs will follow once this lands (both build on the new `glob.go`):
1. Consume `Rule.Paths`/`ExcludePaths` so `review.yml` rules are injected only for matching files.
2. Raise CLAUDE.md caps and discover nested `apps/*/CLAUDE.md` etc. scoped to changed files.

Verified: `go build`, `go vet ./...`, `go test ./...`, `golangci-lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)